### PR TITLE
feat: LT受付設定のUIを改善

### DIFF
--- a/app/community/forms.py
+++ b/app/community/forms.py
@@ -86,7 +86,7 @@ class CommunityUpdateForm(forms.ModelForm):
         fields = [
             'name', 'start_time', 'duration', 'weekdays', 'frequency', 'organizers',
             'group_url', 'organizer_url', 'sns_url', 'discord', 'twitter_hashtag',
-            'poster_image', 'allow_poster_repost', 'accepts_lt_application',
+            'poster_image', 'allow_poster_repost',
             'description', 'platform', 'tags',
         ]
         widgets = {
@@ -104,7 +104,6 @@ class CommunityUpdateForm(forms.ModelForm):
             'allow_poster_repost': forms.CheckboxInput(attrs={'class': 'form-check-input'}),
             'description': forms.Textarea(attrs={'class': 'form-control'}),
             'platform': forms.Select(attrs={'class': 'form-control'}),
-            'accepts_lt_application': forms.CheckboxInput(attrs={'class': 'form-check-input'}),
         }
 
     def __init__(self, *args, **kwargs):

--- a/app/community/templates/community/settings.html
+++ b/app/community/templates/community/settings.html
@@ -123,42 +123,69 @@
             <form method="post" action="{% url 'community:update_lt_settings' community.pk %}">
                 {% csrf_token %}
                 <div class="mb-3">
-                    <label for="lt_application_template" class="form-label fw-medium">追加情報テンプレート</label>
-                    <textarea name="lt_application_template" id="lt_application_template"
-                              class="form-control" rows="6"
-                              placeholder="【発表概要】&#10;&#10;【対象者】&#10;&#10;【必要な前提知識】&#10;&#10;【動画撮影】OK / NG / 公開OK">{{ community.lt_application_template }}</textarea>
-                    <small class="form-text text-muted">
-                        空の場合、申請フォームに追加情報欄は表示されません。
-                    </small>
-                </div>
-                <div class="mb-3">
-                    <label for="lt_application_min_length" class="form-label fw-medium">最低文字数</label>
-                    <div class="d-flex align-items-center gap-2">
-                        <input type="number" name="lt_application_min_length" id="lt_application_min_length"
-                               class="form-control" style="width: 100px;" min="0"
-                               value="{{ community.lt_application_min_length }}">
-                        <span>文字</span>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="accepts_lt_application" name="accepts_lt_application"
+                               {% if community.accepts_lt_application %}checked{% endif %}
+                               onchange="toggleLTSettings()">
+                        <label class="form-check-label fw-medium" for="accepts_lt_application">
+                            LT申請を受け付ける
+                        </label>
                     </div>
                     <small class="form-text text-muted">
-                        0の場合、文字数チェックは行いません。
+                        ONにすると、イベントページにLT申請ボタンが表示されます。
                     </small>
                 </div>
-                <div class="mb-3">
-                    <label for="default_lt_duration" class="form-label fw-medium">デフォルトの発表時間</label>
-                    <div class="d-flex align-items-center gap-2">
-                        <input type="number" name="default_lt_duration" id="default_lt_duration"
-                               class="form-control" style="width: 100px;" min="1"
-                               value="{{ community.default_lt_duration|default:30 }}">
-                        <span>分</span>
+                <div id="lt-settings-detail" style="{% if not community.accepts_lt_application %}display: none;{% endif %}">
+                    <hr class="my-3">
+                    <div class="mb-3">
+                        <label for="lt_application_template" class="form-label fw-medium">追加情報テンプレート</label>
+                        <textarea name="lt_application_template" id="lt_application_template"
+                                  class="form-control" rows="7">{{ lt_application_template_display }}</textarea>
+                        <small class="form-text text-muted">
+                            空の場合、申請フォームに追加情報欄は表示されません。
+                        </small>
                     </div>
-                    <small class="form-text text-muted">
-                        LT申請フォームに表示されるデフォルトの発表時間
-                    </small>
+                    <div class="mb-3">
+                        <label for="lt_application_min_length" class="form-label fw-medium">最低文字数</label>
+                        <div class="d-flex align-items-center gap-2">
+                            <input type="number" name="lt_application_min_length" id="lt_application_min_length"
+                                   class="form-control" style="width: 100px;" min="0"
+                                   value="{{ community.lt_application_min_length }}">
+                            <span>文字</span>
+                        </div>
+                        <small class="form-text text-muted">
+                            0の場合、文字数チェックは行いません。
+                        </small>
+                    </div>
+                    <div class="mb-3">
+                        <label for="default_lt_duration" class="form-label fw-medium">デフォルトの発表時間</label>
+                        <div class="d-flex align-items-center gap-2">
+                            <input type="number" name="default_lt_duration" id="default_lt_duration"
+                                   class="form-control" style="width: 100px;" min="1"
+                                   value="{{ community.default_lt_duration|default:30 }}">
+                            <span>分</span>
+                        </div>
+                        <small class="form-text text-muted">
+                            LT申請フォームに表示されるデフォルトの発表時間
+                        </small>
+                    </div>
                 </div>
                 <button type="submit" class="btn btn-primary">保存</button>
             </form>
         </div>
     </div>
+
+    <script>
+    function toggleLTSettings() {
+        var checkbox = document.getElementById('accepts_lt_application');
+        var detailSection = document.getElementById('lt-settings-detail');
+        if (checkbox.checked) {
+            detailSection.style.display = 'block';
+        } else {
+            detailSection.style.display = 'none';
+        }
+    }
+    </script>
 
     <!-- メンバー管理セクション（主催者のみ） -->
     {% if is_owner %}

--- a/app/community/templates/community/update.html
+++ b/app/community/templates/community/update.html
@@ -43,7 +43,6 @@
                             {% bootstrap_field form.discord %}
                             {% bootstrap_field form.poster_image %}
                             {% bootstrap_field form.allow_poster_repost %}
-                            {% bootstrap_field form.accepts_lt_application %}
                             {% bootstrap_field form.description %}
                             {% bootstrap_field form.platform %}
                             {% bootstrap_field form.tags %}

--- a/app/community/views.py
+++ b/app/community/views.py
@@ -767,6 +767,13 @@ class CommunitySettingsView(LoginRequiredMixin, TemplateView):
                 expires_at__gt=timezone.now()
             ).first()
 
+        # LT申請テンプレートのデフォルト値を設定
+        if community:
+            context['lt_application_template_display'] = (
+                community.lt_application_template or
+                "【発表概要】\n\n【スライド公開】OK / NG\n【動画撮影】OK / NG"
+            )
+
         return context
 
 
@@ -1010,6 +1017,7 @@ class UpdateLTSettingsView(LoginRequiredMixin, UserPassesTestMixin, View):
 
     def post(self, request, pk):
         community = get_object_or_404(Community, pk=pk)
+        accepts_lt = request.POST.get('accepts_lt_application') == 'on'
         lt_template = request.POST.get('lt_application_template', '').strip()
         min_length_str = request.POST.get('lt_application_min_length', '0').strip()
         duration_str = request.POST.get('default_lt_duration', '30').strip()
@@ -1026,10 +1034,11 @@ class UpdateLTSettingsView(LoginRequiredMixin, UserPassesTestMixin, View):
         except ValueError:
             duration = 30
 
+        community.accepts_lt_application = accepts_lt
         community.lt_application_template = lt_template
         community.lt_application_min_length = min_length
         community.default_lt_duration = duration
-        community.save(update_fields=['lt_application_template', 'lt_application_min_length', 'default_lt_duration'])
+        community.save(update_fields=['accepts_lt_application', 'lt_application_template', 'lt_application_min_length', 'default_lt_duration'])
 
         messages.success(request, 'LT申請設定を保存しました。')
         logger.info(


### PR DESCRIPTION
## なぜこの変更が必要か

LT受付のON/OFFが `/community/update/` に散在しており、設定画面に統一されていなかった。
ユーザーがLT関連設定を一箇所で管理できるようにし、UIをシンプルにする。

## 変更内容

- `/community/settings/` にLT受付トグルを追加
- トグルONで詳細設定（テンプレート、最低文字数、発表時間）が展開表示
- `/community/update/` から `accepts_lt_application` チェックボックスを削除
- テンプレートにデフォルト値（発表概要、スライド公開、動画撮影）を設定

## 意思決定

### 採用アプローチ
- トグル連動UIを採用。理由: トグルOFFの場合に詳細設定を非表示にすることでUIがシンプルになる

### トレードオフ
- シンプルさ > 機能分散: LT設定を設定画面に集約し、編集画面をシンプルに保つ

## テスト

- [ ] `/community/settings/` でLT受付トグルが表示される
- [ ] トグルONで詳細設定が展開表示される
- [ ] トグルOFFで詳細設定が非表示になる
- [ ] 設定を保存後、ページリロードしても設定が維持される
- [ ] `/community/update/` から accepts_lt_application チェックボックスが削除されている

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)