### PR TITLE
fix: LT承認モーダルのフリッカーを修正

### DIFF
--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -202,65 +202,6 @@
                                             </button>
                                             {% endif %}
                                         </div>
-
-                                        {% if detail.applicant and detail.status == 'pending' %}
-                                        <div class="modal fade" id="approveModal{{ detail.pk }}" tabindex="-1" aria-labelledby="approveModalLabel{{ detail.pk }}" aria-hidden="true">
-                                            <div class="modal-dialog">
-                                                <div class="modal-content">
-                                                    <div class="modal-header">
-                                                        <h5 class="modal-title" id="approveModalLabel{{ detail.pk }}">LT申請を承認</h5>
-                                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                                    </div>
-                                                    <div class="modal-body">
-                                                        <p>以下のLT申請を承認しますか？</p>
-                                                        <ul class="list-unstyled">
-                                                            <li><strong>テーマ:</strong> {{ detail.theme }}</li>
-                                                            <li><strong>発表者:</strong> {{ detail.speaker }}</li>
-                                                            <li><strong>申請者:</strong> {{ detail.applicant.user_name }}</li>
-                                                            <li><strong>イベント日:</strong> {{ event.date }}</li>
-                                                        </ul>
-                                                    </div>
-                                                    <div class="modal-footer">
-                                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
-                                                        <form method="post" action="{% url 'event:lt_application_approve' detail.pk %}" class="d-inline">
-                                                            {% csrf_token %}
-                                                            <button type="submit" class="btn btn-success">承認する</button>
-                                                        </form>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                        <div class="modal fade" id="rejectModal{{ detail.pk }}" tabindex="-1" aria-labelledby="rejectModalLabel{{ detail.pk }}" aria-hidden="true">
-                                            <div class="modal-dialog">
-                                                <div class="modal-content">
-                                                    <form method="post" action="{% url 'event:lt_application_reject' detail.pk %}">
-                                                        {% csrf_token %}
-                                                        <div class="modal-header">
-                                                            <h5 class="modal-title" id="rejectModalLabel{{ detail.pk }}">LT申請を却下</h5>
-                                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                                        </div>
-                                                        <div class="modal-body">
-                                                            <p>以下のLT申請を却下しますか？</p>
-                                                            <ul class="list-unstyled mb-3">
-                                                                <li><strong>テーマ:</strong> {{ detail.theme }}</li>
-                                                                <li><strong>発表者:</strong> {{ detail.speaker }}</li>
-                                                                <li><strong>申請者:</strong> {{ detail.applicant.user_name }}</li>
-                                                            </ul>
-                                                            <div class="mb-3">
-                                                                <label for="rejection_reason_{{ detail.pk }}" class="form-label">却下理由 <span class="text-danger">*</span></label>
-                                                                <textarea class="form-control" id="rejection_reason_{{ detail.pk }}" name="rejection_reason" rows="3" required placeholder="却下理由を入力してください"></textarea>
-                                                            </div>
-                                                        </div>
-                                                        <div class="modal-footer">
-                                                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
-                                                            <button type="submit" class="btn btn-danger">却下する</button>
-                                                        </div>
-                                                    </form>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        {% endif %}
                                         <hr>
                                     {% endfor %}
                                     <div class="">
@@ -284,6 +225,70 @@
         {% endfor %}
 
         {% include "ta_hub/pagination.html" %}
+
+        {# モーダルをcard要素の外に一括出力（CSSトランジション干渉を回避） #}
+        {% for event in events %}
+            {% for detail in event.detail_list %}
+                {% if detail.applicant and detail.status == 'pending' %}
+                <div class="modal fade" id="approveModal{{ detail.pk }}" tabindex="-1" aria-labelledby="approveModalLabel{{ detail.pk }}" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="approveModalLabel{{ detail.pk }}">LT申請を承認</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                                <p>以下のLT申請を承認しますか？</p>
+                                <ul class="list-unstyled">
+                                    <li><strong>テーマ:</strong> {{ detail.theme }}</li>
+                                    <li><strong>発表者:</strong> {{ detail.speaker }}</li>
+                                    <li><strong>申請者:</strong> {{ detail.applicant.user_name }}</li>
+                                    <li><strong>イベント日:</strong> {{ event.date }}</li>
+                                </ul>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
+                                <form method="post" action="{% url 'event:lt_application_approve' detail.pk %}" class="d-inline">
+                                    {% csrf_token %}
+                                    <button type="submit" class="btn btn-success">承認する</button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="modal fade" id="rejectModal{{ detail.pk }}" tabindex="-1" aria-labelledby="rejectModalLabel{{ detail.pk }}" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <form method="post" action="{% url 'event:lt_application_reject' detail.pk %}">
+                                {% csrf_token %}
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="rejectModalLabel{{ detail.pk }}">LT申請を却下</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                </div>
+                                <div class="modal-body">
+                                    <p>以下のLT申請を却下しますか？</p>
+                                    <ul class="list-unstyled mb-3">
+                                        <li><strong>テーマ:</strong> {{ detail.theme }}</li>
+                                        <li><strong>発表者:</strong> {{ detail.speaker }}</li>
+                                        <li><strong>申請者:</strong> {{ detail.applicant.user_name }}</li>
+                                    </ul>
+                                    <div class="mb-3">
+                                        <label for="rejection_reason_{{ detail.pk }}" class="form-label">却下理由 <span class="text-danger">*</span></label>
+                                        <textarea class="form-control" id="rejection_reason_{{ detail.pk }}" name="rejection_reason" rows="3" required placeholder="却下理由を入力してください"></textarea>
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
+                                    <button type="submit" class="btn btn-danger">却下する</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
 
     </div>
 


### PR DESCRIPTION
## なぜこの変更が必要か

LT申請の承認・却下モーダルを開くと、モーダルが複数回点滅（フリッカー）して操作できない問題が発生していた。
原因: モーダルのDOMがBootstrap cardの内部に配置されており、cardに設定された `transition: all 0.3s ease` がモーダルの `fade` アニメーションと干渉していた。

## 変更内容

- モーダルDOM（承認モーダル・却下モーダル）をcard要素内のforループから、ページ下部（pagination後）に移動
- モーダルのトリガーボタンはcard内に残し、`data-bs-target` によるID参照で接続

## 意思決定

### 採用アプローチ
- モーダルDOMの配置移動を採用。理由: cardのCSS transitionを変更せずに済み、影響範囲が最小限

### 却下した代替案
- `transition: all` をプロパティ限定に変更 → 却下: 他のページのcard表示に影響する可能性があり、別PRで対応すべき（バックログに追記済み）

### 技術的負債
- `base.html` の `.card { transition: all 0.3s ease; }` をプロパティ限定に変更する（根本原因の修正、バックログ追記済み）

## テスト

- [x] `test_pending_lt_shows_approve_reject_buttons`: 承認待ちLTに承認・却下ボタンが表示される
- [x] `test_pending_lt_modals_rendered_outside_card`: モーダルDOMがcard外（pagination後）に配置される
- [x] `test_approved_lt_no_modals`: 承認済みLTにはモーダルが出力されない
- [x] 既存テスト13件全てパス
- [x] ブラウザで承認・却下モーダルの正常動作を確認

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only DOM reordering plus tests; no backend logic or data handling changes, with limited risk aside from potential HTML/ID rendering regressions.
> 
> **Overview**
> Fixes flickering when opening LT approval/rejection modals on `event/my_list` by moving the modal DOM out of the event card loop and rendering all pending-application modals once after pagination, while keeping the in-card trigger buttons targeting the same IDs.
> 
> Adds view tests to ensure pending LT items render approve/reject buttons and that modal markup is emitted *outside* the card (and not emitted for approved items).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40bb785158dc2741a4ac9d4b143ddcdb4349cd81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->