### PR TITLE
feat: /accounts/signup/ を /account/register/ にリダイレクト

### DIFF
--- a/app/user_account/tests/test_views.py
+++ b/app/user_account/tests/test_views.py
@@ -427,6 +427,41 @@ class RegisterViewTests(TestCase):
         self.assertIn('>プライバシーポリシー</a>', content)
 
 
+class AllauthSignupRedirectTests(TestCase):
+    """allauthのsignupページからカスタムregisterページへのリダイレクトテスト."""
+
+    def setUp(self):
+        """テスト用のデータを準備."""
+        self.client = Client()
+        self.allauth_signup_url = '/accounts/signup/'
+        self.custom_register_url = '/account/register/'
+
+    def test_accounts_signup_redirects_to_account_register(self):
+        """/accounts/signup/ が /account/register/ にリダイレクトされること."""
+        response = self.client.get(self.allauth_signup_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.custom_register_url)
+
+    def test_accounts_signup_redirect_is_temporary(self):
+        """リダイレクトが一時的（302）であること."""
+        response = self.client.get(self.allauth_signup_url)
+        # 302 = 一時的リダイレクト、301 = 永続的リダイレクト
+        self.assertNotEqual(response.status_code, 301)
+        self.assertEqual(response.status_code, 302)
+
+    def test_accounts_signup_redirect_follow_leads_to_register_page(self):
+        """リダイレクトを追跡すると登録ページが表示されること."""
+        response = self.client.get(self.allauth_signup_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'account/register.html')
+
+    def test_accounts_signup_preserves_query_string(self):
+        """リダイレクト時にクエリパラメータが保持されること."""
+        response = self.client.get('/accounts/signup/?next=/foo/')
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('next=/foo/', response.url)
+
+
 class LoginPageRegisterLinkTests(TestCase):
     """ログインページの登録リンクテストクラス."""
 

--- a/app/website/urls.py
+++ b/app/website/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.views.generic import RedirectView
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [
@@ -23,6 +24,8 @@ urlpatterns = [
     path('community/', include('community.urls')),
     path('event/', include('event.urls')),
     path('account/', include('user_account.urls')),
+    # Redirect allauth default signup to custom register page (Discord OAuth required)
+    path('accounts/signup/', RedirectView.as_view(url='/account/register/', permanent=False, query_string=True)),
     path('accounts/', include('allauth.urls')),
     path('twitter/', include('twitter.urls')),
     path('api/v1/', include('api_v1.urls')),


### PR DESCRIPTION
## なぜこの変更が必要か

allauth のデフォルト signup ページ (`/accounts/signup/`) に直接アクセスした場合、CSS が適用されていない素の HTML ページが表示されていた。

このプロジェクトでは Discord OAuth が必須のため、ユーザーが誤って `/accounts/signup/` にアクセスした場合でも、正しいスタイルが適用された `/account/register/` ページにリダイレクトする。

## 変更内容

- `/accounts/signup/` へのアクセスを `/account/register/` に 302 リダイレクト
- `query_string=True` でクエリパラメータ（`?next=` など）を保持
- リダイレクト動作のテストを 4 件追加

## 意思決定

### 採用アプローチ
- URL リダイレクト方式を採用。理由: テンプレートを追加するよりシンプルで、既存の登録フローに統一できる

### 却下した代替案
- `account/signup.html` テンプレート追加 → 却下: 同じ機能のページが 2 つになり保守性が下がる

## テスト

- [x] `/accounts/signup/` → `/account/register/` リダイレクト確認
- [x] クエリパラメータ保持確認
- [x] 302 一時リダイレクト確認
- [x] 全 114 件のテストパス

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)