### PR TITLE
feat: 資料アイコンにイベント詳細ページへのリンクを追加

### DIFF
--- a/app/event/templates/event/detail_list_table.html
+++ b/app/event/templates/event/detail_list_table.html
@@ -27,18 +27,17 @@
 
                     <td>
                         {% if detail.youtube_url %}
-                            <i class="bi bi-play-btn" title="動画"></i>
+                            <a href="{% url 'event:detail' detail.pk %}"><i class="bi bi-play-btn" title="動画"></i></a>
                         {% endif %}
                         {% if detail.slide_url %}
-                            <i class="bi bi-link-45deg" title="リンク"></i>
+                            <a href="{% url 'event:detail' detail.pk %}"><i class="bi bi-link-45deg" title="リンク"></i></a>
                         {% endif %}
                         {% if detail.slide_file %}
-                            <i class="bi bi-file-text" title="スライド"></i>
+                            <a href="{% url 'event:detail' detail.pk %}"><i class="bi bi-file-text" title="スライド"></i></a>
                         {% endif %}
                         {% if detail.contents %}
-                            <i class="bi bi-pencil-square" title="コンテンツあり"></i>
+                            <a href="{% url 'event:detail' detail.pk %}"><i class="bi bi-pencil-square" title="コンテンツあり"></i></a>
                         {% endif %}
-
                     </td>
                 {% endif %}
                 <td>


### PR DESCRIPTION
## Why

`/event/detail/history/` ページで資料列のアイコンがクリックできず、ユーザーがイベント詳細ページに遷移するにはテーマ列のリンクをクリックする必要があった。

## What

- 資料列の各アイコン（動画、リンク、スライド、コンテンツあり）にイベント詳細ページへのリンクを追加
- テーマ列と同じURL（`event:detail`）に遷移するよう設定

## Test

- [x] http://localhost:8015/event/detail/history/ で資料アイコンがクリック可能になっていることを確認
- [x] アイコンをクリックするとイベント詳細ページに遷移することを確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)