### PR TITLE
fix: optimize_poster_imagesコマンドのファイルハンドルクローズ漏れを修正

### DIFF
--- a/app/community/management/commands/optimize_poster_images.py
+++ b/app/community/management/commands/optimize_poster_images.py
@@ -156,6 +156,12 @@ class Command(BaseCommand):
             except Exception as e:
                 error_count += 1
                 self.stdout.write(self.style.ERROR(f'[{i}/{total_communities}] {community.name}: エラー - {e}'))
+            finally:
+                # ファイルハンドルを確実に閉じる（リソースリーク防止）
+                try:
+                    poster.file.close()
+                except Exception:
+                    pass  # 既に閉じている場合は無視
 
         # サマリー
         self.stdout.write('\n' + '=' * 50)


### PR DESCRIPTION
## なぜこの変更が必要か

`optimize_poster_images` コマンドでバッチ処理時に `poster.file` を閉じていなかったため、大量のCommunityを処理する際に「Too many open files」エラーが発生するリスクがあった。

## 変更内容

- forループに `finally` ブロックを追加
- 各イテレーション終了時に `poster.file.close()` を確実に呼び出す
- 既にファイルが閉じている場合のエラーは無視

## テスト

- [x] `python manage.py test community.tests.test_optimize_poster_images` パス（5件）
- [x] `--dry-run` モードで正常動作

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)