### PR TITLE
feat: LT申請テンプレートの動画撮影オプションを拡充

### DIFF
--- a/app/community/views.py
+++ b/app/community/views.py
@@ -771,7 +771,7 @@ class CommunitySettingsView(LoginRequiredMixin, TemplateView):
         if community:
             context['lt_application_template_display'] = (
                 community.lt_application_template or
-                "【発表概要】\n\n【スライド公開】OK / NG\n【動画撮影】OK / NG"
+                "【発表概要】\n\n【スライド公開】OK / NG\n\n【動画撮影】YouTube公開 / Discord限定 / OK / NG"
             )
 
         return context


### PR DESCRIPTION
## なぜこの変更が必要か

LT申請時の動画撮影について、単純な「OK / NG」だけでなく、より具体的な公開範囲（YouTube公開、Discord限定）を指定できるようにするため。

これにより、登壇者は自分の発表動画がどの範囲で公開されるかを明確に指定できるようになる。

## 変更内容

- 【動画撮影】の選択肢を「OK / NG」→「YouTube公開 / Discord限定 / OK / NG」に変更
- 【スライド公開】と【動画撮影】の間に空行を追加して可読性を向上

## テスト

- [x] 既存のLT申請テンプレート設定への影響なし（既に設定済みのテンプレートは上書きされない）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)