### PR TITLE
fix: 定期イベント生成がCommunityの時刻変更を反映しないバグを修正

### DIFF
--- a/app/event/management/commands/generate_recurring_events.py
+++ b/app/event/management/commands/generate_recurring_events.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
             dates = service.generate_dates(
                 rule=rule,
                 base_date=base_date,
-                base_time=master.start_time,
+                base_time=community.start_time,
                 months=months,
                 community=community
             )
@@ -137,7 +137,7 @@ class Command(BaseCommand):
                     exists = Event.objects.filter(
                         community=community,
                         date=date,
-                        start_time=master.start_time
+                        start_time=community.start_time
                     ).exists()
                     if not exists:
                         new_dates.append(date)
@@ -156,8 +156,8 @@ class Command(BaseCommand):
                         Event.objects.create(
                             community=community,
                             date=date,
-                            start_time=master.start_time,
-                            duration=master.duration,
+                            start_time=community.start_time,
+                            duration=community.duration,
                             weekday=date.strftime('%a').upper()[:3],
                             recurring_master=master
                         )


### PR DESCRIPTION
## なぜこの変更が必要か

集会「個人開発集会」の開始時刻を21:00→22:00に変更したが、`generate_recurring_events`コマンドで生成されるイベントが21:00のまま。原因: コマンドがマスターイベント（2023年作成、21:00固定）の`start_time`を参照していたため。

## 変更内容

- `generate_recurring_events.py`の4箇所で`master.start_time`/`master.duration`を`community.start_time`/`community.duration`に変更
- 既存テスト(`test_biweekly_rule`, `test_monthly_by_week_rule`)の偽陽性を修正
- 新規テスト2件追加（Community時刻変更反映、duration変更反映）

## 意思決定

### 採用アプローチ
- Communityの設定を正規ソース（Single Source of Truth）として参照。理由: Communityが「現在の正」であり、マスターイベントは過去のスナップショット

### 却下した代替案
- マスターイベントの時刻を自動更新 → 歴史改変になる
- 重複チェックで時刻を無視 → 同日異時刻の正規イベントが区別できなくなる

## テスト

- [x] 既存テスト7件パス
- [x] 新規テスト: Community.start_time変更が生成イベントに反映される
- [x] 新規テスト: Community.duration変更が生成イベントに反映される
- [ ] 本番DBコピーで`--reset-future`後の再生成確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> イベント生成の重複判定と作成時刻/期間のソースが変わるため、既存データと同日別時刻のイベントがある場合に生成結果が変わるリスクがありますが、影響範囲はバッチコマンドとそのテストに限定されます。
> 
> **Overview**
> 定期イベント生成コマンド `generate_recurring_events` が、マスターイベントではなく **`Community` の `start_time`/`duration` を参照して** 日付計算・重複判定・イベント作成を行うように修正しました（Communityの設定変更が将来分の生成に反映される）。
> 
> テストを更新し、隔週・月次（第N曜日）で *マスターとCommunityの時刻/所要時間が異なるケース* を明示的に検証するように変更。加えて、Communityの `start_time`/`duration` を変更した際に生成イベントへ反映されることを確認するテストを2件追加しました。
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c8208df1e44bf1d9da803e2486370408739e817. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->