### PR TITLE
feat: VKETコラボ実績セクションとGoogleカレンダー連携UIを追加

### DIFF
--- a/app/ta_hub/templates/ta_hub/index.html
+++ b/app/ta_hub/templates/ta_hub/index.html
@@ -296,6 +296,34 @@
             transform: translateY(3px);
             box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2) !important;
         }
+
+        /* VKETコラボ実績カードのスタイル */
+        .vket-achievement-card {
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            border: none;
+            overflow: hidden;
+        }
+
+        .vket-achievement-card:hover {
+            transform: translateY(-6px);
+            box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15) !important;
+        }
+
+        .vket-achievement-card .card-body {
+            padding: 1.5rem;
+        }
+
+        .vket-achievement-card .card-img-top-container {
+            overflow: hidden;
+        }
+
+        .vket-achievement-card .card-img-top {
+            transition: transform 0.3s ease;
+        }
+
+        .vket-achievement-card:hover .card-img-top {
+            transform: scale(1.05);
+        }
     </style>
     <link rel="stylesheet" href="https://petipeti-object-storage.work/dist/style.css">
 
@@ -560,6 +588,70 @@
         </section>
     {% endif %}
 
+    <!-- VKET achievements section -->
+    {% if vket_achievements %}
+        <section class="py-5 bg-light">
+            <div class="container">
+                <div class="row featurette text-center text-primary mb-4">
+                    <h2 class="featurette-heading fw-normal lh-1 fw-bold">
+                        <i class="bi bi-trophy-fill me-2"></i>VKETコラボ実績
+                    </h2>
+                </div>
+                <p class="text-center text-muted mb-5">
+                    <i class="bi bi-stars me-2"></i>
+                    バーチャルマーケットとの大規模コラボレーション
+                </p>
+                <div class="row g-4 justify-content-center">
+                    {% for achievement in vket_achievements %}
+                        <div class="col-12 col-md-6">
+                            <a href="{% url 'news:detail' achievement.news_slug %}" class="text-decoration-none d-block h-100">
+                                <div class="card shadow h-100 vket-achievement-card">
+                                    {% if achievement.image %}
+                                        <div class="card-img-top-container">
+                                            <img src="{% static achievement.image %}"
+                                                 class="card-img-top"
+                                                 alt="{{ achievement.title }}"
+                                                 style="height: 200px; object-fit: cover;">
+                                        </div>
+                                    {% endif %}
+                                    <div class="card-body">
+                                        <h3 class="card-title h5 text-primary fw-bold mb-3">{{ achievement.title }}</h3>
+                                        <div class="mb-3">
+                                            <p class="mb-2 text-muted">
+                                                <i class="bi bi-calendar3 me-2"></i>{{ achievement.period }}
+                                            </p>
+                                            <div class="d-flex gap-3 text-muted">
+                                                <span>
+                                                    <i class="bi bi-calendar-week me-1"></i>{{ achievement.stats.days }}日間
+                                                </span>
+                                                <span>
+                                                    <i class="bi bi-people me-1"></i>{{ achievement.stats.communities }}団体参加
+                                                </span>
+                                            </div>
+                                        </div>
+                                        <div class="d-flex flex-wrap gap-2">
+                                            {% for hashtag in achievement.hashtags %}
+                                                <span class="badge" style="background-color: #1DA1F2; font-size: 0.85rem;">
+                                                    {{ hashtag }}
+                                                </span>
+                                            {% endfor %}
+                                        </div>
+                                    </div>
+                                </div>
+                            </a>
+                        </div>
+                    {% endfor %}
+                </div>
+                <div class="text-center mt-4">
+                    <a href="{% url 'news:category_list' 'activity' %}" class="btn btn-outline-primary btn-hover-press">
+                        <i class="bi bi-journal-text me-2"></i>活動履歴をもっと見る
+                    </a>
+                </div>
+            </div>
+        </section>
+    {% endif %}
+    <!-- VKET achievements section end -->
+
     <!-- upcoming events section -->
     <section class="py-5">
         <div class="container">
@@ -571,10 +663,76 @@
                     </h2>
                 </a>
             </div>
-            <p class="text-center text-muted mb-5">
+            <p class="text-center text-muted mb-4">
                 <i class="bi bi-search me-2"></i>
                 注目の技術学術イベントをチェック！お見逃しなく！
             </p>
+
+            <!-- Googleカレンダー連携UI（折りたたみ式） -->
+            <div class="row justify-content-center mb-5">
+                <div class="col-12 col-lg-10">
+                    <div class="card border-info">
+                        <div class="card-header bg-info bg-opacity-10 border-0 py-3">
+                            <a class="d-flex align-items-center justify-content-between text-decoration-none"
+                               data-bs-toggle="collapse"
+                               href="#calendarSyncDetails"
+                               role="button"
+                               aria-expanded="false"
+                               aria-controls="calendarSyncDetails">
+                                <div class="d-flex align-items-center">
+                                    <i class="bi bi-calendar-plus fs-5 text-info me-3"></i>
+                                    <span class="fw-semibold text-dark">Googleカレンダーと連携して予定を管理</span>
+                                </div>
+                                <span class="calendar-toggle-icon text-info">
+                                    <span class="toggle-open">詳しく <i class="bi bi-chevron-down"></i></span>
+                                    <span class="toggle-close d-none">閉じる <i class="bi bi-chevron-up"></i></span>
+                                </span>
+                            </a>
+                        </div>
+                        <div class="collapse" id="calendarSyncDetails">
+                            <div class="card-body pt-0">
+                                <div class="row g-4 py-3">
+                                    <!-- 全イベント同期オプション -->
+                                    <div class="col-12 col-md-6">
+                                        <div class="d-flex align-items-start">
+                                            <div class="flex-shrink-0">
+                                                <i class="bi bi-arrow-repeat fs-3 text-primary"></i>
+                                            </div>
+                                            <div class="flex-grow-1 ms-3">
+                                                <h5 class="mb-2 fw-bold">全イベントを同期</h5>
+                                                <p class="text-muted mb-3">
+                                                    一度追加すれば、新しいイベントも自動で反映されます
+                                                </p>
+                                                <a href="https://calendar.google.com/calendar/u/0/r?cid={{ google_calendar_id|urlencode }}"
+                                                   class="btn btn-primary"
+                                                   target="_blank"
+                                                   rel="noopener noreferrer">
+                                                    <i class="bi bi-google me-2"></i>Googleカレンダーに追加
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <!-- 個別追加オプション -->
+                                    <div class="col-12 col-md-6">
+                                        <div class="d-flex align-items-start">
+                                            <div class="flex-shrink-0">
+                                                <i class="bi bi-star fs-3 text-warning"></i>
+                                            </div>
+                                            <div class="flex-grow-1 ms-3">
+                                                <h5 class="mb-2 fw-bold">気になるイベントだけ追加</h5>
+                                                <p class="text-muted mb-0">
+                                                    各イベントカードの右上にある <i class="bi bi-plus-circle-fill text-primary"></i> をクリックすると、個別にカレンダーへ追加できます
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <div class="row row-cols-1 row-cols-md-2 g-4">
                 {% for event in upcoming_events %}
                     <div class="col">
@@ -659,7 +817,7 @@
                 {% endfor %}
             </div>
             <div class="text-center mt-5">
-                <a href="{% url 'event:list' %}" class="btn btn-primary btn-hover-press">
+                <a href="{% url 'event:list' %}" class="btn btn-primary btn-lg btn-hover-press">
                     <i class="bi bi-calendar-week me-2"></i>すべてのイベントを見る
                 </a>
             </div>
@@ -1092,6 +1250,26 @@
                         }, 2000);
                     }
                 });
+            }
+
+            // Googleカレンダー連携UIの折りたたみ状態に応じてトグルテキストを切り替え
+            const calendarCollapse = document.getElementById('calendarSyncDetails');
+            if (calendarCollapse) {
+                const toggleIcon = calendarCollapse.closest('.card').querySelector('.calendar-toggle-icon');
+                if (toggleIcon) {
+                    const toggleOpen = toggleIcon.querySelector('.toggle-open');
+                    const toggleClose = toggleIcon.querySelector('.toggle-close');
+
+                    calendarCollapse.addEventListener('show.bs.collapse', function () {
+                        toggleOpen.classList.add('d-none');
+                        toggleClose.classList.remove('d-none');
+                    });
+
+                    calendarCollapse.addEventListener('hide.bs.collapse', function () {
+                        toggleOpen.classList.remove('d-none');
+                        toggleClose.classList.add('d-none');
+                    });
+                }
             }
         });
     </script>

--- a/app/ta_hub/tests/test_google_calendar_sync_ui.py
+++ b/app/ta_hub/tests/test_google_calendar_sync_ui.py
@@ -1,0 +1,87 @@
+"""Googleカレンダー連携UIのテスト"""
+
+from django.conf import settings
+from django.test import TestCase, Client
+from django.urls import reverse
+
+
+class GoogleCalendarSyncUITest(TestCase):
+    """トップページのGoogleカレンダー連携UIのテスト"""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_google_calendar_id_in_context(self):
+        """google_calendar_idがコンテキストに含まれること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('google_calendar_id', response.context)
+        self.assertEqual(response.context['google_calendar_id'], settings.GOOGLE_CALENDAR_ID)
+
+    def test_calendar_sync_section_displayed(self):
+        """Googleカレンダー連携セクションが表示されること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Googleカレンダーと連携して予定を管理')
+        self.assertContains(response, 'bi-calendar-plus')
+
+    def test_calendar_sync_collapse_structure(self):
+        """折りたたみ構造（Bootstrap collapse）が正しいこと"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        # collapseのトリガー
+        self.assertContains(response, 'data-bs-toggle="collapse"')
+        self.assertContains(response, 'href="#calendarSyncDetails"')
+        # collapseのターゲット
+        self.assertContains(response, 'id="calendarSyncDetails"')
+        self.assertContains(response, 'class="collapse"')
+
+    def test_toggle_text_elements_present(self):
+        """トグルテキスト要素が存在すること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'toggle-open')
+        self.assertContains(response, 'toggle-close')
+        self.assertContains(response, 'bi-chevron-down')
+        self.assertContains(response, 'bi-chevron-up')
+
+    def test_full_sync_option_displayed(self):
+        """全イベント同期オプションが表示されること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '全イベントを同期')
+        self.assertContains(response, '一度追加すれば、新しいイベントも自動で反映されます')
+        self.assertContains(response, 'bi-arrow-repeat')
+
+    def test_individual_add_option_displayed(self):
+        """個別追加オプションが表示されること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '気になるイベントだけ追加')
+        self.assertContains(response, 'bi-star')
+
+    def test_google_calendar_link_correct(self):
+        """Googleカレンダー追加リンクが正しいこと"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        # calendar.google.comへのリンクがあること
+        self.assertContains(response, 'https://calendar.google.com/calendar/u/0/r?cid=')
+        # Googleカレンダーに追加ボタン
+        self.assertContains(response, 'Googleカレンダーに追加')
+        self.assertContains(response, 'bi-google')
+
+    def test_toggle_javascript_present(self):
+        """トグル切り替え用JavaScriptが存在すること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'calendarSyncDetails')
+        self.assertContains(response, 'show.bs.collapse')
+        self.assertContains(response, 'hide.bs.collapse')

--- a/app/ta_hub/tests/test_vket_achievements.py
+++ b/app/ta_hub/tests/test_vket_achievements.py
@@ -1,0 +1,85 @@
+"""VKETコラボ実績セクションのテスト"""
+
+from django.test import TestCase, Client
+from django.urls import reverse
+
+from ta_hub.views import VKET_ACHIEVEMENTS
+
+
+class VketAchievementsConstantTest(TestCase):
+    """VKET_ACHIEVEMENTS定数のテスト"""
+
+    def test_vket_achievements_is_list(self):
+        """VKET_ACHIEVEMENTSがリストであること"""
+        self.assertIsInstance(VKET_ACHIEVEMENTS, list)
+
+    def test_vket_achievements_has_required_fields(self):
+        """各実績に必須フィールドがあること"""
+        required_fields = ['id', 'title', 'period', 'stats', 'image', 'hashtags', 'news_slug']
+
+        for achievement in VKET_ACHIEVEMENTS:
+            for field in required_fields:
+                self.assertIn(field, achievement, f"Achievement missing field: {field}")
+
+    def test_vket_achievements_stats_has_required_fields(self):
+        """stats辞書に必須フィールドがあること"""
+        for achievement in VKET_ACHIEVEMENTS:
+            self.assertIn('days', achievement['stats'])
+            self.assertIn('communities', achievement['stats'])
+
+
+class VketAchievementsSectionTest(TestCase):
+    """VKETコラボ実績セクション表示のテスト"""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_vket_achievements_in_context(self):
+        """vket_achievementsがコンテキストに含まれること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('vket_achievements', response.context)
+        self.assertEqual(response.context['vket_achievements'], VKET_ACHIEVEMENTS)
+
+    def test_vket_achievements_section_displayed(self):
+        """VKETコラボ実績セクションが表示されること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'VKETコラボ実績')
+        self.assertContains(response, 'bi-trophy-fill')
+
+    def test_vket_achievement_titles_displayed(self):
+        """各実績のタイトルが表示されること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        for achievement in VKET_ACHIEVEMENTS:
+            self.assertContains(response, achievement['title'])
+
+    def test_vket_achievement_periods_displayed(self):
+        """各実績の開催期間が表示されること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        for achievement in VKET_ACHIEVEMENTS:
+            self.assertContains(response, achievement['period'])
+
+    def test_vket_achievement_links_to_news(self):
+        """各実績がニュース詳細ページにリンクしていること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        for achievement in VKET_ACHIEVEMENTS:
+            expected_url = reverse('news:detail', args=[achievement['news_slug']])
+            self.assertContains(response, expected_url)
+
+    def test_activity_history_button_displayed(self):
+        """活動履歴をもっと見るボタンが表示されること"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '活動履歴をもっと見る')
+        activity_url = reverse('news:category_list', args=['activity'])
+        self.assertContains(response, activity_url)

--- a/app/ta_hub/views.py
+++ b/app/ta_hub/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 from django.views.generic import TemplateView
@@ -11,6 +12,28 @@ from event_calendar.calendar_utils import generate_google_calendar_url
 from utils.vrchat_time import get_vrchat_today
 
 logger = logging.getLogger(__name__)
+
+# VKETコラボ実績データ
+VKET_ACHIEVEMENTS = [
+    {
+        'id': 'winter-2025',
+        'title': 'Vket 2025 Winter 技術学術WEEK',
+        'period': '2025年12月6日〜12月21日',
+        'stats': {'days': 16, 'communities': 20},
+        'image': 'ta_hub/images/giga-week2025-winter.avif',
+        'hashtags': ['#Vketステージ', '#Vket技術学術WEEK'],
+        'news_slug': 'vket-2025-winter',
+    },
+    {
+        'id': 'summer-2025',
+        'title': 'Vket 2025 Summer 技術学術WEEK',
+        'period': '2025年7月12日〜7月27日',
+        'stats': {'days': 16, 'communities': 20},
+        'image': None,
+        'hashtags': ['#Vketステージ', '#Vket技術学術WEEK'],
+        'news_slug': 'vket-2025-summer',
+    },
+]
 
 
 class IndexView(TemplateView):
@@ -32,6 +55,13 @@ class IndexView(TemplateView):
         context['vket_start_date'] = vket_start_datetime.date()
         context['vket_end_date'] = vket_end_datetime.date()
         logger.info(f"Vket notice visibility: {context['show_vket_notice']} (current: {current_datetime})")
+
+        # VKETコラボ実績をコンテキストに追加（キャッシュ対象外）
+        context['vket_achievements'] = VKET_ACHIEVEMENTS
+
+        # Googleカレンダー連携用のカレンダーIDを追加
+        context['google_calendar_id'] = settings.GOOGLE_CALENDAR_ID
+
         # キャッシュからデータを取得
         cached_data = cache.get(cache_key)
         if cached_data is not None:


### PR DESCRIPTION
## なぜこの変更が必要か

- VKETコラボ実績をトップページで紹介し、サイトの活動実績をアピールしたい
- Googleカレンダー追加機能の認知度が低く、使い方がわかりにくかった

## 変更内容

### VKETコラボ実績セクション
- トップページにVKETコラボ実績セクションを追加
- 2025 Winter / Summer の2つの実績カードを表示
- カードクリックでニュース詳細ページに遷移
- 「活動履歴をもっと見る」ボタンで活動カテゴリ一覧へ

### Googleカレンダー連携UI
- 折りたたみ式の2段階UIを追加
- 初期状態: コンパクトな1行表示
- 展開時: 全イベント購読と個別追加の両方を説明
- Bootstrap collapseを使用したアニメーション

### その他
- 「すべてのイベントを見る」ボタンを btn-lg に変更

## テスト

- [x] VKETコラボ実績セクションのテスト（9件）
- [x] Googleカレンダー連携UIのテスト（8件）
- [x] 既存テストがパス

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)