### PR TITLE
fix: UI表記統一とレイアウト修正

### DIFF
--- a/app/community/templates/community/settings.html
+++ b/app/community/templates/community/settings.html
@@ -70,10 +70,10 @@
                     </a>
                 </div>
                 <div class="col-md-4 mb-3 mb-md-0">
-                    <h6 class="mb-2">Twitter投稿テンプレート</h6>
+                    <h6 class="mb-2">X (旧Twitter) 投稿テンプレート</h6>
                     <p class="text-muted small mb-2">イベント告知用のテンプレートを管理します。</p>
                     <a href="{% url 'twitter:template_list' %}" class="btn btn-outline-primary">
-                        <i class="fa-brands fa-twitter me-1"></i>テンプレート管理
+                        <i class="fa-brands fa-x-twitter me-1"></i>テンプレート管理
                     </a>
                 </div>
                 <div class="col-md-4">

--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -4,7 +4,7 @@
 {% block main %}
     <div class="container my-4">
         {# ヘッダー部分 - 集会切り替えドロップダウン #}
-        <div class="d-flex justify-content-between align-items-center mb-4">
+        <div class="d-flex justify-content-center align-items-center mb-4">
             <h2 class="fw-bold keiko_yellow">
                 イベント管理:
                 {% if communities|length > 1 %}

--- a/app/twitter/templates/twitter/twitter_template_form.html
+++ b/app/twitter/templates/twitter/twitter_template_form.html
@@ -4,7 +4,7 @@
     <div class="container my-5">
         <h1 class="text-center mb-5 fw-bold">
             <i class="bi bi-twitter text-primary me-2"></i>
-            {% if form.instance.pk %}Twitter告知テンプレートを編集{% else %}新規Twitter告知テンプレート{% endif %}
+            {% if form.instance.pk %}X (旧Twitter) 告知テンプレートを編集{% else %}新規X (旧Twitter) 告知テンプレート{% endif %}
         </h1>
 
         <div class="row justify-content-center">

--- a/app/twitter/templates/twitter/twitter_template_list.html
+++ b/app/twitter/templates/twitter/twitter_template_list.html
@@ -12,10 +12,10 @@
                 </div>
             </div>
         {% endif %}
-        <h1 class="text-center mb-5 fw-bold">Twitter告知テンプレート</h1>
+        <h1 class="text-center mb-5 fw-bold">X (旧Twitter) 告知テンプレート</h1>
         <div class="d-flex justify-content-end mb-4">
             <a href="{% url 'event:my_list' %}" class="btn btn-outline-secondary me-2">
-                <i class="bi bi-calendar-event me-2"></i>イベント一覧
+                <i class="bi bi-calendar-event me-2"></i>イベント管理
             </a>
             <a href="{% url 'twitter:template_create' %}" class="btn btn-primary">
                 <i class="bi bi-plus-circle me-2"></i>新規作成
@@ -48,7 +48,7 @@
             {% endfor %}
         </div>
         <div class="mt-3">
-            ※ 投稿のタイミングを調整したい場合はTwitterの予約投稿機能をご利用ください
+            ※ 投稿のタイミングを調整したい場合はX (旧Twitter) の予約投稿機能をご利用ください
         </div>
     </div>
 


### PR DESCRIPTION
## なぜこの変更が必要か

PR #43 で Twitter 告知機能の UI を改善したが、他の画面で「Twitter」表記が残っていた。また、イベント管理画面の見出しが左寄せで統一感がなかった。

## 変更内容

- 「Twitter」→「X (旧Twitter)」に表記統一
  - テンプレート一覧・編集画面
  - 集会設定画面
- イベント管理画面の見出しを中央揃えに変更
- テンプレート一覧の「イベント一覧」→「イベント管理」に修正

## テスト

- [x] イベント管理画面で見出しが中央揃えになっていることを確認
- [x] テンプレート一覧画面で表記が統一されていることを確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)