### PR TITLE
fix: Discord認証で既存アカウントへ自動連携する

### DIFF
--- a/app/user_account/adapters.py
+++ b/app/user_account/adapters.py
@@ -1,7 +1,9 @@
 """Discord OAuth用のカスタムアダプター."""
 import logging
 
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
@@ -32,12 +34,13 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
         """
         # Discordから取得したデータを確認
         email = sociallogin.account.extra_data.get('email', '')
+        is_verified = sociallogin.account.extra_data.get('verified') is True
 
-        if email:
-            logger.info("Email found, allowing auto signup")
+        if email and is_verified:
+            logger.info("Verified email found, allowing auto signup")
             return True
         else:
-            logger.info("No email found, redirecting to signup form")
+            logger.info("Missing or unverified email, redirecting to signup form")
             return False
 
     def pre_social_login(self, request, sociallogin):
@@ -60,7 +63,60 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
             return
 
         discord_id = sociallogin.account.uid
-        logger.info(f"Discord login attempt: discord_id={discord_id}")
+        discord_id_suffix = discord_id[-4:] if len(discord_id) > 4 else discord_id
+        email = sociallogin.account.extra_data.get('email', '')
+        is_verified = sociallogin.account.extra_data.get('verified') is True
+        logger.info("Discord login attempt: discord_id_suffix=%s", discord_id_suffix)
+
+        if not email or not is_verified:
+            if email and not is_verified:
+                logger.warning(
+                    "Skipping auto connect for unverified Discord email: discord_id_suffix=%s",
+                    discord_id_suffix,
+                )
+            return
+
+        existing_user = User.objects.filter(email__iexact=email).first()
+        if not existing_user:
+            return
+
+        if not EmailAddress.objects.filter(
+            user=existing_user,
+            email__iexact=email,
+            verified=True,
+        ).exists():
+            logger.warning(
+                "Skipping auto connect because existing user email is not verified: user_id=%s",
+                existing_user.id,
+            )
+            return
+
+        if SocialAccount.objects.filter(
+            user=existing_user,
+            provider=sociallogin.account.provider,
+        ).exclude(uid=discord_id).exists():
+            logger.warning(
+                "Skipping auto connect because user already has another Discord account: user_id=%s",
+                existing_user.id,
+            )
+            return
+
+        if SocialAccount.objects.filter(
+            provider=sociallogin.account.provider,
+            uid=discord_id,
+        ).exclude(user=existing_user).exists():
+            logger.warning(
+                "Discord account conflict detected for existing user: user_id=%s",
+                existing_user.id,
+            )
+            return
+
+        logger.info(
+            "Connecting Discord account to existing user: user_id=%s, discord_id_suffix=%s",
+            existing_user.id,
+            discord_id_suffix,
+        )
+        sociallogin.connect(request, existing_user)
 
     def populate_user(self, request, sociallogin, data):
         """新規ユーザー作成時のフィールド設定.

--- a/app/user_account/tests/test_adapters.py
+++ b/app/user_account/tests/test_adapters.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory, TestCase
 
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from user_account.adapters import CustomSocialAccountAdapter
 from user_account.tests.utils import create_discord_linked_user
@@ -23,24 +24,47 @@ class CustomSocialAccountAdapterTests(TestCase):
             email='existing@example.com',
             password='testpass123',
         )
+        EmailAddress.objects.create(
+            user=self.existing_user,
+            email='existing@example.com',
+            verified=True,
+            primary=True,
+        )
 
     def test_is_auto_signup_allowed_returns_true_when_email_exists(self):
-        """メールアドレスがある場合、自動サインアップを許可すること."""
+        """検証済みメールアドレスがある場合、自動サインアップを許可すること."""
         request = self.factory.get('/accounts/discord/login/callback/')
 
         sociallogin = MagicMock()
-        sociallogin.account.extra_data = {'email': 'test@example.com'}
+        sociallogin.account.extra_data = {
+            'email': 'test@example.com',
+            'verified': True,
+        }
 
         result = self.adapter.is_auto_signup_allowed(request, sociallogin)
 
         self.assertTrue(result)
+
+    def test_is_auto_signup_allowed_returns_false_when_email_is_unverified(self):
+        """未検証メールアドレスでは自動サインアップを許可しないこと."""
+        request = self.factory.get('/accounts/discord/login/callback/')
+
+        sociallogin = MagicMock()
+        sociallogin.account.extra_data = {
+            'email': 'test@example.com',
+            'verified': False,
+        }
+
+        result = self.adapter.is_auto_signup_allowed(request, sociallogin)
+
+        self.assertFalse(result)
 
     def test_is_auto_signup_allowed_returns_false_when_email_missing(self):
         """メールアドレスがない場合、自動サインアップを許可しないこと（フォーム表示）."""
         request = self.factory.get('/accounts/discord/login/callback/')
 
         sociallogin = MagicMock()
-        sociallogin.account.extra_data = {'email': ''}
+        sociallogin.account.extra_data = {'email': '', 'verified': False}
 
         result = self.adapter.is_auto_signup_allowed(request, sociallogin)
 
@@ -51,7 +75,7 @@ class CustomSocialAccountAdapterTests(TestCase):
         request = self.factory.get('/accounts/discord/login/callback/')
 
         sociallogin = MagicMock()
-        sociallogin.account.extra_data = {}
+        sociallogin.account.extra_data = {'verified': False}
 
         result = self.adapter.is_auto_signup_allowed(request, sociallogin)
 
@@ -64,6 +88,151 @@ class CustomSocialAccountAdapterTests(TestCase):
         sociallogin = MagicMock()
         sociallogin.is_existing = True
         sociallogin.account.uid = '123456789'
+
+        self.adapter.pre_social_login(request, sociallogin)
+
+        sociallogin.connect.assert_not_called()
+
+    def test_pre_social_login_connects_existing_user_with_same_email(self):
+        """Discord のメールアドレスが既存ユーザーと一致する場合は連携すること."""
+        request = self.factory.get('/accounts/discord/login/callback/')
+
+        sociallogin = MagicMock()
+        sociallogin.is_existing = False
+        sociallogin.state = {}
+        sociallogin.account.provider = 'discord'
+        sociallogin.account.uid = '123456789'
+        sociallogin.account.extra_data = {
+            'email': 'existing@example.com',
+            'verified': True,
+        }
+
+        self.adapter.pre_social_login(request, sociallogin)
+
+        sociallogin.connect.assert_called_once_with(request, self.existing_user)
+
+    def test_pre_social_login_skips_when_email_is_not_verified(self):
+        """Discord 側でメール未検証なら自動連携しないこと."""
+        request = self.factory.get('/accounts/discord/login/callback/')
+
+        sociallogin = MagicMock()
+        sociallogin.is_existing = False
+        sociallogin.state = {}
+        sociallogin.account.provider = 'discord'
+        sociallogin.account.uid = '123456789'
+        sociallogin.account.extra_data = {
+            'email': 'existing@example.com',
+            'verified': False,
+        }
+
+        self.adapter.pre_social_login(request, sociallogin)
+
+        sociallogin.connect.assert_not_called()
+
+    def test_pre_social_login_skips_connect_when_process_is_connect(self):
+        """process=connect の場合は既存ユーザー自動紐付けを行わないこと."""
+        request = self.factory.get('/accounts/discord/login/callback/')
+
+        sociallogin = MagicMock()
+        sociallogin.is_existing = False
+        sociallogin.state = {'process': 'connect'}
+        sociallogin.account.provider = 'discord'
+        sociallogin.account.uid = '123456789'
+        sociallogin.account.extra_data = {
+            'email': 'existing@example.com',
+            'verified': True,
+        }
+
+        self.adapter.pre_social_login(request, sociallogin)
+
+        sociallogin.connect.assert_not_called()
+
+    def test_pre_social_login_skips_when_no_matching_email(self):
+        """一致するメールアドレスがない場合は新規フローを継続すること."""
+        request = self.factory.get('/accounts/discord/login/callback/')
+
+        sociallogin = MagicMock()
+        sociallogin.is_existing = False
+        sociallogin.state = {}
+        sociallogin.account.provider = 'discord'
+        sociallogin.account.uid = '123456789'
+        sociallogin.account.extra_data = {
+            'email': 'missing@example.com',
+            'verified': True,
+        }
+
+        self.adapter.pre_social_login(request, sociallogin)
+
+        sociallogin.connect.assert_not_called()
+
+    def test_pre_social_login_skips_when_discord_uid_is_linked_to_other_user(self):
+        """同じ Discord UID が別ユーザーに紐付いている場合は自動連携しないこと."""
+        other_user = User.objects.create_user(
+            user_name='other_user',
+            email='other@example.com',
+            password='testpass123',
+        )
+        SocialAccount.objects.create(
+            user=other_user,
+            provider='discord',
+            uid='123456789',
+        )
+
+        request = self.factory.get('/accounts/discord/login/callback/')
+
+        sociallogin = MagicMock()
+        sociallogin.is_existing = False
+        sociallogin.state = {}
+        sociallogin.account.provider = 'discord'
+        sociallogin.account.uid = '123456789'
+        sociallogin.account.extra_data = {
+            'email': 'existing@example.com',
+            'verified': True,
+        }
+
+        self.adapter.pre_social_login(request, sociallogin)
+
+        sociallogin.connect.assert_not_called()
+
+    def test_pre_social_login_skips_when_existing_user_email_is_not_verified(self):
+        """既存ユーザー側のメールが未検証なら自動連携しないこと."""
+        EmailAddress.objects.filter(user=self.existing_user).delete()
+
+        request = self.factory.get('/accounts/discord/login/callback/')
+
+        sociallogin = MagicMock()
+        sociallogin.is_existing = False
+        sociallogin.state = {}
+        sociallogin.account.provider = 'discord'
+        sociallogin.account.uid = '123456789'
+        sociallogin.account.extra_data = {
+            'email': 'existing@example.com',
+            'verified': True,
+        }
+
+        self.adapter.pre_social_login(request, sociallogin)
+
+        sociallogin.connect.assert_not_called()
+
+    def test_pre_social_login_skips_when_existing_user_has_other_discord_account(self):
+        """既存ユーザーが別の Discord アカウントを連携済みなら自動連携しないこと."""
+        SocialAccount.objects.create(
+            user=self.existing_user,
+            provider='discord',
+            uid='999999999',
+        )
+
+        request = self.factory.get('/accounts/discord/login/callback/')
+
+        sociallogin = MagicMock()
+        sociallogin.is_existing = False
+        sociallogin.state = {}
+        sociallogin.account.provider = 'discord'
+        sociallogin.account.uid = '123456789'
+        sociallogin.account.extra_data = {
+            'email': 'existing@example.com',
+            'verified': True,
+        }
 
         self.adapter.pre_social_login(request, sociallogin)
 


### PR DESCRIPTION
## なぜこの変更が必要か

Discord 認証時に、既存アカウントと同じメールアドレスを持つユーザーでも新規作成フローに入り、`account_customuser.email` の一意制約違反で失敗していました。
その結果、既存アカウントへ入れず、別アカウントが作られて権限が分裂する実害が出ていたため、既存アカウントへの安全な自動連携が必要でした。

## 変更内容

- Discord OAuth の `pre_social_login()` で、条件を満たす既存ユーザーへ自動連携する処理を追加
- 自動連携は `verified=True` のメール、既存 verified email、一意な Discord UID の場合だけに制限
- `is_auto_signup_allowed()` も verified email 前提に揃えて、新規作成側の条件を一貫化
- 再発防止テストを追加し、同一メール、未検証メール、`process='connect'`、UID 競合などを検証

## 意思決定

### 採用アプローチ
- `allauth` の `pre_social_login()` で既存ユーザー判定後に `sociallogin.connect()` を使う方法を採用
- 理由: 既存の OAuth フローに最小変更で差し込めて、今回の障害点を直接潰せるため

### 却下した代替案
- DB 上で分裂アカウントを都度手動統合する
- 却下理由: 同種障害の再発を防げず、運用コストが高い

### トレードオフ
- verified email と UID 条件を厳しめにする代わりに、古いデータ状態の一部アカウントは自動連携されない可能性がある
- 今回は誤連携防止を優先

## テスト

- [x] `docker compose exec -T vrc-ta-hub python manage.py test user_account.tests.test_adapters --verbosity=2`
- [x] 結果: `22 tests, OK`
- [x] 本番 DB で `user_id=280` に `community_id=80 / owner` が付与されていることを確認

Closes #89

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
