### PR TITLE
feat: ポスター掲載許可のデフォルト値をTrueに設定

### DIFF
--- a/app/community/forms.py
+++ b/app/community/forms.py
@@ -167,3 +167,4 @@ class CommunityCreateForm(forms.ModelForm):
         self.fields['poster_image'].help_text = """最大サイズ: 30MB
 対応フォーマット: jpg, jpeg, png
 このサイトやイベント紹介、ワールドに設置されているアセット、APIなどで利用されます"""
+        self.fields['allow_poster_repost'].initial = True

--- a/app/community/tests/test_community_create.py
+++ b/app/community/tests/test_community_create.py
@@ -50,6 +50,11 @@ class CommunityCreateFormTest(TestCase):
         form = CommunityCreateForm()
         self.assertEqual(list(form.fields['tags'].choices), list(FORM_TAGS))
 
+    def test_allow_poster_repost_default_is_true(self):
+        """allow_poster_repostのデフォルト値がTrueであることをテスト."""
+        form = CommunityCreateForm()
+        self.assertTrue(form.fields['allow_poster_repost'].initial)
+
 
 @override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS)
 class CommunityCreateViewTest(TestCase):


### PR DESCRIPTION
## Why
新規集会登録時に、ポスター掲載許可（allow_poster_repost）がデフォルトでTrueになることで、ユーザーの手間を減らし、ポスター転載を促進する。

## What
- `CommunityCreateForm.__init__`に`self.fields['allow_poster_repost'].initial = True`を追加
- 対応するユニットテストを追加

## Test
- [x] `test_allow_poster_repost_default_is_true`テスト追加済み
- [x] テスト実行確認済み

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)