### PR TITLE
chore: deploy Cloud Run image by SHORT_SHA

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
       - '--region'
       - 'asia-northeast1'
       - '--image'
-      - '${_DOCKER_PATH}${_SERVICE_NAME}:latest'
+      - '${_DOCKER_PATH}${_SERVICE_NAME}:$SHORT_SHA'
       - '--platform'
       - 'managed'
       - '--revision-suffix'


### PR DESCRIPTION
## 目的\nCloud Build の Cloud Run デプロイで `:latest` を使わず、ビルドした `:` のイメージを確実にデプロイする。\n\n## 変更\n- `cloudbuild.yaml` の `gcloud run deploy --image` を `:latest` → `:` に変更\n\n## 動作確認\n- ローカル: 差分確認（Cloud Build 本番実行はマージ後に自動実行）