### PR TITLE
fix: EventDetailView権限拡張とLT申請編集のステータスチェック追加

### DIFF
--- a/app/user_account/templates/account/lt_application_list.html
+++ b/app/user_account/templates/account/lt_application_list.html
@@ -44,9 +44,11 @@
                                                     {% endif %}
                                                 </td>
                                                 <td>
-                                                    <a href="{% url 'account:lt_application_edit' app.pk %}" class="btn btn-sm btn-outline-primary">
-                                                        <i class="fa-solid fa-pen-to-square"></i> 編集
-                                                    </a>
+                                                    {% if app.status != 'rejected' %}
+                                                        <a href="{% url 'account:lt_application_edit' app.pk %}" class="btn btn-sm btn-outline-primary">
+                                                            <i class="fa-solid fa-pen-to-square"></i> 編集
+                                                        </a>
+                                                    {% endif %}
                                                     {% if app.status == 'approved' %}
                                                         <a href="{% url 'event:detail' app.pk %}" class="btn btn-sm btn-outline-secondary">
                                                             <i class="fa-solid fa-eye"></i> 確認

--- a/app/user_account/tests/test_lt_application_views.py
+++ b/app/user_account/tests/test_lt_application_views.py
@@ -203,3 +203,27 @@ class LTApplicationEditViewTests(LTApplicationViewTestBase):
         })
         self.my_application.refresh_from_db()
         self.assertEqual(self.my_application.status, 'approved')
+
+    def test_cannot_edit_rejected_application(self):
+        """却下済みのLT申請は編集画面にアクセスすると404"""
+        self.client.login(username='applicant', password='testpass123')
+        rejected_edit_url = reverse('account:lt_application_edit', kwargs={'pk': self.my_rejected.pk})
+        response = self.client.get(rejected_edit_url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_can_edit_pending_application(self):
+        """承認待ちのLT申請は編集画面にアクセスできる"""
+        my_pending = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Pending Theme',
+            speaker='applicant',
+            start_time=time(23, 0),
+            duration=15,
+            status='pending',
+            applicant=self.user,
+        )
+        self.client.login(username='applicant', password='testpass123')
+        pending_edit_url = reverse('account:lt_application_edit', kwargs={'pk': my_pending.pk})
+        response = self.client.get(pending_edit_url)
+        self.assertEqual(response.status_code, 200)

--- a/app/user_account/views.py
+++ b/app/user_account/views.py
@@ -189,7 +189,7 @@ class LTApplicationEditView(LoginRequiredMixin, UpdateView):
         return EventDetail.objects.filter(
             applicant=self.request.user,
             detail_type='LT',
-        ).select_related('event', 'event__community')
+        ).exclude(status='rejected').select_related('event', 'event__community')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
## なぜこの変更が必要か

PR #74 で却下済み・未承認LT申請の公開ビュー漏洩を修正したが、2つの問題が残っていた:

1. **EventDetailView が厳しすぎ**: superuser以外は approved のみ閲覧可能になったため、コミュニティ管理者が管理画面（EventMyList）の「確認」ボタンから pending/rejected の詳細を開くと404になっていた
2. **LT申請編集画面が緩すぎ**: `LTApplicationEditView` にステータスチェックがなく、却下された申請でも編集画面に入れてしまっていた

## 変更内容

- **EventDetailView**: `get_queryset` のstatusフィルタを `get_object` オーバーライドに変更。approved → superuser → コミュニティ管理者 → 申請者本人 → 404 の順で権限判定
- **LTApplicationEditView**: `get_queryset` に `.exclude(status='rejected')` を追加し、却下済み申請の編集を防止
- **LT申請一覧テンプレート**: rejected 時に編集ボタンを非表示にする条件分岐を追加
- **テスト**: EventDetailViewに6件、LTApplicationEditViewに2件のテストを追加

## 意思決定

### 採用アプローチ
- `get_object` で権限判定。理由: 既存 `can_edit()` を再利用でき、コードが明快

### 却下した代替案
- `get_queryset` で Q オブジェクト → 却下: サブクエリが複雑
- カスタム Mixin → 却下: YAGNI

### トレードオフ
- 権限なし時は 403 でなく 404 を返す → リソース存在の隠蔽（セキュリティ上好ましい）

## テスト

- [x] `event.tests.test_rejected_lt_visibility.EventDetailViewAccessTest` 11件全通過
- [x] `user_account.tests.test_lt_application_views` 13件全通過
- [x] `event.tests.test_rejected_lt_visibility` 全23件通過（既存テストの回帰なし）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)