### PR TITLE
fix: 古くなったRegisterRedirectViewTestを削除

### DIFF
--- a/app/community/tests/test_community_create.py
+++ b/app/community/tests/test_community_create.py
@@ -226,32 +226,6 @@ class CommunityCreateViewTest(TestCase):
 
 
 @override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS)
-class RegisterRedirectViewTest(TestCase):
-    """通常登録ページのリダイレクトテスト."""
-
-    def setUp(self):
-        # Discord SocialAppを作成（テンプレートのprovider_login_urlタグに必要）
-        # override_settingsでAPPS設定を無効化しているため、DBのSocialAppが使用される
-        site = Site.objects.get_current()
-        social_app = SocialApp.objects.create(
-            provider='discord',
-            name='Discord',
-            client_id='test-client-id',
-            secret='test-secret'
-        )
-        social_app.sites.add(site)
-
-        self.client = Client()
-        self.register_url = reverse('account:register')
-
-    def test_register_redirects_to_login(self):
-        """通常登録ページがログインページにリダイレクトされることをテスト."""
-        response = self.client.get(self.register_url)
-        self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, reverse('account:login'))
-
-
-@override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS)
 class SettingsViewCommunityButtonTest(TestCase):
     """設定画面の集会登録ボタン表示テスト."""
 


### PR DESCRIPTION
## なぜこの変更が必要か

CIテストが失敗していた。原因は `RegisterRedirectViewTest` が古い仕様をテストしていたため。

- コミット `ed82b11` でログイン画面と登録画面が分離された
- 以前は `/account/register/` がログインページにリダイレクト（302）していた
- 現在は独自の登録ページを表示（200）
- `user_account/tests/test_views.py` の `RegisterViewTests` が現在の正しい動作をテストしている

## 変更内容

- `community/tests/test_community_create.py` から `RegisterRedirectViewTest` クラスを削除

## テスト

- [x] ローカルでテストがパス（113件）
- [x] 削除したテストは重複していた（`RegisterViewTests` でカバー済み）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)