### PR TITLE
feat: 登録画面に利用規約・プライバシーポリシーへの同意文言を追加

### DIFF
--- a/app/user_account/templates/account/register.html
+++ b/app/user_account/templates/account/register.html
@@ -27,6 +27,9 @@
                             <a href="{% provider_login_url 'discord' %}" class="btn btn-lg" style="background-color: #5865F2; color: white;">
                                 <i class="fab fa-discord me-2"></i>Discordで登録
                             </a>
+                            <p class="text-muted small mt-3">
+                                登録することで、<a href="{% url 'ta_hub:terms' %}" target="_blank" rel="noopener noreferrer" class="text-decoration-underline">利用規約</a>および<a href="{% url 'ta_hub:privacy' %}" target="_blank" rel="noopener noreferrer" class="text-decoration-underline">プライバシーポリシー</a>に同意したものとみなされます。
+                            </p>
                         </div>
                         <div class="text-center mt-4">
                             <p class="text-muted">既にアカウントをお持ちの方は<a href="{% url 'account:login' %}">こちら</a></p>

--- a/app/user_account/tests/test_views.py
+++ b/app/user_account/tests/test_views.py
@@ -218,6 +218,27 @@ class RegisterViewTests(TestCase):
         response = self.client.get(self.register_url)
         self.assertContains(response, '<h4 class="mb-0">新規登録</h4>')
 
+    def test_register_page_contains_terms_agreement(self):
+        """新規登録ページに利用規約への同意文言が含まれていること."""
+        response = self.client.get(self.register_url)
+        self.assertContains(response, '登録することで')
+        self.assertContains(response, '利用規約')
+        self.assertContains(response, 'プライバシーポリシー')
+        self.assertContains(response, '同意したものとみなされます')
+
+    def test_register_page_terms_links_open_in_new_tab(self):
+        """利用規約とプライバシーポリシーのリンクが新しいタブで開くこと."""
+        response = self.client.get(self.register_url)
+        content = response.content.decode('utf-8')
+        # 利用規約リンクがtarget="_blank"を持つこと
+        self.assertIn('href="/terms/"', content)
+        self.assertIn('href="/privacy/"', content)
+        # target="_blank"とrel="noopener noreferrer"が設定されていること
+        self.assertIn('target="_blank"', content)
+        self.assertIn('rel="noopener noreferrer"', content)
+        self.assertIn('>利用規約</a>', content)
+        self.assertIn('>プライバシーポリシー</a>', content)
+
 
 class LoginPageRegisterLinkTests(TestCase):
     """ログインページの登録リンクテストクラス."""


### PR DESCRIPTION
## なぜこの変更が必要か

登録画面に利用規約・プライバシーポリシーへの同意文言がなく、法的に適切な同意取得フローになっていなかった。
ユーザーが登録前に利用規約・プライバシーポリシーを確認できる導線も不足していた。

## 変更内容

- Discordで登録ボタンの下に同意文言を追加
- 利用規約とプライバシーポリシーへのリンクを設定
- セキュリティ属性（`rel="noopener noreferrer"`）を追加
- リンクの視認性向上のため下線を追加

## テスト

- [x] 同意文言の存在を確認するテストを追加
- [x] リンク属性を確認するテストを追加
- [x] 全テストパス確認済み

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)