### PR TITLE
fix: LT申請レビューページから申請者メールアドレスを非表示に

### DIFF
--- a/app/event/templates/event/lt_application_review.html
+++ b/app/event/templates/event/lt_application_review.html
@@ -50,12 +50,7 @@
                                 </tr>
                                 <tr>
                                     <th scope="row" class="bg-light">申請者</th>
-                                    <td>
-                                        {{ event_detail.applicant.user_name }}
-                                        {% if event_detail.applicant.email %}
-                                            <small class="text-muted">({{ event_detail.applicant.email }})</small>
-                                        {% endif %}
-                                    </td>
+                                    <td>{{ event_detail.applicant.user_name }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row" class="bg-light">申請日時</th>


### PR DESCRIPTION
## なぜこの変更が必要か

LT申請レビューページで申請者のメールアドレスが主催者に表示されていた。
- 主催者にメールアドレスが見える必要がない
- 発表者情報と重複していて冗長

## 変更内容

- `lt_application_review.html`: 申請者のメールアドレス表示を削除

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)