### PR TITLE
fix: ガイドページが本番で表示されない問題を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN pip3 install -r /app/requirements.txt
 
 # アプリケーションのコピー
 COPY ./app /app
+COPY ./docs /docs
 COPY uwsgi.ini /uwsgi.ini
 COPY uwsgi_params /uwsgi_params
 


### PR DESCRIPTION
## Summary

- Dockerfileに `COPY ./docs /docs` を追加し、本番環境（Cloud Run）でガイドページのコンテンツが表示されるように修正

## 原因

- ローカル: `docker-compose.yaml` で `./docs:/docs` マウントがあるため正常動作
- 本番: Dockerイメージに `docs/` が含まれず、`_nav.yaml` が読めないためナビゲーションが空 → 「準備中」表示

## Test plan

- [x] Docker rebuild後、コンテナ内に `/docs/guide/_nav.yaml` が存在することを確認
- [x] `localhost:8015/guide/` でガイドカードが表示されることを確認
- [x] 「準備中」メッセージが表示されないことを確認

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)