### PR TITLE
fix: guard missing generate button on event detail

### DIFF
--- a/app/event/templates/event/detail.html
+++ b/app/event/templates/event/detail.html
@@ -267,10 +267,13 @@
     </div>
 
     <script>
-        document.getElementById('generate-button').addEventListener('click', function (event) {
-            event.target.disabled = true;
-            event.target.textContent = '生成中...';
-            event.target.form.submit();
-        });
+        const generateButton = document.getElementById('generate-button');
+        if (generateButton) {
+            generateButton.addEventListener('click', function (event) {
+                event.target.disabled = true;
+                event.target.textContent = '生成中...';
+                event.target.form.submit();
+            });
+        }
     </script>
 {% endblock %}

--- a/app/event/tests/test_event_detail_template.py
+++ b/app/event/tests/test_event_detail_template.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+
+class EventDetailTemplateTest(SimpleTestCase):
+    """event/detail.html の回帰テスト."""
+
+    def test_generate_button_script_is_null_safe(self):
+        """記事生成ボタンがない公開ページでも JS が落ちない."""
+        template = (
+            Path(__file__).resolve().parents[1] / "templates" / "event" / "detail.html"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("const generateButton = document.getElementById('generate-button');", template)
+        self.assertIn("if (generateButton) {", template)
+        self.assertNotIn("document.getElementById('generate-button').addEventListener", template)


### PR DESCRIPTION
## Summary
- make the event detail inline script null-safe when the generate button is absent
- add a template regression test so public pages do not crash on load

## Testing
- docker compose run --rm vrc-ta-hub python manage.py test event.tests.test_event_detail_template

Closes #93