### PR TITLE
fix: ACCOUNT_DEFAULT_HTTP_PROTOCOLのデフォルトをhttpsに変更

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ DEFAULT_GENERATE_MONTHS=3  # デフォルトの生成月数（開発環境では
 # Discord OAuth設定
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
-ACCOUNT_DEFAULT_HTTP_PROTOCOL=http  # 本番環境では https に設定
+ACCOUNT_DEFAULT_HTTP_PROTOCOL=http  # 開発環境のみ設定（本番はデフォルトhttps）
 
 # Discord Webhook（管理者通知用）
 DISCORD_WEBHOOK_URL=

--- a/app/website/settings.py
+++ b/app/website/settings.py
@@ -394,7 +394,7 @@ SOCIALACCOUNT_LOGIN_ON_GET = True
 SOCIALACCOUNT_ADAPTER = 'user_account.adapters.CustomSocialAccountAdapter'
 
 # OAuth callback URLのプロトコル（本番: https、開発: http）
-ACCOUNT_DEFAULT_HTTP_PROTOCOL = os.environ.get('ACCOUNT_DEFAULT_HTTP_PROTOCOL', 'http')
+ACCOUNT_DEFAULT_HTTP_PROTOCOL = os.environ.get('ACCOUNT_DEFAULT_HTTP_PROTOCOL', 'https')
 
 # Discord OAuth設定
 DISCORD_CLIENT_ID = os.environ.get('DISCORD_CLIENT_ID', '')


### PR DESCRIPTION
## Why

本番環境では環境変数を設定せずにhttpsがデフォルトで使われるようにする。
開発環境でのみ `ACCOUNT_DEFAULT_HTTP_PROTOCOL=http` を設定すれば良い。

## What

- デフォルト値を `http` → `https` に変更
- .env.example のコメントを更新

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)