### PR TITLE
fix: Python 3.12のテストディスカバリ問題を回避

### DIFF
--- a/app/api_v1/tests/__init__.py
+++ b/app/api_v1/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for api_v1

--- a/app/community/tests/__init__.py
+++ b/app/community/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for community

--- a/app/event/tests/__init__.py
+++ b/app/event/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for event

--- a/app/event_calendar/tests/__init__.py
+++ b/app/event_calendar/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for event_calendar

--- a/app/guide/tests/__init__.py
+++ b/app/guide/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for guide

--- a/app/ta_hub/tests/__init__.py
+++ b/app/ta_hub/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for ta_hub

--- a/app/twitter/tests/__init__.py
+++ b/app/twitter/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for twitter

--- a/app/user_account/tests/__init__.py
+++ b/app/user_account/tests/__init__.py
@@ -1,1 +1,1 @@
-# This file is intentionally empty to make the directory a Python package 
+# Test package for user_account

--- a/app/website/tests/__init__.py
+++ b/app/website/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for website

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - .env.local
     environment:
       - DEBUG=True
+      - PYTHONPATH=/app
     ports:
       - '8015:8080'
     networks:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# テスト実行スクリプト
+# Python 3.12のモジュールディスカバリ問題を回避するため、
+# 明示的にテストパスを指定して実行する
+
+TEST_APPS=(
+    "api_v1.tests"
+    "community.tests"
+    "event.tests"
+    "event_calendar.tests"
+    "guide.tests"
+    "ta_hub.tests"
+    "twitter.tests"
+    "user_account.tests"
+    "website.tests"
+)
+
+# 引数があればそれを使う、なければ全アプリ
+if [ $# -gt 0 ]; then
+    docker compose exec vrc-ta-hub python manage.py test "$@"
+else
+    docker compose exec vrc-ta-hub python manage.py test "${TEST_APPS[@]}" --verbosity=1
+fi


### PR DESCRIPTION
## なぜこの変更が必要か

`python manage.py test` を実行すると、Python 3.12のunittest loaderが`tests`モジュールのインポートに失敗するエラーが発生していた。

```
ImportError: 'tests' module incorrectly imported from '/app/api_v1/tests'. Expected '/app/api_v1'. Is this module globally installed?
```

## 変更内容

- `scripts/run_tests.sh` を追加：明示的にテストパスを指定して実行
- 各 `tests/__init__.py` にコメントを追加
- `docker-compose.yaml` に `PYTHONPATH=/app` を追加

## 使い方

```bash
# 全テスト実行
./scripts/run_tests.sh

# 特定アプリのテスト
./scripts/run_tests.sh guide.tests
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)