### PR TITLE
fix: 曜日表示を日本語に統一

### DIFF
--- a/app/community/templates/community/settings.html
+++ b/app/community/templates/community/settings.html
@@ -1,4 +1,5 @@
 {% extends 'ta_hub/base.html' %}
+{% load custom_filters %}
 
 {% block title %}集会設定 - {{ community.name }}{% endblock %}
 
@@ -30,15 +31,7 @@
                     <label class="text-muted">開催曜日</label>
                     <p class="mb-0">
                         {% for weekday in community.weekdays %}
-                            {% if weekday == 'Sun' %}日曜日{% endif %}
-                            {% if weekday == 'Mon' %}月曜日{% endif %}
-                            {% if weekday == 'Tue' %}火曜日{% endif %}
-                            {% if weekday == 'Wed' %}水曜日{% endif %}
-                            {% if weekday == 'Thu' %}木曜日{% endif %}
-                            {% if weekday == 'Fri' %}金曜日{% endif %}
-                            {% if weekday == 'Sat' %}土曜日{% endif %}
-                            {% if weekday == 'Other' %}その他{% endif %}
-                            {% if not forloop.last %}、{% endif %}
+                            {{ weekday|weekday_jp }}{% if not forloop.last %}、{% endif %}
                         {% empty %}
                             -
                         {% endfor %}

--- a/app/community/templatetags/custom_filters.py
+++ b/app/community/templatetags/custom_filters.py
@@ -8,10 +8,34 @@ def get_item(dictionary, key):
     return dictionary.get(key)
 
 
+WEEKDAY_JP = {
+    'Sun': '日曜日', 'Mon': '月曜日', 'Tue': '火曜日', 'Wed': '水曜日',
+    'Thu': '木曜日', 'Fri': '金曜日', 'Sat': '土曜日', 'Other': 'その他',
+}
+
+WEEKDAY_ABBR = {
+    'Sun': '日', 'Mon': '月', 'Tue': '火', 'Wed': '水',
+    'Thu': '木', 'Fri': '金', 'Sat': '土', 'Other': '他',
+}
+
+
 @register.filter
 def weekday_abbr(weekday):
-    weekday_dict = {
-        'Sun': '日', 'Mon': '月', 'Tue': '火', 'Wed': '水',
-        'Thu': '木', 'Fri': '金', 'Sat': '土', 'Other': '他'
-    }
-    return weekday_dict.get(weekday, weekday)
+    normalized = weekday.title() if isinstance(weekday, str) else weekday
+    return WEEKDAY_ABBR.get(normalized, weekday)
+
+
+@register.filter
+def weekday_jp(weekday):
+    """英語曜日略称 → 日本語フル名（例: 'Sun'/'SUN' → '日曜日'）"""
+    normalized = weekday.title() if isinstance(weekday, str) else weekday
+    return WEEKDAY_JP.get(normalized, weekday)
+
+
+@register.filter
+def date_weekday_jp(date_obj):
+    """dateオブジェクト → 日本語曜日フル名"""
+    if date_obj:
+        weekday_map = ['月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日', '日曜日']
+        return weekday_map[date_obj.weekday()]
+    return ''

--- a/app/community/tests/test_custom_filters.py
+++ b/app/community/tests/test_custom_filters.py
@@ -1,0 +1,74 @@
+from datetime import date
+
+from django.test import TestCase
+
+from community.templatetags.custom_filters import (
+    date_weekday_jp,
+    weekday_abbr,
+    weekday_jp,
+)
+
+
+class WeekdayJpFilterTest(TestCase):
+    """weekday_jp フィルターのテスト"""
+
+    def test_all_weekdays(self):
+        expected = {
+            'Sun': '日曜日', 'Mon': '月曜日', 'Tue': '火曜日', 'Wed': '水曜日',
+            'Thu': '木曜日', 'Fri': '金曜日', 'Sat': '土曜日',
+        }
+        for eng, jp in expected.items():
+            self.assertEqual(weekday_jp(eng), jp)
+
+    def test_other(self):
+        self.assertEqual(weekday_jp('Other'), 'その他')
+
+    def test_uppercase(self):
+        self.assertEqual(weekday_jp('SUN'), '日曜日')
+        self.assertEqual(weekday_jp('SAT'), '土曜日')
+        self.assertEqual(weekday_jp('MON'), '月曜日')
+
+    def test_lowercase(self):
+        self.assertEqual(weekday_jp('sun'), '日曜日')
+        self.assertEqual(weekday_jp('sat'), '土曜日')
+
+    def test_unknown_value_fallback(self):
+        self.assertEqual(weekday_jp('Unknown'), 'Unknown')
+
+    def test_empty_string(self):
+        self.assertEqual(weekday_jp(''), '')
+
+
+class DateWeekdayJpFilterTest(TestCase):
+    """date_weekday_jp フィルターのテスト"""
+
+    def test_saturday(self):
+        self.assertEqual(date_weekday_jp(date(2026, 3, 28)), '土曜日')
+
+    def test_tuesday(self):
+        self.assertEqual(date_weekday_jp(date(2026, 3, 24)), '火曜日')
+
+    def test_sunday(self):
+        self.assertEqual(date_weekday_jp(date(2026, 3, 29)), '日曜日')
+
+    def test_none(self):
+        self.assertEqual(date_weekday_jp(None), '')
+
+
+class WeekdayAbbrFilterTest(TestCase):
+    """weekday_abbr フィルターの回帰テスト"""
+
+    def test_all_weekdays(self):
+        expected = {
+            'Sun': '日', 'Mon': '月', 'Tue': '火', 'Wed': '水',
+            'Thu': '木', 'Fri': '金', 'Sat': '土', 'Other': '他',
+        }
+        for eng, jp in expected.items():
+            self.assertEqual(weekday_abbr(eng), jp)
+
+    def test_uppercase(self):
+        self.assertEqual(weekday_abbr('SUN'), '日')
+        self.assertEqual(weekday_abbr('SAT'), '土')
+
+    def test_unknown_fallback(self):
+        self.assertEqual(weekday_abbr('Unknown'), 'Unknown')

--- a/app/ta_hub/templates/ta_hub/index.html
+++ b/app/ta_hub/templates/ta_hub/index.html
@@ -1,5 +1,5 @@
 {% extends 'ta_hub/base.html' %}
-{% load static %}
+{% load static custom_filters %}
 {% block main %}
     <style>
         .rounded-custom {
@@ -396,7 +396,7 @@
                                                     </div>
                                                     <p class="card-text">
                                                         <i class="bi bi-calendar3"></i> {{ event_group.grouper.date|date:"Y/m/d" }}
-                                                        <small class="text-muted">（{{ event_group.grouper.date|date:"D" }}）</small><br>
+                                                        <small class="text-muted">（{{ event_group.grouper.date|date_weekday_jp }}）</small><br>
                                                         <i class="bi bi-clock"></i> {{ event_group.grouper.start_time|time:"H:i" }}<small
                                                             class="text-muted">（日本時間）</small>
                                                     </p>
@@ -545,7 +545,7 @@
                                             </div>
                                             <p class="card-text">
                                                 <i class="bi bi-calendar3"></i> {{ event_group.grouper.date|date:"Y/m/d" }}
-                                                <small class="text-muted">（{{ event_group.grouper.date|date:"D" }}）</small><br>
+                                                <small class="text-muted">（{{ event_group.grouper.date|date_weekday_jp }}）</small><br>
                                                 <i class="bi bi-clock"></i> {{ event_group.grouper.start_time|time:"H:i" }}<small
                                                     class="text-muted">（日本時間）</small>
                                             </p>
@@ -764,23 +764,7 @@
                                                                 <span>{{ event.date|date:"Y/m/d" }}</span>
                                                             </div>
                                                             <div class="weekday-badge weekday-{{ event.weekday|lower }}">
-                                                                {% if event.weekday == 'Sun' %}
-                                                                    日曜日
-                                                                {% elif event.weekday == 'Mon' %}
-                                                                    月曜日
-                                                                {% elif event.weekday == 'Tue' %}
-                                                                    火曜日
-                                                                {% elif event.weekday == 'Wed' %}
-                                                                    水曜日
-                                                                {% elif event.weekday == 'Thu' %}
-                                                                    木曜日
-                                                                {% elif event.weekday == 'Fri' %}
-                                                                    金曜日
-                                                                {% elif event.weekday == 'Sat' %}
-                                                                    土曜日
-                                                                {% else %}
-                                                                    {{ event.weekday }}
-                                                                {% endif %}
+                                                                {{ event.weekday|weekday_jp }}
                                                             </div>
                                                         </div>
                                                         <div class="time-info">


### PR DESCRIPTION
## Summary

トップページのイベントカードで曜日が英語（SAT, SUN, MON等）と日本語（土曜日）で混在していた問題を修正。

- `weekday_jp`/`date_weekday_jp` テンプレートフィルターを追加し、全テンプレートで統一
- DB値の大文字小文字揺れ（'SAT' vs 'Sat'）にも `.title()` 正規化で対応
- `date:"D"` (英語出力) や if/elif 18行のブロックをフィルター1行に置換

## Test plan

- [x] フィルターのユニットテスト13件追加・全パス
- [x] 既存テスト425件パス
- [x] `curl localhost:8015` で英語曜日が0件、全て日本語表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)