### PR TITLE
fix: 集会停止時の関連データ削除とadmin-cleanup 405を修正

### DIFF
--- a/app/api_v1/views.py
+++ b/app/api_v1/views.py
@@ -91,7 +91,8 @@ class EventFilter(filters.FilterSet):
 class EventViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Event.objects.filter(
         date__gte=timezone.now().date(),
-        community__status='approved'
+        community__status='approved',
+        community__end_at__isnull=True,
     ).select_related('community').order_by('date', 'start_time')
     serializer_class = EventSerializer
     filterset_class = EventFilter
@@ -127,6 +128,7 @@ class EventDetailFilter(filters.FilterSet):
 class EventDetailViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = EventDetail.objects.filter(
         event__community__status='approved',
+        event__community__end_at__isnull=True,
         status='approved'
     ).select_related('event', 'event__community').order_by('event__date', 'start_time')
     serializer_class = EventDetailSerializer

--- a/app/community/templates/community/detail.html
+++ b/app/community/templates/community/detail.html
@@ -357,6 +357,53 @@
                 </p>
             </div>
         </div>
+
+        <div class="card my-5 shadow border-danger">
+            <div class="card-body">
+                <h2 class="fs-3 fw-bold my-4 text-center text-danger">
+                    管理者メンテナンス（ワンクリック）
+                </h2>
+                <p class="text-muted mb-2">
+                    集会を停止状態にし、翌日以降のイベント・定期ルール・Googleカレンダー予定を一括削除します。
+                </p>
+                <p class="text-danger small mb-3">
+                    この操作は取り消せません。
+                </p>
+                <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#adminCleanupModal">
+                    <i class="bi bi-exclamation-octagon me-1"></i>管理者ワンクリック修復を実行
+                </button>
+            </div>
+        </div>
+    {% endif %}
+
+    {% if request.user.is_superuser %}
+    <div class="modal fade" id="adminCleanupModal" tabindex="-1" aria-labelledby="adminCleanupModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="adminCleanupModalLabel">管理者ワンクリック修復の確認</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>以下を実行します。</p>
+                    <ul>
+                        <li>集会を停止状態にする（未停止の場合）</li>
+                        <li>翌日以降のイベントを削除</li>
+                        <li>定期ルールを削除</li>
+                        <li>Googleカレンダー上の該当予定を削除</li>
+                    </ul>
+                    <p class="text-danger mb-0">実行後は元に戻せません。</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
+                    <form action="{% url 'community:admin_cleanup' community.pk %}" method="post" class="d-inline">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-danger">実行する</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
     {% endif %}
 
 {% endblock %}

--- a/app/community/urls.py
+++ b/app/community/urls.py
@@ -26,6 +26,7 @@ from .views import (
     UpdateWebhookView,
     TestWebhookView,
     UpdateLTSettingsView,
+    AdminCommunityCleanupView,
 )
 
 app_name = 'community'
@@ -43,6 +44,7 @@ urlpatterns = [
     path('reject/<int:pk>/', RejectView.as_view(), name='reject'),
     path('close/<int:pk>/', CloseCommunityView.as_view(), name='close'),
     path('reopen/<int:pk>/', ReopenCommunityView.as_view(), name='reopen'),
+    path('<int:pk>/admin-cleanup/', AdminCommunityCleanupView.as_view(), name='admin_cleanup'),
     path('<int:pk>/members/', CommunityMemberManageView.as_view(), name='member_manage'),
     path('<int:pk>/members/<int:member_id>/remove/', RemoveStaffView.as_view(), name='remove_staff'),
     path('<int:pk>/invite/create/', CreateInvitationView.as_view(), name='create_invitation'),

--- a/app/event/community_cleanup.py
+++ b/app/event/community_cleanup.py
@@ -1,0 +1,152 @@
+from datetime import date, datetime, timedelta
+
+from django.conf import settings
+from googleapiclient.errors import HttpError
+
+from community.models import Community
+from event.google_calendar import GoogleCalendarService
+from event.models import Event, RecurrenceRule
+
+
+def cleanup_community_future_data(
+    community,
+    from_date: date,
+    *,
+    delete_rules: bool = True,
+    delete_google_events: bool = True,
+    google_window_days: int = 180,
+    google_years: int = 3,
+):
+    """指定コミュニティの指定日以降データをクリーンアップする。"""
+    stats = {
+        "db_events": 0,
+        "rules": 0,
+        "google_events": 0,
+    }
+
+    target_events = list(
+        Event.objects.filter(
+            community=community,
+            date__gte=from_date,
+        )
+    )
+    event_ids = [event.id for event in target_events]
+    stats["db_events"] = len(event_ids)
+    if event_ids:
+        Event.objects.filter(id__in=event_ids).delete()
+
+    if delete_rules:
+        rules = list(RecurrenceRule.objects.filter(community=community))
+        for rule in rules:
+            rule.delete_future_events(from_date)
+            rule.delete(delete_future_events=False)
+        stats["rules"] = len(rules)
+
+    if delete_google_events:
+        service = GoogleCalendarService(
+            calendar_id=settings.GOOGLE_CALENDAR_ID,
+            credentials_path=settings.GOOGLE_CALENDAR_CREDENTIALS,
+        )
+        # まずDBに残っていたGoogle Calendar IDを優先して削除する
+        existing_google_ids = {
+            event.google_calendar_event_id for event in target_events if event.google_calendar_event_id
+        }
+        deleted_by_ids = _delete_google_events_by_ids(
+            service=service,
+            google_event_ids=existing_google_ids,
+        )
+        deleted_by_summary = 0
+
+        # 直接DB操作などでIDが消えている残骸は、同名が一意な場合のみ補完削除する
+        is_name_unique = Community.objects.filter(name=community.name).count() == 1
+        if is_name_unique:
+            deleted_by_summary = _delete_google_events_by_summary(
+                service=service,
+                community_name=community.name,
+                from_date=from_date,
+                window_days=google_window_days,
+                years=google_years,
+                already_deleted_ids=existing_google_ids,
+            )
+
+        stats["google_events"] = deleted_by_ids + deleted_by_summary
+
+    return stats
+
+
+def _delete_google_events_by_ids(
+    service: GoogleCalendarService,
+    google_event_ids: set[str],
+) -> int:
+    deleted = 0
+    for event_id in google_event_ids:
+        try:
+            service.delete_event(event_id)
+            deleted += 1
+        except HttpError as e:
+            # 既に削除済み(404)は再実行時の正常ケースとして扱う
+            if getattr(e, "status_code", None) == 404 or (hasattr(e, "resp") and getattr(e.resp, "status", None) == 404):
+                continue
+            raise
+    return deleted
+
+
+def _delete_google_events_by_summary(
+    service: GoogleCalendarService,
+    community_name: str,
+    from_date: date,
+    *,
+    window_days: int,
+    years: int,
+    already_deleted_ids: set[str],
+) -> int:
+    start = datetime.combine(from_date, datetime.min.time())
+    hard_end_date = from_date + timedelta(days=365 * years)
+    end = datetime.combine(hard_end_date, datetime.max.time())
+
+    matched_ids = set()
+    current = start
+    while current < end:
+        window_end = min(current + timedelta(days=window_days), end)
+        events = service.list_events(
+            time_min=current,
+            time_max=window_end,
+            max_results=2500,
+        )
+        for event in events:
+            summary = (event.get("summary") or "").strip()
+            if summary != community_name:
+                continue
+            event_date = _extract_event_date(event)
+            if event_date and event_date >= from_date:
+                matched_ids.add(event["id"])
+        current = window_end
+
+    deleted = 0
+    for event_id in matched_ids:
+        if event_id in already_deleted_ids:
+            continue
+        try:
+            service.delete_event(event_id)
+            deleted += 1
+        except HttpError as e:
+            if getattr(e, "status_code", None) == 404 or (hasattr(e, "resp") and getattr(e.resp, "status", None) == 404):
+                continue
+            raise
+    return deleted
+
+
+def _extract_event_date(event) -> date | None:
+    start = event.get("start", {})
+    if "dateTime" in start:
+        try:
+            dt = datetime.fromisoformat(start["dateTime"].replace("Z", "+00:00"))
+            return dt.date()
+        except ValueError:
+            return None
+    if "date" in start:
+        try:
+            return date.fromisoformat(start["date"])
+        except ValueError:
+            return None
+    return None

--- a/app/event/google_calendar.py
+++ b/app/event/google_calendar.py
@@ -210,15 +210,25 @@ class GoogleCalendarService:
             time_min_str = time_min.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ') if time_min else None
             time_max_str = time_max.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ') if time_max else None
 
-            events_result = self.service.events().list(
-                calendarId=self.calendar_id,
-                maxResults=max_results,
-                timeMin=time_min_str,
-                timeMax=time_max_str,
-                singleEvents=True,
-                orderBy='startTime'
-            ).execute()
-            return events_result.get('items', [])
+            all_items = []
+            page_token = None
+
+            while True:
+                events_result = self.service.events().list(
+                    calendarId=self.calendar_id,
+                    maxResults=max_results,
+                    timeMin=time_min_str,
+                    timeMax=time_max_str,
+                    singleEvents=True,
+                    orderBy='startTime',
+                    pageToken=page_token,
+                ).execute()
+                all_items.extend(events_result.get('items', []))
+                page_token = events_result.get('nextPageToken')
+                if not page_token:
+                    break
+
+            return all_items
         except HttpError as error:
             print(f'An error occurred: {error}')
             raise

--- a/app/event/management/commands/purge_community_events.py
+++ b/app/event/management/commands/purge_community_events.py
@@ -1,0 +1,219 @@
+from datetime import date, datetime, timedelta
+from typing import Iterable
+
+from django.core.cache import cache
+from django.core.management.base import BaseCommand, CommandError
+
+from event.google_calendar import GoogleCalendarService
+from event.models import Event, RecurrenceRule
+from website.settings import GOOGLE_CALENDAR_CREDENTIALS, GOOGLE_CALENDAR_ID
+
+
+class Command(BaseCommand):
+    help = (
+        "指定コミュニティの指定日以降イベントをDBとGoogleカレンダーから削除します。"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--community",
+            action="append",
+            required=True,
+            help="削除対象コミュニティ名（複数指定可）",
+        )
+        parser.add_argument(
+            "--from-date",
+            required=True,
+            help="削除開始日（YYYY-MM-DD）",
+        )
+        parser.add_argument(
+            "--delete-rules",
+            action="store_true",
+            help="対象コミュニティの定期ルールも停止（未来イベント削除後にルール削除）",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="実際には削除せず、対象件数のみ表示",
+        )
+        parser.add_argument(
+            "--google-window-days",
+            type=int,
+            default=180,
+            help="Googleカレンダー走査の分割日数（デフォルト: 180日）",
+        )
+        parser.add_argument(
+            "--google-years",
+            type=int,
+            default=5,
+            help="Googleカレンダー走査年数（from-date起点、デフォルト: 5年）",
+        )
+
+    def handle(self, *args, **options):
+        community_names = sorted(set(options["community"]))
+        from_date = self._parse_date(options["from_date"])
+        dry_run = options["dry_run"]
+        delete_rules = options["delete_rules"]
+        window_days = options["google_window_days"]
+        google_years = options["google_years"]
+
+        if window_days <= 0:
+            raise CommandError("--google-window-days は1以上を指定してください。")
+        if google_years <= 0:
+            raise CommandError("--google-years は1以上を指定してください。")
+
+        self.stdout.write(self.style.WARNING("=" * 80))
+        self.stdout.write(self.style.WARNING("イベント削除タスク"))
+        self.stdout.write(self.style.WARNING(f"コミュニティ: {', '.join(community_names)}"))
+        self.stdout.write(self.style.WARNING(f"削除開始日: {from_date}"))
+        self.stdout.write(self.style.WARNING(f"定期ルール停止: {delete_rules}"))
+        self.stdout.write(self.style.WARNING(f"DRY-RUN: {dry_run}"))
+        self.stdout.write(self.style.WARNING("=" * 80))
+
+        db_deleted = self._purge_database_events(
+            community_names=community_names,
+            from_date=from_date,
+            dry_run=dry_run,
+        )
+
+        rules_deleted = self._purge_recurrence_rules(
+            community_names=community_names,
+            from_date=from_date,
+            delete_rules=delete_rules,
+            dry_run=dry_run,
+        )
+
+        google_deleted = self._purge_google_calendar_events(
+            community_names=community_names,
+            from_date=from_date,
+            dry_run=dry_run,
+            window_days=window_days,
+            google_years=google_years,
+        )
+
+        if not dry_run:
+            cache.clear()
+            self.stdout.write(self.style.SUCCESS("キャッシュをクリアしました。"))
+
+        self.stdout.write(self.style.SUCCESS("=" * 80))
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"完了: DBイベント={db_deleted}件, 定期ルール={rules_deleted}件, Googleイベント={google_deleted}件"
+            )
+        )
+        self.stdout.write(self.style.SUCCESS("=" * 80))
+
+    def _parse_date(self, value: str) -> date:
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise CommandError(f"日付形式が不正です: {value} (期待: YYYY-MM-DD)") from exc
+
+    def _purge_database_events(self, community_names: Iterable[str], from_date: date, dry_run: bool) -> int:
+        qs = Event.objects.filter(
+            community__name__in=community_names,
+            date__gte=from_date,
+        ).select_related("community")
+        event_ids = list(qs.values_list("id", flat=True))
+
+        self.stdout.write(f"DB対象イベント件数: {len(event_ids)}件")
+        if not event_ids or dry_run:
+            return len(event_ids)
+
+        deleted_count, _ = Event.objects.filter(id__in=event_ids).delete()
+        self.stdout.write(self.style.SUCCESS(f"DB削除実行: {deleted_count}件（関連オブジェクト含む）"))
+        return len(event_ids)
+
+    def _purge_recurrence_rules(
+        self,
+        community_names: Iterable[str],
+        from_date: date,
+        delete_rules: bool,
+        dry_run: bool,
+    ) -> int:
+        if not delete_rules:
+            self.stdout.write("定期ルール停止: スキップ")
+            return 0
+
+        rules = list(
+            RecurrenceRule.objects.filter(community__name__in=community_names).select_related("community")
+        )
+        self.stdout.write(f"対象定期ルール件数: {len(rules)}件")
+
+        if dry_run:
+            return len(rules)
+
+        deleted_rules = 0
+        for rule in rules:
+            deleted_events = rule.delete_future_events(from_date)
+            rule.delete(delete_future_events=False)
+            deleted_rules += 1
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"定期ルール削除: community={rule.community.name if rule.community else '未設定'} "
+                    f"future_events={deleted_events}"
+                )
+            )
+        return deleted_rules
+
+    def _purge_google_calendar_events(
+        self,
+        community_names: Iterable[str],
+        from_date: date,
+        dry_run: bool,
+        window_days: int,
+        google_years: int,
+    ) -> int:
+        community_set = set(community_names)
+        service = GoogleCalendarService(
+            calendar_id=GOOGLE_CALENDAR_ID,
+            credentials_path=GOOGLE_CALENDAR_CREDENTIALS,
+        )
+
+        start = datetime.combine(from_date, datetime.min.time())
+        hard_end_date = from_date + timedelta(days=365 * google_years)
+        end = datetime.combine(hard_end_date, datetime.max.time())
+
+        matched_ids = set()
+        current = start
+        while current < end:
+            window_end = min(current + timedelta(days=window_days), end)
+            events = service.list_events(
+                time_min=current,
+                time_max=window_end,
+                max_results=2500,
+            )
+            for event in events:
+                summary = (event.get("summary") or "").strip()
+                if summary not in community_set:
+                    continue
+                event_date = self._extract_event_date(event)
+                if event_date and event_date >= from_date:
+                    matched_ids.add(event["id"])
+            current = window_end
+
+        self.stdout.write(f"Google削除対象イベント件数: {len(matched_ids)}件")
+        if dry_run:
+            return len(matched_ids)
+
+        deleted = 0
+        for event_id in matched_ids:
+            service.delete_event(event_id)
+            deleted += 1
+        self.stdout.write(self.style.SUCCESS(f"Google削除実行: {deleted}件"))
+        return deleted
+
+    def _extract_event_date(self, event) -> date | None:
+        start = event.get("start", {})
+        if "dateTime" in start:
+            try:
+                dt = datetime.fromisoformat(start["dateTime"].replace("Z", "+00:00"))
+                return dt.date()
+            except ValueError:
+                return None
+        if "date" in start:
+            try:
+                return date.fromisoformat(start["date"])
+            except ValueError:
+                return None
+        return None

--- a/app/event/templates/event/detail_list_table.html
+++ b/app/event/templates/event/detail_list_table.html
@@ -17,7 +17,7 @@
         {% for detail in event_details %}
             <tr>
                 <td>
-                    <a href="{{ request.path }}?{{ request.GET.urlencode }}&community_name={{ detail.event.community.name }}">
+                    <a href="{{ request.path }}?{% if community_link_base_query %}{{ community_link_base_query }}&{% endif %}community_name={{ detail.event.community.name|urlencode }}">
                         {{ detail.event.community.name }}
                     </a>
                 </td>
@@ -41,7 +41,7 @@
                     </td>
                 {% endif %}
                 <td>
-                    <a href="{{ request.path }}?{{ request.GET.urlencode }}&speaker={{ detail.speaker }}">
+                    <a href="{{ request.path }}?{% if speaker_link_base_query %}{{ speaker_link_base_query }}&{% endif %}speaker={{ detail.speaker|urlencode }}">
                         {{ detail.speaker }}
                     </a>
                 </td>

--- a/app/event/tests/test_community_cleanup.py
+++ b/app/event/tests/test_community_cleanup.py
@@ -1,0 +1,130 @@
+from datetime import date, time
+from unittest.mock import patch, MagicMock
+
+from django.test import TestCase
+from googleapiclient.errors import HttpError
+
+from community.models import Community
+from event.community_cleanup import cleanup_community_future_data
+from event.models import Event, RecurrenceRule
+
+
+class CommunityCleanupServiceTest(TestCase):
+    def setUp(self):
+        self.community = Community.objects.create(
+            name='Cleanup Test Community',
+            status='approved',
+            frequency='毎週',
+            organizers='Tester',
+            weekdays=['Mon'],
+            start_time=time(21, 0),
+        )
+        self.from_date = date(2026, 2, 10)
+
+        self.before_event = Event.objects.create(
+            community=self.community,
+            date=date(2026, 2, 9),
+            start_time=time(21, 0),
+            duration=60,
+            weekday='MON',
+        )
+        self.after_event = Event.objects.create(
+            community=self.community,
+            date=date(2026, 2, 10),
+            start_time=time(21, 0),
+            duration=60,
+            weekday='TUE',
+        )
+
+        self.rule = RecurrenceRule.objects.create(
+            community=self.community,
+            frequency='WEEKLY',
+            interval=1,
+            start_date=date(2026, 1, 1),
+        )
+
+    @patch('event.community_cleanup.GoogleCalendarService')
+    def test_cleanup_deletes_future_data_and_google_events(self, mock_service_cls):
+        mock_service = mock_service_cls.return_value
+        mock_service.list_events.return_value = [
+            {
+                'id': 'gcal-target',
+                'summary': self.community.name,
+                'start': {'dateTime': '2026-02-10T21:00:00+09:00'},
+            },
+            {
+                'id': 'gcal-before',
+                'summary': self.community.name,
+                'start': {'dateTime': '2026-02-09T21:00:00+09:00'},
+            },
+        ]
+
+        stats = cleanup_community_future_data(
+            community=self.community,
+            from_date=self.from_date,
+            delete_rules=True,
+            delete_google_events=True,
+            google_window_days=365,
+            google_years=1,
+        )
+
+        self.assertEqual(stats['db_events'], 1)
+        self.assertEqual(stats['rules'], 1)
+        self.assertEqual(stats['google_events'], 1)
+        self.assertTrue(Event.objects.filter(id=self.before_event.id).exists())
+        self.assertFalse(Event.objects.filter(id=self.after_event.id).exists())
+        self.assertFalse(RecurrenceRule.objects.filter(id=self.rule.id).exists())
+        mock_service.delete_event.assert_called_once_with('gcal-target')
+
+    @patch('event.community_cleanup.GoogleCalendarService')
+    def test_cleanup_skips_summary_fallback_when_name_is_duplicated(self, mock_service_cls):
+        Community.objects.create(
+            name=self.community.name,
+            status='approved',
+            frequency='毎週',
+            organizers='Another',
+            weekdays=['Tue'],
+            start_time=time(22, 0),
+        )
+        mock_service = mock_service_cls.return_value
+        mock_service.list_events.return_value = [
+            {
+                'id': 'gcal-target',
+                'summary': self.community.name,
+                'start': {'dateTime': '2026-02-10T21:00:00+09:00'},
+            }
+        ]
+
+        stats = cleanup_community_future_data(
+            community=self.community,
+            from_date=self.from_date,
+            delete_rules=False,
+            delete_google_events=True,
+            google_window_days=365,
+            google_years=1,
+        )
+
+        self.assertEqual(stats['google_events'], 0)
+        mock_service.delete_event.assert_not_called()
+
+    @patch('event.community_cleanup.GoogleCalendarService')
+    def test_cleanup_ignores_404_on_google_delete(self, mock_service_cls):
+        self.after_event.google_calendar_event_id = 'gone-event-id'
+        self.after_event.save(update_fields=['google_calendar_event_id'])
+
+        mock_service = mock_service_cls.return_value
+        mock_service.list_events.return_value = []
+        mock_resp = MagicMock()
+        mock_resp.status = 404
+        mock_service.delete_event.side_effect = HttpError(mock_resp, b'Not Found')
+
+        stats = cleanup_community_future_data(
+            community=self.community,
+            from_date=self.from_date,
+            delete_rules=False,
+            delete_google_events=True,
+            google_window_days=365,
+            google_years=1,
+        )
+
+        self.assertEqual(stats['google_events'], 0)

--- a/app/event/tests/test_detail_history_rate_limit.py
+++ b/app/event/tests/test_detail_history_rate_limit.py
@@ -1,0 +1,124 @@
+from datetime import date, time, timedelta
+
+from django.core.cache import cache
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+
+from community.models import Community
+from event.models import Event, EventDetail
+
+
+@override_settings(ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1'])
+class EventDetailHistoryRateLimitTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.client = Client()
+        self.url = reverse('event:detail_history')
+
+        community = Community.objects.create(
+            name='History Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+        event = Event.objects.create(
+            community=community,
+            date=date.today() - timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+        EventDetail.objects.create(
+            event=event,
+            detail_type='LT',
+            status='approved',
+            speaker='Approved Speaker',
+            theme='Approved Theme',
+            duration=15,
+            start_time=time(22, 0),
+        )
+
+    def test_rate_limit_is_20_requests_per_10_minutes_per_ip(self):
+        for _ in range(20):
+            response = self.client.get(self.url, HTTP_X_FORWARDED_FOR='1.2.3.4')
+            self.assertEqual(response.status_code, 200)
+
+        blocked = self.client.get(self.url, HTTP_X_FORWARDED_FOR='1.2.3.4')
+        self.assertEqual(blocked.status_code, 429)
+        self.assertContains(
+            blocked,
+            'アクセスが集中しています。しばらくしてから再度お試しください。',
+            status_code=429,
+        )
+
+    def test_rate_limit_is_independent_per_ip(self):
+        for _ in range(20):
+            self.client.get(self.url, HTTP_X_FORWARDED_FOR='1.2.3.4')
+
+        blocked = self.client.get(self.url, HTTP_X_FORWARDED_FOR='1.2.3.4')
+        self.assertEqual(blocked.status_code, 429)
+
+        other_ip = self.client.get(self.url, HTTP_X_FORWARDED_FOR='5.6.7.8')
+        self.assertEqual(other_ip.status_code, 200)
+
+
+@override_settings(ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1'])
+class EventDetailHistoryQueryBloatPreventionTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.client = Client()
+        self.url = reverse('event:detail_history')
+
+        community = Community.objects.create(
+            name='History Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Test Organizer',
+            status='approved',
+        )
+        event = Event.objects.create(
+            community=community,
+            date=date.today() - timedelta(days=7),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+        self.detail = EventDetail.objects.create(
+            event=event,
+            detail_type='LT',
+            status='approved',
+            speaker='Approved Speaker',
+            theme='Interesting Theme',
+            duration=15,
+            start_time=time(22, 0),
+        )
+
+    def test_history_links_do_not_accumulate_duplicate_speaker_params(self):
+        response = self.client.get(
+            self.url,
+            {
+                'speaker': ['OldA', 'Approved Speaker'],
+                'theme': 'Interesting Theme',
+                'nocache': 'https://example.com',
+                'page': '3',
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # speakerリンクは既存speakerを引き継がず、新しいspeakerのみ付与
+        self.assertContains(response, '?theme=Interesting+Theme&speaker=Approved%20Speaker')
+        self.assertNotContains(response, 'speaker=OldA&speaker=Approved%20Speaker&speaker=Approved%20Speaker')
+
+        # communityリンクは検索条件を保持しつつ、不要キーは引き継がない
+        self.assertContains(response, 'speaker=Approved+Speaker')
+        self.assertContains(response, 'theme=Interesting+Theme')
+        self.assertContains(response, 'community_name=History%20Community')
+        self.assertNotContains(response, 'nocache=')
+        self.assertNotContains(response, 'page=3&community_name=')

--- a/app/event/tests/test_event_visibility_and_purge_command.py
+++ b/app/event/tests/test_event_visibility_and_purge_command.py
@@ -1,0 +1,285 @@
+from datetime import date, time, timedelta
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management import call_command
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from community.models import Community
+from event.models import Event, EventDetail, RecurrenceRule
+
+
+def _create_test_image():
+    """テスト用の最小PNGバイナリを返す。"""
+    import struct
+    import zlib
+
+    def _chunk(chunk_type, data):
+        c = chunk_type + data
+        crc = struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+        return struct.pack(">I", len(data)) + c + crc
+
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr_data = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+    raw_data = b"\x00\xff\x00\x00"
+    idat_data = zlib.compress(raw_data)
+    return signature + _chunk(b"IHDR", ihdr_data) + _chunk(b"IDAT", idat_data) + _chunk(b"IEND", b"")
+
+
+class EventVisibilityFilterRegressionTest(TestCase):
+    """終了済み/非承認コミュニティのイベントが公開面に出ないことを確認する。"""
+
+    def setUp(self):
+        self.client = Client()
+        cache.clear()
+        self.today = date.today()
+        image_content = _create_test_image()
+
+        self.active_community = Community.objects.create(
+            name="Active Community",
+            start_time=time(21, 0),
+            duration=60,
+            weekdays=["Mon"],
+            frequency="Every week",
+            organizers="Active Organizer",
+            status="approved",
+            poster_image=SimpleUploadedFile("active.png", image_content, content_type="image/png"),
+        )
+        self.ended_community = Community.objects.create(
+            name="Ended Community",
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=["Tue"],
+            frequency="Every week",
+            organizers="Ended Organizer",
+            status="approved",
+            end_at=self.today,
+            poster_image=SimpleUploadedFile("ended.png", image_content, content_type="image/png"),
+        )
+        self.pending_community = Community.objects.create(
+            name="Pending Community",
+            start_time=time(23, 0),
+            duration=60,
+            weekdays=["Wed"],
+            frequency="Every week",
+            organizers="Pending Organizer",
+            status="pending",
+            poster_image=SimpleUploadedFile("pending.png", image_content, content_type="image/png"),
+        )
+
+        self.active_event = Event.objects.create(
+            community=self.active_community,
+            date=self.today + timedelta(days=2),
+            start_time=time(21, 0),
+            duration=60,
+            weekday="MON",
+        )
+        self.ended_event = Event.objects.create(
+            community=self.ended_community,
+            date=self.today + timedelta(days=2),
+            start_time=time(22, 0),
+            duration=60,
+            weekday="TUE",
+        )
+        self.pending_event = Event.objects.create(
+            community=self.pending_community,
+            date=self.today + timedelta(days=2),
+            start_time=time(23, 0),
+            duration=60,
+            weekday="WED",
+        )
+
+        EventDetail.objects.create(
+            event=self.active_event,
+            detail_type="LT",
+            status="approved",
+            speaker="Active Speaker",
+            theme="Active Theme",
+            start_time=time(21, 0),
+        )
+        EventDetail.objects.create(
+            event=self.ended_event,
+            detail_type="LT",
+            status="approved",
+            speaker="Ended Speaker",
+            theme="Ended Theme",
+            start_time=time(22, 0),
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_event_list_excludes_ended_and_pending_communities(self):
+        response = self.client.get(reverse("event:list"))
+        self.assertEqual(response.status_code, 200)
+
+        event_ids = [event.id for event in response.context["events"]]
+        self.assertIn(self.active_event.id, event_ids)
+        self.assertNotIn(self.ended_event.id, event_ids)
+        self.assertNotIn(self.pending_event.id, event_ids)
+
+    def test_index_excludes_ended_and_pending_communities(self):
+        response = self.client.get(reverse("ta_hub:index"))
+        self.assertEqual(response.status_code, 200)
+
+        upcoming_events = response.context.get("upcoming_events", [])
+        event_ids = [event["id"] for event in upcoming_events]
+        self.assertIn(self.active_event.id, event_ids)
+        self.assertNotIn(self.ended_event.id, event_ids)
+        self.assertNotIn(self.pending_event.id, event_ids)
+
+    def test_public_api_excludes_ended_communities(self):
+        event_response = self.client.get("/api/v1/event/")
+        self.assertEqual(event_response.status_code, 200)
+        event_payload = event_response.json()
+        event_results = event_payload["results"] if isinstance(event_payload, dict) else event_payload
+        returned_event_ids = [item["id"] for item in event_results]
+        self.assertIn(self.active_event.id, returned_event_ids)
+        self.assertNotIn(self.ended_event.id, returned_event_ids)
+        self.assertNotIn(self.pending_event.id, returned_event_ids)
+
+        detail_response = self.client.get("/api/v1/event_detail/")
+        self.assertEqual(detail_response.status_code, 200)
+        detail_payload = detail_response.json()
+        detail_results = detail_payload["results"] if isinstance(detail_payload, dict) else detail_payload
+        returned_speakers = [item["speaker"] for item in detail_results]
+        self.assertIn("Active Speaker", returned_speakers)
+        self.assertNotIn("Ended Speaker", returned_speakers)
+
+
+class PurgeCommunityEventsCommandTest(TestCase):
+    """purge_community_events コマンドの回帰テスト。"""
+
+    def setUp(self):
+        self.from_date = date(2026, 2, 10)
+        self.target_name = "AI集会テックWeek"
+
+        self.target_community = Community.objects.create(
+            name=self.target_name,
+            start_time=time(21, 0),
+            duration=60,
+            weekdays=["Mon"],
+            frequency="Every week",
+            organizers="Target Organizer",
+            status="approved",
+        )
+        self.other_community = Community.objects.create(
+            name="Other Community",
+            start_time=time(21, 0),
+            duration=60,
+            weekdays=["Mon"],
+            frequency="Every week",
+            organizers="Other Organizer",
+            status="approved",
+        )
+
+        self.before_event = Event.objects.create(
+            community=self.target_community,
+            date=date(2026, 2, 9),
+            start_time=time(21, 0),
+            duration=60,
+            weekday="MON",
+        )
+        self.after_event = Event.objects.create(
+            community=self.target_community,
+            date=date(2026, 2, 10),
+            start_time=time(21, 0),
+            duration=60,
+            weekday="TUE",
+        )
+        self.other_event = Event.objects.create(
+            community=self.other_community,
+            date=date(2026, 2, 10),
+            start_time=time(21, 0),
+            duration=60,
+            weekday="TUE",
+        )
+
+        self.rule = RecurrenceRule.objects.create(
+            community=self.target_community,
+            frequency="WEEKLY",
+            interval=1,
+            start_date=date(2026, 1, 1),
+        )
+        self.master = Event.objects.create(
+            community=self.target_community,
+            date=date(2026, 1, 1),
+            start_time=time(21, 0),
+            duration=60,
+            weekday="THU",
+            recurrence_rule=self.rule,
+            is_recurring_master=True,
+        )
+        self.future_instance = Event.objects.create(
+            community=self.target_community,
+            date=date(2026, 2, 17),
+            start_time=time(21, 0),
+            duration=60,
+            weekday="TUE",
+            recurring_master=self.master,
+        )
+
+    @patch("event.management.commands.purge_community_events.GoogleCalendarService")
+    def test_dry_run_does_not_delete_data(self, mock_service_cls):
+        mock_service = mock_service_cls.return_value
+        mock_service.list_events.return_value = [
+            {
+                "id": "gcal-target",
+                "summary": self.target_name,
+                "start": {"dateTime": "2026-02-10T12:00:00+09:00"},
+            }
+        ]
+
+        call_command(
+            "purge_community_events",
+            f"--community={self.target_name}",
+            f"--from-date={self.from_date.isoformat()}",
+            "--delete-rules",
+            "--dry-run",
+            "--google-window-days=365",
+            "--google-years=1",
+        )
+
+        self.assertTrue(Event.objects.filter(id=self.after_event.id).exists())
+        self.assertTrue(RecurrenceRule.objects.filter(id=self.rule.id).exists())
+        mock_service.delete_event.assert_not_called()
+
+    @patch("event.management.commands.purge_community_events.GoogleCalendarService")
+    def test_execute_deletes_target_range_and_rules(self, mock_service_cls):
+        mock_service = mock_service_cls.return_value
+        mock_service.list_events.return_value = [
+            {
+                "id": "gcal-target",
+                "summary": self.target_name,
+                "start": {"dateTime": "2026-02-10T12:00:00+09:00"},
+            },
+            {
+                "id": "gcal-before",
+                "summary": self.target_name,
+                "start": {"dateTime": "2026-02-09T12:00:00+09:00"},
+            },
+            {
+                "id": "gcal-other-community",
+                "summary": "Other Community",
+                "start": {"dateTime": "2026-02-10T12:00:00+09:00"},
+            },
+        ]
+
+        call_command(
+            "purge_community_events",
+            f"--community={self.target_name}",
+            f"--from-date={self.from_date.isoformat()}",
+            "--delete-rules",
+            "--google-window-days=365",
+            "--google-years=1",
+        )
+
+        self.assertTrue(Event.objects.filter(id=self.before_event.id).exists())
+        self.assertFalse(Event.objects.filter(id=self.after_event.id).exists())
+        self.assertTrue(Event.objects.filter(id=self.other_event.id).exists())
+        self.assertFalse(RecurrenceRule.objects.filter(id=self.rule.id).exists())
+
+        deleted_ids = {call.args[0] for call in mock_service.delete_event.call_args_list}
+        self.assertEqual(deleted_ids, {"gcal-target"})

--- a/app/event/tests/test_google_calendar_list_pagination.py
+++ b/app/event/tests/test_google_calendar_list_pagination.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from event.google_calendar import GoogleCalendarService
+
+
+class GoogleCalendarListPaginationTest(TestCase):
+    def test_list_events_fetches_all_pages(self):
+        service = GoogleCalendarService.__new__(GoogleCalendarService)
+        service.calendar_id = "test-calendar"
+        service.service = MagicMock()
+
+        first_page = {
+            "items": [{"id": "evt-1"}],
+            "nextPageToken": "page-2",
+        }
+        second_page = {
+            "items": [{"id": "evt-2"}],
+        }
+
+        events_resource = service.service.events.return_value
+        events_resource.list.side_effect = [
+            MagicMock(execute=MagicMock(return_value=first_page)),
+            MagicMock(execute=MagicMock(return_value=second_page)),
+        ]
+
+        now = datetime.now()
+        result = service.list_events(
+            max_results=1,
+            time_min=now,
+            time_max=now + timedelta(days=1),
+        )
+
+        self.assertEqual([item["id"] for item in result], ["evt-1", "evt-2"])
+        self.assertEqual(events_resource.list.call_count, 2)
+        first_kwargs = events_resource.list.call_args_list[0].kwargs
+        second_kwargs = events_resource.list.call_args_list[1].kwargs
+        self.assertIsNone(first_kwargs["pageToken"])
+        self.assertEqual(second_kwargs["pageToken"], "page-2")

--- a/app/ta_hub/views.py
+++ b/app/ta_hub/views.py
@@ -82,6 +82,8 @@ class IndexView(TemplateView):
         upcoming_events = Event.objects.filter(
             date__gte=today,
             date__lte=end_date,
+            community__status='approved',
+            community__end_at__isnull=True,
             # ポスター画像があるコミュニティのイベントのみ
             community__poster_image__isnull=False
         ).exclude(
@@ -90,6 +92,8 @@ class IndexView(TemplateView):
 
         upcoming_event_details = EventDetail.objects.filter(
             event__date__gte=today,
+            event__community__status='approved',
+            event__community__end_at__isnull=True,
             detail_type='LT',  # LTのみ
             status='approved',
             # ポスター画像があるコミュニティのイベントのみ
@@ -103,6 +107,8 @@ class IndexView(TemplateView):
             detail_type='SPECIAL',
             status='approved',
             event__date__gte=today,  # 今日以降のイベント
+            event__community__status='approved',
+            event__community__end_at__isnull=True,
             # ポスター画像があるコミュニティのイベントのみ
             event__community__poster_image__isnull=False
         ).exclude(

--- a/docs/notes/todo.md
+++ b/docs/notes/todo.md
@@ -6,6 +6,7 @@
 
 - [x] `docs/notes/index.md` のリンク整備（存在しない `how/deployment.md` / `how/django.md` / `logs/2026-01.md` の扱いを決める）
 - [x] `docker-compose.test.yml` の `version:` が obsolete のため削除する（警告抑止）
+- [ ] `event/detail/{id}` ページでコンソールエラー `Cannot read properties of null` が発生しているため修正する（`https://vrc-ta-hub.com/event/detail/522/` と `https://vrc-ta-hub.com/event/detail/523/` で再現）
 
 ## Vket コラボ
 

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -8,6 +8,7 @@ http = 127.0.0.1:8000
 master = true
 processes = 1
 threads = 10
+buffer-size = 8192
 max-requests = 1000                  ; Restart workers after this many requests
 max-worker-lifetime = 3600           ; Restart workers after this many seconds
 reload-on-rss = 512                  ; Restart workers after this much resident memory


### PR DESCRIPTION
## 背景
集会をDB直接操作で停止したケースで、イベント一覧/Googleカレンダーに残骸が残る問題が発生していました。
また、管理者ワンクリック修復導線でログイン後 `next` リダイレクトが `GET /community/{id}/admin-cleanup/` となり、HTTP 405が発生していました。

## 変更内容
- 集会停止/管理者修復で共通利用するクリーンアップ処理を追加
  - DBの未来イベント削除
  - 定期ルール削除
  - Googleカレンダー予定削除（ID優先 + 同名一意時の補完削除、404は許容）
- `CloseCommunityView` を強化し、停止時に上記クリーンアップを実行
- 管理者専用のワンクリック修復ビューを追加
- `admin-cleanup` と `close` のPOST専用URLに対し、GET時は405ではなく詳細画面へリダイレクト
- イベント表示系API/トップ/一覧のフィルタを強化（`community__status='approved'` + `end_at__isnull=True`）
- Googleカレンダー一覧取得のページング対応
- 運用用コマンド `purge_community_events` 追加

## テスト
- `python manage.py test community.tests.test_switch_community community.tests.test_views event.tests.test_community_cleanup event.tests.test_detail_history_rate_limit event.tests.test_event_visibility_and_purge_command event.tests.test_google_calendar_list_pagination`
  - 47 tests passed
