### PR TITLE
feat: ログイン画面と登録画面を分離

### DIFF
--- a/app/user_account/templates/account/login.html
+++ b/app/user_account/templates/account/login.html
@@ -73,6 +73,9 @@
                                 <i class="fas fa-sign-in-alt me-2"></i>ログイン
                             </button>
                         </form>
+                        <div class="text-center mt-4">
+                            <p class="text-muted">アカウントをお持ちでない方は<a href="{% url 'account:register' %}">こちら</a></p>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/app/user_account/templates/account/register.html
+++ b/app/user_account/templates/account/register.html
@@ -1,0 +1,39 @@
+{% extends 'ta_hub/base.html' %}
+{% load socialaccount %}
+{% block meta %}
+    <title>新規登録 - VRChat 技術・学術系イベントHub</title>
+    <meta name="twitter:title" content="新規登録 - VRChat 技術・学術系イベントHub">
+    <meta property="og:title" content="新規登録 - VRChat 技術・学術系イベントHub">
+    <meta name="description"
+          content="技術・学術系イベントHubの新規登録ページです。Discordアカウントで簡単に登録できます。">
+    <meta name="twitter:description"
+          content="技術・学術系イベントHubの新規登録ページです。Discordアカウントで簡単に登録できます。">
+    <meta property="og:description"
+          content="技術・学術系イベントHubの新規登録ページです。Discordアカウントで簡単に登録できます。">
+    <meta property="og:image" content="https://data.vrc-ta-hub.com/images/negipan-night-1600.jpeg">
+    <meta name="twitter:image" content="https://data.vrc-ta-hub.com/images/negipan-night-1600.jpeg">
+{% endblock %}
+
+{% block main %}
+    <div class="container my-4">
+        <div class="row">
+            <div class="col-md-6 offset-md-3">
+                <div class="card">
+                    <div class="card-header bg-primary text-white">
+                        <h4 class="mb-0">新規登録</h4>
+                    </div>
+                    <div class="card-body">
+                        <div class="text-center my-5">
+                            <a href="{% provider_login_url 'discord' %}" class="btn btn-lg" style="background-color: #5865F2; color: white;">
+                                <i class="fab fa-discord me-2"></i>Discordで登録
+                            </a>
+                        </div>
+                        <div class="text-center mt-4">
+                            <p class="text-muted">既にアカウントをお持ちの方は<a href="{% url 'account:login' %}">こちら</a></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/app/user_account/tests/test_views.py
+++ b/app/user_account/tests/test_views.py
@@ -174,3 +174,61 @@ class SettingsViewTests(TestCase):
         self.assertNotContains(response, 'bi-three-dots')
         self.assertNotContains(response, 'headingOther')
         self.assertNotContains(response, 'collapseOther')
+
+
+class RegisterViewTests(TestCase):
+    """RegisterViewのテストクラス."""
+
+    def setUp(self):
+        """テスト用のデータを準備."""
+        self.client = Client()
+        self.register_url = reverse('account:register')
+
+    def test_register_page_renders_correctly(self):
+        """新規登録ページが正しくレンダリングされること."""
+        response = self.client.get(self.register_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'account/register.html')
+
+    def test_register_page_contains_discord_button(self):
+        """新規登録ページにDiscordログインボタンが含まれていること."""
+        response = self.client.get(self.register_url)
+        self.assertContains(response, 'Discordで登録')
+        self.assertContains(response, 'fab fa-discord')
+
+    def test_register_page_does_not_contain_password_form(self):
+        """新規登録ページにユーザー名/パスワードフォームが含まれていないこと."""
+        response = self.client.get(self.register_url)
+        self.assertNotContains(response, '<form method="post">')
+
+    def test_register_page_contains_login_link(self):
+        """新規登録ページにログインページへのリンクが含まれていること."""
+        response = self.client.get(self.register_url)
+        self.assertContains(response, '既にアカウントをお持ちの方は')
+        self.assertContains(response, reverse('account:login'))
+
+    def test_register_page_does_not_show_redirect_message(self):
+        """新規登録ページにリダイレクトメッセージが表示されないこと."""
+        response = self.client.get(self.register_url)
+        # 以前の実装で表示されていたメッセージが含まれていないこと
+        self.assertNotContains(response, '新規登録はDiscordアカウントで行ってください')
+
+    def test_register_page_has_correct_header(self):
+        """新規登録ページのヘッダーが「新規登録」であること."""
+        response = self.client.get(self.register_url)
+        self.assertContains(response, '<h4 class="mb-0">新規登録</h4>')
+
+
+class LoginPageRegisterLinkTests(TestCase):
+    """ログインページの登録リンクテストクラス."""
+
+    def setUp(self):
+        """テスト用のデータを準備."""
+        self.client = Client()
+        self.login_url = reverse('account:login')
+
+    def test_login_page_contains_register_link(self):
+        """ログインページに新規登録ページへのリンクが含まれていること."""
+        response = self.client.get(self.login_url)
+        self.assertContains(response, 'アカウントをお持ちでない方は')
+        self.assertContains(response, reverse('account:register'))

--- a/app/user_account/urls.py
+++ b/app/user_account/urls.py
@@ -2,14 +2,14 @@ from django.contrib.auth.views import PasswordChangeDoneView
 from django.urls import path
 from django.views.generic import TemplateView
 
-from .views import CustomLoginView, CustomLogoutView, RegisterRedirectView, CustomPasswordChangeView, \
+from .views import CustomLoginView, CustomLogoutView, RegisterView, CustomPasswordChangeView, \
     UserNameChangeView, UserUpdateView, SettingsView, APIKeyListView, APIKeyCreateView, APIKeyDeleteView
 
 app_name = 'account'
 urlpatterns = [
     path('login/', CustomLoginView.as_view(), name='login'),
     path('logout/', CustomLogoutView.as_view(), name='logout'),
-    path('register/', RegisterRedirectView.as_view(), name='register'),
+    path('register/', RegisterView.as_view(), name='register'),
     path('password_change/', CustomPasswordChangeView.as_view(), name='password_change'),
     path('user_name_change/', UserNameChangeView.as_view(), name='user_name_change'),
     path('update/', UserUpdateView.as_view(), name='user_update'),

--- a/app/user_account/views.py
+++ b/app/user_account/views.py
@@ -56,12 +56,9 @@ class CustomLogoutView(LogoutView):
         return super().dispatch(request, *args, **kwargs)
 
 
-class RegisterRedirectView(View):
-    """通常登録ページへのアクセスをDiscord OAuthログインページにリダイレクト."""
-
-    def get(self, request):
-        messages.info(request, '新規登録はDiscordアカウントで行ってください。')
-        return redirect('account:login')
+class RegisterView(TemplateView):
+    """新規登録ページ（Discordログインのみ）"""
+    template_name = 'account/register.html'
 
 
 class UserNameChangeView(LoginRequiredMixin, UpdateView):


### PR DESCRIPTION
## なぜこの変更が必要か

現状、新規登録にはDiscordのみ使用するのに、ログインページでメッセージを表示してリダイレクトしていた。
登録とログインが同じテンプレートで混在しており、ユーザー体験が分かりにくかった。

## 変更内容

- `/account/register/` を専用の登録ページに変更（Discordボタンのみ）
- `/account/login/` はDiscordボタン + ユーザー名/パスワードフォームを維持
- 両ページ間の相互リンクを追加
- `RegisterRedirectView` を `RegisterView(TemplateView)` に変更

## テスト

- [x] `/account/register/` にアクセスし、Discordログインボタンのみ表示されることを確認
- [x] `/account/login/` にアクセスし、Discord ボタン + ユーザー名/パスワードフォームが表示されることを確認
- [x] 登録ページに「新規登録はDiscordアカウントで行ってください」のメッセージが表示されないことを確認
- [x] 両ページ間の相互リンクが正常に動作することを確認
- [x] 全20テストがパス

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)