### PR TITLE
fix: transition: all をプロパティ限定に変更してモーダル干渉を防止

### DIFF
--- a/app/ta_hub/templates/404.html
+++ b/app/ta_hub/templates/404.html
@@ -63,7 +63,7 @@
         padding: 1rem;
         background: #f8f9fa;
         border-radius: 8px;
-        transition: all 0.3s ease;
+        transition: background 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
         text-decoration: none;
         color: #333;
     }

--- a/app/ta_hub/templates/500.html
+++ b/app/ta_hub/templates/500.html
@@ -82,7 +82,7 @@
             padding: 0.75rem 2rem;
             font-size: 1.1rem;
             border-radius: 50px;
-            transition: all 0.3s ease;
+            transition: background 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
         }
         .btn-primary:hover {
             background: #2B80DC;
@@ -95,7 +95,7 @@
             padding: 0.75rem 2rem;
             font-size: 1.1rem;
             border-radius: 50px;
-            transition: all 0.3s ease;
+            transition: background 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
         }
         .btn-outline-secondary:hover {
             background: #f8f9fa;

--- a/app/ta_hub/templates/503.html
+++ b/app/ta_hub/templates/503.html
@@ -100,7 +100,7 @@
             padding: 0.75rem 2rem;
             font-size: 1.1rem;
             border-radius: 50px;
-            transition: all 0.3s ease;
+            transition: background 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
             text-decoration: none;
             display: inline-block;
             margin-top: 1rem;

--- a/app/ta_hub/templates/ta_hub/base.html
+++ b/app/ta_hub/templates/ta_hub/base.html
@@ -208,7 +208,7 @@
         }
 
         footer a {
-            transition: all 0.3s ease;
+            transition: color 0.3s ease, transform 0.3s ease;
         }
 
         footer a:hover {
@@ -217,7 +217,7 @@
         }
 
         footer .bi {
-            transition: all 0.3s ease;
+            transition: transform 0.3s ease;
         }
 
         footer a:hover .bi {
@@ -225,7 +225,7 @@
         }
 
         footer ul li {
-            transition: all 0.2s ease;
+            transition: transform 0.2s ease;
         }
 
         footer ul li:hover {
@@ -261,7 +261,7 @@
         
         /* カードの統一ホバー効果 */
         .card {
-            transition: all 0.3s ease;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
         }
         
         .card:hover {
@@ -286,7 +286,7 @@
         
         /* リストグループアイテムのホバー効果 */
         .list-group-item {
-            transition: all 0.2s ease;
+            transition: background-color 0.2s ease, transform 0.2s ease;
         }
         
         .list-group-item:hover {
@@ -305,7 +305,7 @@
         
         /* バッジのホバー効果 */
         .badge {
-            transition: all 0.2s ease;
+            transition: transform 0.2s ease, filter 0.2s ease;
             cursor: pointer;
         }
         
@@ -316,7 +316,7 @@
         
         /* ページネーションのホバー効果 */
         .page-link {
-            transition: all 0.2s ease;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
         }
         
         .page-link:hover {


### PR DESCRIPTION
## なぜこの変更が必要か

`transition: all 0.3s ease` が `.card` 等のグローバルセレクタに設定されていたため、hover効果に無関係なプロパティ（opacity, visibility等）にもトランジションが適用され、モーダル表示時のフリッカーの根本原因になっていた。

## 変更内容

- `base.html`: 7箇所の `transition: all` を各hoverで実際に使用するプロパティのみに限定
- `404.html`, `500.html`, `503.html`: エラーページの `transition: all` も同様に修正

## 意思決定

### 採用アプローチ
- 各セレクタの `:hover` で変更されるプロパティのみを `transition` に指定。理由: 最小限の変更で意図しない副作用を排除

### 却下した代替案
- `transition: none` にしてJSでアニメーション → 過剰な複雑化

## テスト

- [x] カードhover効果（translateY + box-shadow）正常動作
- [x] フッターリンクhover効果 正常動作
- [x] コンソールエラーなし

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes that narrow `transition` scopes; low risk aside from potential minor visual regressions in hover/animation behavior.
> 
> **Overview**
> Replaces broad `transition: all` declarations with property-specific transitions across global hover styles in `ta_hub/base.html` (e.g., footer links/icons, `.card`, `.list-group-item`, `.badge`, `.page-link`) to prevent unintended animations on unrelated properties.
> 
> Applies the same tightening on the `404.html`, `500.html`, and `503.html` error pages for link/button hover effects, reducing side effects like modal flicker while preserving intended hover animations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 738964500a5eac2dd1746d992d387e4acbbc5689. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->