### PR TITLE
feat: ユーザー情報更新ページにメールアドレス非公開の説明を追加

### DIFF
--- a/app/user_account/templates/account/user_update.html
+++ b/app/user_account/templates/account/user_update.html
@@ -11,7 +11,26 @@
                     <div class="card-body">
                         <form method="post" enctype="multipart/form-data">
                             {% csrf_token %}
-                            {{ form.as_p }}
+                            <div class="mb-3">
+                                <label for="{{ form.user_name.id_for_label }}" class="form-label">{{ form.user_name.label }}:</label>
+                                {{ form.user_name }}
+                                {% if form.user_name.help_text %}
+                                    <div class="form-text">{{ form.user_name.help_text }}</div>
+                                {% endif %}
+                                {% if form.user_name.errors %}
+                                    <div class="text-danger small">{{ form.user_name.errors }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="mb-3">
+                                <label for="{{ form.email.id_for_label }}" class="form-label">{{ form.email.label }}:</label>
+                                {{ form.email }}
+                                <div class="form-text">
+                                    <i class="fas fa-lock me-1"></i>メールアドレスは公開されません
+                                </div>
+                                {% if form.email.errors %}
+                                    <div class="text-danger small">{{ form.email.errors }}</div>
+                                {% endif %}
+                            </div>
                             <button type="submit" class="btn btn-primary">更新</button>
                         </form>
                     </div>

--- a/app/user_account/tests/test_views.py
+++ b/app/user_account/tests/test_views.py
@@ -326,6 +326,43 @@ class SettingsViewTests(TestCase):
         self.assertNotContains(response, '承認待集会一覧')
 
 
+class UserUpdateViewTests(TestCase):
+    """UserUpdateViewのテストクラス."""
+
+    def setUp(self):
+        """テスト用のデータを準備."""
+        self.client = Client()
+        self.update_url = reverse('account:user_update')
+        # Discord連携済みユーザーを作成（ミドルウェアでリダイレクトされないため）
+        self.test_user = create_discord_linked_user(
+            user_name='test_update_user',
+            email='test_update@example.com',
+            password='testpass123',
+        )
+
+    def test_user_update_view_requires_login(self):
+        """ユーザー情報更新ページはログインが必要であること."""
+        response = self.client.get(self.update_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('login', response.url)
+
+    def test_user_update_view_renders_correctly(self):
+        """ログイン状態でユーザー情報更新ページが正しくレンダリングされること."""
+        self.client.login(username='test_update_user', password='testpass123')
+        response = self.client.get(self.update_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'account/user_update.html')
+
+    def test_user_update_view_contains_email_privacy_notice(self):
+        """ユーザー情報更新ページにメールアドレス非公開の説明が含まれていること."""
+        self.client.login(username='test_update_user', password='testpass123')
+        response = self.client.get(self.update_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'メールアドレスは公開されません')
+        self.assertContains(response, 'fa-lock')
+        self.assertContains(response, 'form-text')
+
+
 class RegisterViewTests(TestCase):
     """RegisterViewのテストクラス."""
 


### PR DESCRIPTION
## なぜこの変更が必要か

ユーザー情報更新ページでメールアドレスを入力する際、このメールアドレスが公開されないことをユーザーに明示することで、プライバシーへの配慮を示し、安心して入力できるようにする。

## 変更内容

- フォームを `{{ form.as_p }}` から個別フィールドレンダリングに変更
- メールアドレス入力欄の下に鍵アイコン付きで「メールアドレスは公開されません」を表示
- Bootstrap の `form-text` クラスでさりげなく表示

## テスト

- [x] UserUpdateViewTests（3件）がパス
- [x] ブラウザで表示位置を確認済み

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)