### PR TITLE
fix: イベント詳細更新ページで権限がない場合にリダイレクトする

### DIFF
--- a/app/event/tests/test_event_detail_permissions.py
+++ b/app/event/tests/test_event_detail_permissions.py
@@ -69,13 +69,23 @@ class EventDetailPermissionTests(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_non_member_cannot_access_event_detail_update_view(self):
-        """非メンバーはEventDetail更新ページにアクセスできない（403）."""
+        """非メンバーはEventDetail更新ページにアクセスするとイベント詳細にリダイレクトされる."""
         self.client.login(username="other_user", password="testpass123")
 
         url = reverse("event:detail_update", kwargs={"pk": self.event_detail.pk})
         response = self.client.get(url)
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 302)
+        expected_url = reverse("event:detail", kwargs={"pk": self.event_detail.pk})
+        self.assertEqual(response.url, expected_url)
+
+    def test_anonymous_user_redirected_to_login_on_update(self):
+        """未ログインユーザーはEventDetail更新ページからログインページにリダイレクトされる."""
+        url = reverse("event:detail_update", kwargs={"pk": self.event_detail.pk})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/account/login/", response.url)
 
     def test_non_member_cannot_delete_event_detail(self):
         """非メンバーはEventDetailを削除できない（403）."""

--- a/app/event/views.py
+++ b/app/event/views.py
@@ -729,7 +729,13 @@ class EventDetailUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView)
         event_detail = self.get_object()
         # イベント詳細は、所属コミュニティの管理者（owner/staff）またはsuperuserのみ更新可
         return self.request.user.is_superuser or event_detail.event.community.can_edit(self.request.user)
-    
+
+    def handle_no_permission(self):
+        """認証済みだが権限がないユーザーはイベント詳細ページにリダイレクトする."""
+        if self.request.user.is_authenticated:
+            return redirect('event:detail', pk=self.get_object().pk)
+        return super().handle_no_permission()
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['event'] = self.object.event


### PR DESCRIPTION
## Summary
- `EventDetailUpdateView` で権限がないログイン済みユーザーが403エラーになる問題を修正
- `handle_no_permission` をオーバーライドし、イベント詳細ページ (`/event/detail/{id}/`) へリダイレクトするように変更
- 未ログインユーザーは既存通りログインページへリダイレクト

## Test plan
- [x] 非メンバーがUpdateページにアクセス → 302でイベント詳細にリダイレクトされること
- [x] 未ログインユーザーがUpdateページにアクセス → ログインページにリダイレクトされること
- [x] `event.tests.test_event_detail_permissions` 全テストパス

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)