### PR TITLE
feat: Discord OAuthサインアップ画面を改善

### DIFF
--- a/app/user_account/templates/socialaccount/signup.html
+++ b/app/user_account/templates/socialaccount/signup.html
@@ -23,16 +23,30 @@
                         </div>
 
                         {% if form.errors %}
-                            <div class="alert alert-danger">
-                                <strong>以下の項目を確認してください:</strong>
-                                <ul class="mb-0">
-                                    {% for field, errors in form.errors.items %}
-                                        {% for error in errors %}
-                                            <li>{{ error }}</li>
-                                        {% endfor %}
-                                    {% endfor %}
-                                </ul>
-                            </div>
+                            {% if form|has_email_duplicate_error %}
+                                <div class="alert alert-warning">
+                                    <i class="fas fa-exclamation-triangle me-2"></i>
+                                    <strong>このメールアドレスは既に登録されています</strong>
+                                    <p class="mb-2 mt-2">
+                                        既存のアカウントにログインしてから、Discord連携を行ってください。
+                                    </p>
+                                    <a href="{% url 'account_login' %}" class="btn btn-outline-primary">
+                                        <i class="fas fa-sign-in-alt me-2"></i>ログインページへ
+                                    </a>
+                                </div>
+                            {% endif %}
+                            {% with other_errors=form|get_other_errors %}
+                                {% if other_errors %}
+                                    <div class="alert alert-danger">
+                                        <strong>以下の項目を確認してください:</strong>
+                                        <ul class="mb-0">
+                                            {% for error in other_errors %}
+                                                <li>{{ error }}</li>
+                                            {% endfor %}
+                                        </ul>
+                                    </div>
+                                {% endif %}
+                            {% endwith %}
                         {% endif %}
 
                         <form method="post" action="{% url 'socialaccount_signup' %}">

--- a/app/user_account/templatetags/account_tags.py
+++ b/app/user_account/templatetags/account_tags.py
@@ -25,3 +25,37 @@ def add_class(field, css_class):
             css_class = f"{existing_classes} {css_class}"
         return field.as_widget(attrs={'class': css_class})
     return field
+
+
+# メール重複エラーを検出するためのキーワード
+EMAIL_DUPLICATE_ERROR_KEYWORD = 'このメールアドレスは既に登録されています'
+
+
+@register.filter
+def has_email_duplicate_error(form):
+    """フォームにメールアドレス重複エラーがあるかをチェックする。
+
+    使用例:
+        {% if form|has_email_duplicate_error %}
+    """
+    if hasattr(form, 'errors') and 'email' in form.errors:
+        for error in form.errors['email']:
+            if EMAIL_DUPLICATE_ERROR_KEYWORD in str(error):
+                return True
+    return False
+
+
+@register.filter
+def get_other_errors(form):
+    """メールアドレス重複エラー以外のエラーを取得する。
+
+    使用例:
+        {% for error in form|get_other_errors %}
+    """
+    other_errors = []
+    if hasattr(form, 'errors'):
+        for field, errors in form.errors.items():
+            for error in errors:
+                if EMAIL_DUPLICATE_ERROR_KEYWORD not in str(error):
+                    other_errors.append(str(error))
+    return other_errors


### PR DESCRIPTION
## なぜこの変更が必要か

Discord OAuth後のサインアップ画面で以下の問題があった:
1. メール重複時にユーザーが適切な対応を取れない（既存アカウントへの誘導がない）
2. アカウント名を自分で設定できない
3. アカウント更新画面でDiscord IDを誤って編集できてしまう

## 変更内容

- アカウント名入力欄を追加（Discordユーザー名をプレースホルダーに表示）
- メール重複時にログインリンク付きメッセージを表示
- メール重複チェックを大文字小文字区別なしに変更（`email__iexact`）
- アカウント更新画面からDiscord ID編集欄を削除
- `save_user`でフォームの`user_name`を正しく保存するよう修正

## テスト

- [x] サインアップ画面でアカウント名入力欄がメールの上に表示される
- [x] Discordユーザー名がプレースホルダーに表示される
- [x] 重複メールアドレス入力時にログインリンク付きメッセージが表示される
- [x] `/account/update/` 画面にDiscord ID編集欄がない
- [x] 全76件のテストがパス

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)