### PR TITLE
security: 却下済み・未承認LT申請の公開ビュー漏洩を修正

### DIFF
--- a/app/api_v1/views.py
+++ b/app/api_v1/views.py
@@ -126,7 +126,8 @@ class EventDetailFilter(filters.FilterSet):
 @method_decorator(csrf_exempt, name='dispatch')
 class EventDetailViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = EventDetail.objects.filter(
-        event__community__status='approved'
+        event__community__status='approved',
+        status='approved'
     ).select_related('event', 'event__community').order_by('event__date', 'start_time')
     serializer_class = EventDetailSerializer
     filterset_class = EventDetailFilter

--- a/app/event/tests/test_rejected_lt_visibility.py
+++ b/app/event/tests/test_rejected_lt_visibility.py
@@ -1,0 +1,861 @@
+"""却下済み・未承認のLT申請が公開ビューに表示されない再発防止テスト.
+
+修正背景:
+    status='approved' フィルタの欠落により、pending/rejected状態の
+    EventDetailがイベント一覧・カレンダー・Twitter・APIに漏洩していた。
+"""
+from datetime import date, time, timedelta
+from urllib.parse import unquote
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, Client, RequestFactory, override_settings
+from django.urls import reverse
+
+from community.models import Community
+from event.models import Event, EventDetail
+
+User = get_user_model()
+
+
+class EventListViewFilterTest(TestCase):
+    """EventListView で承認済みのEventDetailのみ表示されるテスト"""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.community = Community.objects.create(
+            name='Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Approved Theme',
+            speaker='Approved Speaker',
+            status='approved',
+            duration=15,
+            start_time=time(22, 0),
+        )
+
+        self.pending_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Pending Theme',
+            speaker='Pending Speaker',
+            status='pending',
+            duration=15,
+            start_time=time(22, 15),
+        )
+
+        self.rejected_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Rejected Theme',
+            speaker='Rejected Speaker',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=15,
+            start_time=time(22, 30),
+        )
+
+    def test_event_list_only_shows_approved_details(self):
+        """イベント一覧で承認済みのEventDetailのみprefetchされる"""
+        url = reverse('event:list')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        # コンテキストからイベントを取得
+        events = response.context['events']
+
+        for event in events:
+            if event.id == self.event.id:
+                # prefetch_relatedでロード済みのdetailsを確認
+                details = list(event.details.all())
+                detail_statuses = [d.status for d in details]
+
+                self.assertIn('approved', detail_statuses)
+                self.assertNotIn('pending', detail_statuses)
+                self.assertNotIn('rejected', detail_statuses)
+                break
+        else:
+            self.fail('テスト対象のイベントが一覧に見つからない')
+
+
+class EventDetailAPIPublicViewSetFilterTest(TestCase):
+    """公開API (EventDetailViewSet) で承認済みのEventDetailのみ返るテスト"""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.community = Community.objects.create(
+            name='API Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Approved API Theme',
+            speaker='Approved API Speaker',
+            status='approved',
+            duration=15,
+            start_time=time(22, 0),
+        )
+
+        self.pending_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Pending API Theme',
+            speaker='Pending API Speaker',
+            status='pending',
+            duration=15,
+            start_time=time(22, 15),
+        )
+
+        self.rejected_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Rejected API Theme',
+            speaker='Rejected API Speaker',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=15,
+            start_time=time(22, 30),
+        )
+
+    def test_public_api_only_returns_approved_details(self):
+        """公開APIで承認済みのEventDetailのみ返される"""
+        url = reverse('eventdetail-list')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        # ページネーションありの場合はresultsキー、なしの場合は直接リスト
+        results = data['results'] if isinstance(data, dict) and 'results' in data else data
+
+        returned_ids = [item['id'] for item in results]
+
+        self.assertIn(self.approved_detail.id, returned_ids)
+        self.assertNotIn(self.pending_detail.id, returned_ids)
+        self.assertNotIn(self.rejected_detail.id, returned_ids)
+
+    def test_public_api_does_not_return_pending_detail_by_id(self):
+        """公開APIでpendingのEventDetailを個別取得できない"""
+        url = reverse('eventdetail-detail', kwargs={'pk': self.pending_detail.pk})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_public_api_does_not_return_rejected_detail_by_id(self):
+        """公開APIでrejectedのEventDetailを個別取得できない"""
+        url = reverse('eventdetail-detail', kwargs={'pk': self.rejected_detail.pk})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 404)
+
+
+class TwitterUtilsFilterTest(TestCase):
+    """twitter/utils.py の format_event_info で承認済みのみ取得するテスト"""
+
+    def setUp(self):
+        self.community = Community.objects.create(
+            name='Twitter Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Approved Twitter Theme',
+            speaker='Approved Twitter Speaker',
+            status='approved',
+            duration=15,
+            start_time=time(22, 0),
+        )
+
+        self.pending_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Pending Twitter Theme',
+            speaker='Pending Twitter Speaker',
+            status='pending',
+            duration=15,
+            start_time=time(22, 15),
+        )
+
+        self.rejected_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Rejected Twitter Theme',
+            speaker='Rejected Twitter Speaker',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=15,
+            start_time=time(22, 30),
+        )
+
+    def test_format_event_info_only_includes_approved(self):
+        """format_event_info は承認済みのEventDetailのみ含む"""
+        from twitter.utils import format_event_info
+
+        event_info = format_event_info(self.event)
+        details_text = event_info['details']
+
+        self.assertIn('Approved Twitter Theme', details_text)
+        self.assertNotIn('Pending Twitter Theme', details_text)
+        self.assertNotIn('Rejected Twitter Theme', details_text)
+
+
+class CalendarUtilsFilterTest(TestCase):
+    """calendar_utils.py の generate_google_calendar_url で承認済みのみ含むテスト"""
+
+    def setUp(self):
+        self.community = Community.objects.create(
+            name='Calendar Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Approved Calendar Theme',
+            speaker='Approved Calendar Speaker',
+            status='approved',
+            duration=15,
+            start_time=time(22, 0),
+        )
+
+        self.rejected_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Rejected Calendar Theme',
+            speaker='Rejected Calendar Speaker',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=15,
+            start_time=time(22, 30),
+        )
+
+    def test_google_calendar_url_only_includes_approved_details(self):
+        """GoogleカレンダーURL生成時に承認済みの発表情報のみ含まれる"""
+        from event_calendar.calendar_utils import generate_google_calendar_url
+
+        factory = RequestFactory()
+        request = factory.get('/')
+        request.META['SERVER_NAME'] = 'testserver'
+        request.META['SERVER_PORT'] = '80'
+
+        url = generate_google_calendar_url(request, self.event)
+        decoded_url = unquote(url)
+
+        self.assertIn('Approved Calendar Speaker', decoded_url)
+        self.assertIn('Approved Calendar Theme', decoded_url)
+        self.assertNotIn('Rejected Calendar Speaker', decoded_url)
+        self.assertNotIn('Rejected Calendar Theme', decoded_url)
+
+
+def _create_test_image():
+    """テスト用の最小限のPNG画像バイナリを生成する"""
+    # 1x1ピクセルの最小PNG
+    import struct
+    import zlib
+
+    def _chunk(chunk_type, data):
+        c = chunk_type + data
+        crc = struct.pack('>I', zlib.crc32(c) & 0xffffffff)
+        return struct.pack('>I', len(data)) + c + crc
+
+    signature = b'\x89PNG\r\n\x1a\n'
+    ihdr_data = struct.pack('>IIBBBBB', 1, 1, 8, 2, 0, 0, 0)
+    raw_data = b'\x00\xff\x00\x00'
+    idat_data = zlib.compress(raw_data)
+
+    return signature + _chunk(b'IHDR', ihdr_data) + _chunk(b'IDAT', idat_data) + _chunk(b'IEND', b'')
+
+
+class IndexViewLTFilterTest(TestCase):
+    """トップページのLT一覧で承認済みのEventDetailのみ表示されるテスト"""
+
+    def setUp(self):
+        self.client = Client()
+        cache.clear()
+
+        image_content = _create_test_image()
+        poster = SimpleUploadedFile('test.png', image_content, content_type='image/png')
+
+        self.community = Community.objects.create(
+            name='Index LT Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+            poster_image=poster,
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=3),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_lt = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Approved Index LT',
+            speaker='Approved Speaker',
+            status='approved',
+            duration=15,
+            start_time=time(22, 0),
+        )
+
+        self.rejected_lt = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Rejected Index LT',
+            speaker='Rejected Speaker',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=15,
+            start_time=time(22, 15),
+        )
+
+        self.pending_lt = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Pending Index LT',
+            speaker='Pending Speaker',
+            status='pending',
+            duration=15,
+            start_time=time(22, 30),
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_index_lt_list_only_shows_approved(self):
+        """トップページのLT一覧で承認済みのみ表示される"""
+        url = reverse('ta_hub:index')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        details = response.context.get('upcoming_event_details', [])
+        # details はdict形式の場合もあるため、speaker キーで判定
+        speakers = []
+        for d in details:
+            if isinstance(d, dict):
+                speakers.append(d.get('speaker', ''))
+            else:
+                speakers.append(getattr(d, 'speaker', ''))
+
+        self.assertIn('Approved Speaker', speakers)
+        self.assertNotIn('Rejected Speaker', speakers)
+        self.assertNotIn('Pending Speaker', speakers)
+
+
+class IndexViewSpecialFilterTest(TestCase):
+    """トップページの特別企画で承認済みのEventDetailのみ表示されるテスト"""
+
+    def setUp(self):
+        self.client = Client()
+        cache.clear()
+
+        image_content = _create_test_image()
+        poster = SimpleUploadedFile('test.png', image_content, content_type='image/png')
+
+        self.community = Community.objects.create(
+            name='Index Special Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+            poster_image=poster,
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=3),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_special = EventDetail.objects.create(
+            event=self.event,
+            detail_type='SPECIAL',
+            theme='Approved Special Event',
+            status='approved',
+            duration=60,
+            start_time=time(22, 0),
+        )
+
+        self.rejected_special = EventDetail.objects.create(
+            event=self.event,
+            detail_type='SPECIAL',
+            theme='Rejected Special Event',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=60,
+            start_time=time(22, 0),
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_index_special_events_only_shows_approved(self):
+        """トップページの特別企画で承認済みのみ表示される"""
+        url = reverse('ta_hub:index')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        specials = response.context.get('special_events', [])
+        themes = []
+        for s in specials:
+            if isinstance(s, dict):
+                themes.append(s.get('theme', ''))
+            else:
+                themes.append(getattr(s, 'theme', ''))
+
+        self.assertIn('Approved Special Event', themes)
+        self.assertNotIn('Rejected Special Event', themes)
+
+
+class EventDetailViewAccessTest(TestCase):
+    """EventDetailView で未認証ユーザーがrejected/pendingの詳細にアクセスすると404になるテスト"""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.community = Community.objects.create(
+            name='Detail Access Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Approved Detail',
+            speaker='Speaker A',
+            status='approved',
+            duration=15,
+            start_time=time(22, 0),
+        )
+
+        self.rejected_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Rejected Detail',
+            speaker='Speaker B',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=15,
+            start_time=time(22, 15),
+        )
+
+        self.pending_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Pending Detail',
+            speaker='Speaker C',
+            status='pending',
+            duration=15,
+            start_time=time(22, 30),
+        )
+
+        # スーパーユーザーを作成
+        self.superuser = User.objects.create_superuser(
+            user_name='admin_test',
+            email='admin@test.com',
+            password='testpass123',
+        )
+
+    def test_anonymous_can_access_approved_detail(self):
+        """未認証ユーザーはapprovedの詳細にアクセスできる"""
+        url = reverse('event:detail', kwargs={'pk': self.approved_detail.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_anonymous_cannot_access_rejected_detail(self):
+        """未認証ユーザーはrejectedの詳細にアクセスすると404"""
+        url = reverse('event:detail', kwargs={'pk': self.rejected_detail.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_anonymous_cannot_access_pending_detail(self):
+        """未認証ユーザーはpendingの詳細にアクセスすると404"""
+        url = reverse('event:detail', kwargs={'pk': self.pending_detail.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_superuser_can_access_rejected_detail(self):
+        """スーパーユーザーはrejectedの詳細にもアクセスできる"""
+        self.client.login(username='admin_test', password='testpass123')
+        url = reverse('event:detail', kwargs={'pk': self.rejected_detail.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_superuser_can_access_pending_detail(self):
+        """スーパーユーザーはpendingの詳細にもアクセスできる"""
+        self.client.login(username='admin_test', password='testpass123')
+        url = reverse('event:detail', kwargs={'pk': self.pending_detail.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class EventDetailPastListFilterTest(TestCase):
+    """EventDetailPastList でapprovedのみ表示されるテスト"""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.community = Community.objects.create(
+            name='Past List Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() - timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Approved Past LT',
+            speaker='Approved Past Speaker',
+            status='approved',
+            duration=15,
+            start_time=time(22, 0),
+        )
+
+        self.rejected_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Rejected Past LT',
+            speaker='Rejected Past Speaker',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=15,
+            start_time=time(22, 15),
+        )
+
+        self.pending_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Pending Past LT',
+            speaker='Pending Past Speaker',
+            status='pending',
+            duration=15,
+            start_time=time(22, 30),
+        )
+
+    def test_past_list_only_shows_approved(self):
+        """LT履歴一覧で承認済みのみ表示される"""
+        url = reverse('event:detail_history')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        event_details = response.context['event_details']
+        detail_ids = [d.id for d in event_details]
+
+        self.assertIn(self.approved_detail.id, detail_ids)
+        self.assertNotIn(self.rejected_detail.id, detail_ids)
+        self.assertNotIn(self.pending_detail.id, detail_ids)
+
+
+class EventLogListViewFilterTest(TestCase):
+    """EventLogListView でapprovedのみ表示されるテスト"""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.community = Community.objects.create(
+            name='Event Log Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() - timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_special = EventDetail.objects.create(
+            event=self.event,
+            detail_type='SPECIAL',
+            theme='Approved Special Log',
+            status='approved',
+            duration=60,
+            start_time=time(22, 0),
+        )
+
+        self.rejected_blog = EventDetail.objects.create(
+            event=self.event,
+            detail_type='BLOG',
+            theme='Rejected Blog Log',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=60,
+            start_time=time(22, 0),
+        )
+
+        self.pending_special = EventDetail.objects.create(
+            event=self.event,
+            detail_type='SPECIAL',
+            theme='Pending Special Log',
+            status='pending',
+            duration=60,
+            start_time=time(22, 0),
+        )
+
+    def test_event_log_list_only_shows_approved(self):
+        """特別企画/ブログ一覧で承認済みのみ表示される"""
+        url = reverse('event:event_log_list')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        event_logs = response.context['event_logs']
+        log_ids = [d.id for d in event_logs]
+
+        self.assertIn(self.approved_special.id, log_ids)
+        self.assertNotIn(self.rejected_blog.id, log_ids)
+        self.assertNotIn(self.pending_special.id, log_ids)
+
+
+class SitemapFilterTest(TestCase):
+    """サイトマップでapprovedのEventDetailのみ含まれるテスト"""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.community = Community.objects.create(
+            name='Sitemap Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Approved Sitemap LT',
+            speaker='Speaker A',
+            status='approved',
+            duration=15,
+            start_time=time(22, 0),
+        )
+
+        self.rejected_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Rejected Sitemap LT',
+            speaker='Speaker B',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=15,
+            start_time=time(22, 15),
+        )
+
+        self.pending_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Pending Sitemap LT',
+            speaker='Speaker C',
+            status='pending',
+            duration=15,
+            start_time=time(22, 30),
+        )
+
+    def test_sitemap_only_includes_approved_details(self):
+        """サイトマップにapprovedのEventDetailのみ含まれる"""
+        url = reverse('sitemap:sitemap')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        event_details = response.context['event_details']
+        detail_ids = [d.id for d in event_details]
+
+        self.assertIn(self.approved_detail.id, detail_ids)
+        self.assertNotIn(self.rejected_detail.id, detail_ids)
+        self.assertNotIn(self.pending_detail.id, detail_ids)
+
+
+class RelatedEventDetailsFilterTest(TestCase):
+    """EventDetailView._fetch_related_event_details で承認済みのみ返るテスト"""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.community = Community.objects.create(
+            name='Related Details Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+
+        self.approved_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Main LT',
+            speaker='Main Speaker',
+            status='approved',
+            duration=15,
+            start_time=time(22, 0),
+            h1='Main Article Title',
+        )
+
+        self.approved_related = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Related Approved LT',
+            speaker='Related Approved Speaker',
+            status='approved',
+            duration=15,
+            start_time=time(22, 15),
+            h1='Approved Related Title',
+        )
+
+        self.rejected_related = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Related Rejected LT',
+            speaker='Related Rejected Speaker',
+            status='rejected',
+            rejection_reason='Not suitable',
+            duration=15,
+            start_time=time(22, 30),
+            h1='Rejected Related Title',
+        )
+
+    def test_related_details_only_includes_approved(self):
+        """関連記事に承認済みのEventDetailのみ含まれる"""
+        from django.core.cache import cache
+        cache.clear()
+
+        url = reverse('event:detail', kwargs={'pk': self.approved_detail.pk})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        related = response.context.get('related_event_details', [])
+        related_h1s = [r['h1'] for r in related]
+
+        self.assertIn('Approved Related Title', related_h1s)
+        self.assertNotIn('Rejected Related Title', related_h1s)

--- a/app/event_calendar/calendar_utils.py
+++ b/app/event_calendar/calendar_utils.py
@@ -155,8 +155,9 @@ def generate_google_calendar_url(request, event):
     description = [f"参加方法: {community_url}"]
     
     # 発表情報を追加（存在する場合）
-    if event.details.exists():
-        description.extend([f"発表者: {detail.speaker}\nテーマ: {detail.theme}" for detail in event.details.all()])
+    approved_details = event.details.filter(status='approved')
+    if approved_details.exists():
+        description.extend([f"発表者: {detail.speaker}\nテーマ: {detail.theme}" for detail in approved_details])
     
     # URLパラメータを作成
     params = {

--- a/app/event_calendar/views.py
+++ b/app/event_calendar/views.py
@@ -114,9 +114,10 @@ class CalendarEntryUpdateView(LoginRequiredMixin, UpdateView):
         description = [f"参加方法: {community_url}"]
 
         # 発表情報を追加（存在する場合）
-        if event.details.exists():
+        approved_details = event.details.filter(status='approved')
+        if approved_details.exists():
             description.extend([f"発表者: {detail.speaker}\nテーマ: {
-            detail.theme}" for detail in event.details.all()])
+            detail.theme}" for detail in approved_details])
 
         # URLパラメータを作成
         params = {

--- a/app/sitemap/views.py
+++ b/app/sitemap/views.py
@@ -10,7 +10,7 @@ class SitemapView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        event_details = EventDetail.objects.all().order_by('-pk')
+        event_details = EventDetail.objects.filter(status='approved').order_by('-pk')
         context['event_details'] = event_details
         communities = Community.objects.filter(status='approved').order_by('-pk')
         context['communities'] = communities

--- a/app/ta_hub/views.py
+++ b/app/ta_hub/views.py
@@ -91,6 +91,7 @@ class IndexView(TemplateView):
         upcoming_event_details = EventDetail.objects.filter(
             event__date__gte=today,
             detail_type='LT',  # LTのみ
+            status='approved',
             # ポスター画像があるコミュニティのイベントのみ
             event__community__poster_image__isnull=False
         ).exclude(
@@ -100,6 +101,7 @@ class IndexView(TemplateView):
         # 特別企画を取得（今日からイベント終了日の24時まで表示）
         special_events = EventDetail.objects.filter(
             detail_type='SPECIAL',
+            status='approved',
             event__date__gte=today,  # 今日以降のイベント
             # ポスター画像があるコミュニティのイベントのみ
             event__community__poster_image__isnull=False

--- a/app/twitter/utils.py
+++ b/app/twitter/utils.py
@@ -19,7 +19,7 @@ def format_event_info(event):
     weekdays = ['月', '火', '水', '木', '金', '土', '日']
     weekday = weekdays[event.date.weekday()]
     
-    details = event.details.all().order_by('start_time')
+    details = event.details.filter(status='approved').order_by('start_time')
     details_text = "\n".join([f"{d.start_time.strftime('%H:%M')} - {d.theme} ({d.speaker})" for d in details])
     return {
         "event_name": event.community.name,


### PR DESCRIPTION
## なぜこの変更が必要か

脆弱性報告により、運営者が却下したLT申請（`status='rejected'`）や承認待ち（`status='pending'`）のEventDetailが、イベント一覧ページ・トップページ・公開API・サイトマップ等に表示され続けていることが判明した。

これにより、本来非公開であるべき申請者名・テーマ等が第三者に閲覧可能な状態になっていた（CWE-213/CWE-284, CVSS 4.3 Medium）。

## 変更内容

EventDetailを取得する全ての公開ビューで `status='approved'` フィルタを追加:

- **EventListView**: `Prefetch`オブジェクトでapprovedのみprefetch
- **EventDetailView**: `get_queryset`オーバーライド（superuserのみ全ステータス閲覧可）
- **EventDetailPastList / EventLogListView**: querysetにフィルタ追加
- **IndexView**: トップページLT一覧・特別企画にフィルタ追加
- **SitemapView**: approvedのみサイトマップに含める
- **CalendarEntryUpdateView / calendar_utils**: カレンダー情報にフィルタ追加
- **format_event_info**: Twitter投稿にフィルタ追加
- **EventDetailViewSet**: 公開APIにフィルタ追加
- **_fetch_related_event_details**: 関連記事にフィルタ追加

## 意思決定

### 採用アプローチ
- 各ビュー/ユーティリティの取得箇所で個別にフィルタを適用。理由: カスタムマネージャで一律フィルタすると管理画面やバッチ処理に影響するため、公開箇所のみ明示的にフィルタ
- `EventDetailView`はsuperuserのみ全ステータス閲覧可能。理由: コミュニティオーナー判定よりシンプルで、管理画面（EventMyList）から全ステータス確認可能

### 却下した代替案
- カスタムマネージャ（`ApprovedManager`）→ 却下: 管理画面等への影響範囲が広すぎる
- テンプレート側でのフィルタ → 却下: View層でフィルタすべき（防御の深さ）

### 技術的負債
- `_fetch_related_event_details`のキャッシュキーがstatus変更を考慮していない（最大1時間で自然失効）

## テスト

- [ ] EventListViewで承認済みのみprefetchされる
- [ ] 公開APIで承認済みのみ返る（list/detail/rejected個別/pending個別）
- [ ] Twitter utils でapprovedのみ含む
- [ ] GoogleカレンダーURLにapprovedのみ含む
- [ ] トップページLT一覧でapprovedのみ表示
- [ ] トップページ特別企画でapprovedのみ表示
- [ ] EventDetailView: 匿名→rejected/pendingは404、superuser→200
- [ ] LT履歴一覧でapprovedのみ表示
- [ ] 特別企画/ブログ一覧でapprovedのみ表示
- [ ] サイトマップにapprovedのみ含む
- [ ] 関連記事にapprovedのみ含む

全17テストパス

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens filtering across multiple public endpoints/views to exclude non-approved `EventDetail`, which is security-relevant and could affect what content becomes visible; main risk is unintended hiding of legitimate content or breaking expectations around caching/prefetch behavior.
> 
> **Overview**
> Fixes an information disclosure where non-approved (`pending`/`rejected`) `EventDetail` records could appear in public surfaces by consistently enforcing `status='approved'` filtering.
> 
> Public-facing queries now restrict details to approved only across the public API (`EventDetailViewSet`), event list prefetching (`Prefetch`), event detail access (404 for non-approved unless superuser), related-article selection, homepage LT/special sections, sitemap generation, Google Calendar URL generation, and Twitter formatting.
> 
> Adds a comprehensive regression test suite (`test_rejected_lt_visibility.py`) covering the above public views/utilities to ensure non-approved items are never exposed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79ae9e3809cd67d8f8136c59b485553679f07a83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->