### PR TITLE
fix: 集会停止時の関連データ削除とadmin-cleanup 405を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ local_settings.py
 .env.production.local
 db.sqlite3
 test_db.sqlite3
+app/test_db.sqlite3
 /.local.env
 /app/ta_hub/static/ta_hub/js/*.js
 /output.txt


### PR DESCRIPTION
## 背景
集会をDB直接操作で停止したケースで、イベント一覧/Googleカレンダーに残骸が残る問題が発生していました。
また、管理者ワンクリック修復導線でログイン後 `next` リダイレクトが `GET /community/{id}/admin-cleanup/` となり、HTTP 405が発生していました。

## 変更内容
- 集会停止/管理者修復で共通利用するクリーンアップ処理を追加
  - DBの未来イベント削除
  - 定期ルール削除
  - Googleカレンダー予定削除（ID優先 + 同名一意時の補完削除、404は許容）
- `CloseCommunityView` を強化し、停止時に上記クリーンアップを実行
- 管理者専用のワンクリック修復ビューを追加
- `admin-cleanup` と `close` のPOST専用URLに対し、GET時は405ではなく詳細画面へリダイレクト
- イベント表示系API/トップ/一覧のフィルタを強化（`community__status='approved'` + `end_at__isnull=True`）
- Googleカレンダー一覧取得のページング対応
- 運用用コマンド `purge_community_events` 追加

## テスト
- `python manage.py test community.tests.test_switch_community community.tests.test_views event.tests.test_community_cleanup event.tests.test_detail_history_rate_limit event.tests.test_event_visibility_and_purge_command event.tests.test_google_calendar_list_pagination`
  - 47 tests passed
