### PR TITLE
style: 参加方法ボタンの配色変更＆Discord2段目に移動

### DIFF
--- a/app/community/templates/community/detail.html
+++ b/app/community/templates/community/detail.html
@@ -166,19 +166,21 @@
                                         <i class="bi bi-globe me-2"></i>VRChatグループに参加
                                     </a>
                                 {% endif %}
-                                {% if community.discord %}
-                                    <a href="{{ community.discord }}" target="_blank"
-                                       class="btn btn-secondary">
-                                        <i class="bi bi-discord me-2"></i>Discordサーバーに参加
-                                    </a>
-                                {% endif %}
                                 {% if community.twitter_hashtag %}
                                     <a href="https://twitter.com/hashtag/{{ community.twitter_hashtag|slice:"1:" }}?f=live"
-                                       target="_blank" class="btn btn-outline-info">
+                                       target="_blank" class="btn text-white" style="background-color: #1DA1F2;">
                                         <i class="bi bi-hash me-1"></i>{{ community.twitter_hashtag|slice:"1:" }}
                                     </a>
                                 {% endif %}
                             </div>
+                            {% if community.discord %}
+                                <div>
+                                    <a href="{{ community.discord }}" target="_blank"
+                                       class="btn text-white" style="background-color: #5865F2;">
+                                        <i class="bi bi-discord me-2"></i>Discordサーバーに参加
+                                    </a>
+                                </div>
+                            {% endif %}
                         </section>
 
                         <!-- LT発表申請 -->


### PR DESCRIPTION
## Summary

- ハッシュタグボタンをoutline-infoからXブルー(#1DA1F2)塗りつぶしに変更
- DiscordボタンをDiscordブランドカラー(#5865F2)に変更＆2段目に配置

## Test plan

- [ ] /community/19/ で参加方法セクションのボタン配色・配置を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)