### PR TITLE
fix: 活動停止通報Webhookに集会ページURLを追加

### DIFF
--- a/app/community/views.py
+++ b/app/community/views.py
@@ -1139,7 +1139,8 @@ def _send_report_webhook(community, report_count):
     message = {
         "content": (
             f"**集会の活動停止が通報されました**\n"
-            f"📢 **{community.name}**\n\n"
+            f"📢 **{community.name}**\n"
+            f"{community_url}\n\n"
             "活動しているかを確認して、リアクションで教えてください\n\n"
             "✅ → まだ開催されている　❌ → 停止している\n\n"
             "💬 詳しい情報があればスレッドで教えてください"


### PR DESCRIPTION
## Summary

- 活動停止通報のDiscord Webhookメッセージに、集会ページURL（`https://vrc-ta-hub.com/community/NN/`）を追加
- 管理者がワンクリックで該当集会の詳細ページを確認できるようになる

## Test plan

- [x] `community.tests.test_community_report` 全11テストパス確認済み


🤖 Generated with [Claude Code](https://claude.com/claude-code)