### PR TITLE
fix: X-Forwarded-For の先頭取得を Cloud Run 対応に修正

### DIFF
--- a/app/community/tests/test_community_report.py
+++ b/app/community/tests/test_community_report.py
@@ -6,7 +6,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from community.models import Community, CommunityReport
-from community.views import _get_client_ip
+from ta_hub.utils import get_client_ip
 
 
 @override_settings(DISCORD_REPORT_WEBHOOK_URL='')
@@ -103,17 +103,23 @@ class GetClientIpTest(TestCase):
         """X-Forwarded-For に単一IP"""
         request = self._make_request()
         request.META['HTTP_X_FORWARDED_FOR'] = '203.0.113.1'
-        self.assertEqual(_get_client_ip(request), '203.0.113.1')
+        self.assertEqual(get_client_ip(request), '203.0.113.1')
 
-    def test_forwarded_for_multiple_ips(self):
-        """X-Forwarded-For に複数IP → 先頭を取得"""
+    def test_forwarded_for_two_ips(self):
+        """X-Forwarded-For に2つのIP → 末尾から2番目を取得"""
         request = self._make_request()
         request.META['HTTP_X_FORWARDED_FOR'] = '203.0.113.1, 10.0.0.1'
-        self.assertEqual(_get_client_ip(request), '203.0.113.1')
+        self.assertEqual(get_client_ip(request), '203.0.113.1')
+
+    def test_forwarded_for_spoofed_ips(self):
+        """X-Forwarded-For にスプーフィングされたIP → 末尾から2番目を取得"""
+        request = self._make_request()
+        request.META['HTTP_X_FORWARDED_FOR'] = '1.2.3.4, 203.0.113.1, 10.128.0.1'
+        self.assertEqual(get_client_ip(request), '203.0.113.1')
 
     def test_remote_addr_fallback(self):
         """X-Forwarded-For がない場合は REMOTE_ADDR にフォールバック"""
         request = self._make_request()
         request.META.pop('HTTP_X_FORWARDED_FOR', None)
-        ip = _get_client_ip(request)
+        ip = get_client_ip(request)
         self.assertIsNotNone(ip)

--- a/app/community/views.py
+++ b/app/community/views.py
@@ -18,6 +18,8 @@ from django.core.mail import send_mail
 from django.conf import settings
 from django.template.loader import render_to_string
 from django.core.cache import cache
+
+from ta_hub.utils import get_client_ip
 from django.utils.http import url_has_allowed_host_and_scheme
 import requests
 
@@ -1129,13 +1131,6 @@ REPORT_DUPLICATE_TTL_SECONDS = 30 * 24 * 60 * 60
 REPORT_GLOBAL_LIMIT_PER_IP = 3
 
 
-def _get_client_ip(request):
-    """クライアントIPを取得する（Cloud Run の X-Forwarded-For 対応）"""
-    forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', '')
-    if forwarded_for:
-        return forwarded_for.split(',')[0].strip()
-    return request.META.get('REMOTE_ADDR') or '0.0.0.0'
-
 
 def _send_report_webhook(community, report_count):
     """活動停止通報の Discord Webhook を送信する"""
@@ -1187,7 +1182,7 @@ class CommunityReportView(View):
     def post(self, request, pk):
         community = get_object_or_404(Community, pk=pk, status='approved')
 
-        ip = _get_client_ip(request)
+        ip = get_client_ip(request)
 
         # 同一集会の重複チェック
         cache_key = f"community_report:{pk}:{ip}"

--- a/app/event/views.py
+++ b/app/event/views.py
@@ -9,6 +9,8 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.cache import cache
+
+from ta_hub.utils import get_client_ip
 from django.db.models import Prefetch, QuerySet
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
@@ -1088,19 +1090,12 @@ class EventDetailPastList(ListView):
     RATE_LIMIT_MAX_REQUESTS = 20
     ALLOWED_FILTER_KEYS = ('community_name', 'speaker', 'theme')
 
-    def _get_client_ip(self):
-        """Cloud Run配下を考慮してクライアントIPを取得する。"""
-        forwarded_for = self.request.META.get('HTTP_X_FORWARDED_FOR', '')
-        if forwarded_for:
-            return forwarded_for.split(',')[0].strip()
-        return self.request.META.get('REMOTE_ADDR', 'unknown')
-
     def _get_rate_limit_cache_key(self, client_ip):
         bucket = int(timezone.now().timestamp()) // self.RATE_LIMIT_WINDOW_SECONDS
         return f"event_detail_history:ip:{client_ip}:bucket:{bucket}"
 
     def _is_rate_limited(self):
-        client_ip = self._get_client_ip()
+        client_ip = get_client_ip(self.request)
         cache_key = self._get_rate_limit_cache_key(client_ip)
         request_count = cache.get(cache_key, 0)
 

--- a/app/ta_hub/tests/test_utils.py
+++ b/app/ta_hub/tests/test_utils.py
@@ -1,0 +1,68 @@
+from django.test import TestCase, RequestFactory
+
+from ta_hub.utils import get_client_ip
+
+
+class GetClientIpTest(TestCase):
+    """Cloud Run 環境での get_client_ip の動作を検証する。
+
+    Cloud Run では Google LB が X-Forwarded-For の末尾にクライアント IP を追加する。
+    構成: [ユーザー偽装IP, ..., クライアントIP, Google LB IP]
+    """
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _make_request(self):
+        return self.factory.get('/')
+
+    def test_single_ip(self):
+        """単一 IP: そのまま返す"""
+        request = self._make_request()
+        request.META['HTTP_X_FORWARDED_FOR'] = '203.0.113.1'
+        self.assertEqual(get_client_ip(request), '203.0.113.1')
+
+    def test_two_ips_returns_second_to_last(self):
+        """2つの IP: クライアント + LB -> 末尾から2番目（クライアント IP）を返す"""
+        request = self._make_request()
+        request.META['HTTP_X_FORWARDED_FOR'] = '203.0.113.1, 10.128.0.1'
+        self.assertEqual(get_client_ip(request), '203.0.113.1')
+
+    def test_three_ips_spoofed_header(self):
+        """3つの IP: 偽装 + クライアント + LB -> 末尾から2番目（クライアント IP）を返す"""
+        request = self._make_request()
+        request.META['HTTP_X_FORWARDED_FOR'] = '1.2.3.4, 203.0.113.1, 10.128.0.1'
+        self.assertEqual(get_client_ip(request), '203.0.113.1')
+
+    def test_four_ips_multiple_spoofed(self):
+        """4つの IP: 偽装x2 + クライアント + LB -> 末尾から2番目を返す"""
+        request = self._make_request()
+        request.META['HTTP_X_FORWARDED_FOR'] = '1.2.3.4, 5.6.7.8, 203.0.113.1, 10.128.0.1'
+        self.assertEqual(get_client_ip(request), '203.0.113.1')
+
+    def test_remote_addr_fallback(self):
+        """X-Forwarded-For がない場合は REMOTE_ADDR にフォールバック"""
+        request = self._make_request()
+        request.META.pop('HTTP_X_FORWARDED_FOR', None)
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+        self.assertEqual(get_client_ip(request), '127.0.0.1')
+
+    def test_no_ip_info_returns_default(self):
+        """IP 情報が一切ない場合はデフォルト値を返す"""
+        request = self._make_request()
+        request.META.pop('HTTP_X_FORWARDED_FOR', None)
+        request.META.pop('REMOTE_ADDR', None)
+        self.assertEqual(get_client_ip(request), '0.0.0.0')
+
+    def test_whitespace_handling(self):
+        """IP アドレスの前後の空白が除去される"""
+        request = self._make_request()
+        request.META['HTTP_X_FORWARDED_FOR'] = ' 203.0.113.1 , 10.128.0.1 '
+        self.assertEqual(get_client_ip(request), '203.0.113.1')
+
+    def test_empty_forwarded_for_falls_back(self):
+        """空の X-Forwarded-For は REMOTE_ADDR にフォールバック"""
+        request = self._make_request()
+        request.META['HTTP_X_FORWARDED_FOR'] = ''
+        request.META['REMOTE_ADDR'] = '192.168.1.1'
+        self.assertEqual(get_client_ip(request), '192.168.1.1')

--- a/app/ta_hub/utils.py
+++ b/app/ta_hub/utils.py
@@ -1,0 +1,28 @@
+"""ta_hub 共通ユーティリティ"""
+
+# X-Forwarded-For 内の最小 IP 数（クライアント + LB）
+_MIN_IPS_WITH_LB = 2
+
+
+def get_client_ip(request):
+    """Cloud Run 配下を考慮してクライアント IP を取得する。
+
+    Cloud Run では Google LB が X-Forwarded-For の末尾にクライアント IP を追加する。
+    構成: [ユーザー偽装IP, ..., クライアントIP, Google LB IP]
+
+    単一 IP の場合はそのまま返す。
+    2つ以上の場合は末尾から2番目（= LB が追加したクライアント IP）を返す。
+
+    Args:
+        request: Django の HttpRequest オブジェクト
+
+    Returns:
+        クライアント IP アドレス文字列
+    """
+    forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', '')
+    if forwarded_for:
+        ips = [ip.strip() for ip in forwarded_for.split(',')]
+        if len(ips) < _MIN_IPS_WITH_LB:
+            return ips[0]
+        return ips[-_MIN_IPS_WITH_LB]
+    return request.META.get('REMOTE_ADDR') or '0.0.0.0'


### PR DESCRIPTION
## Summary
- Cloud Run環境でGoogle LBが`X-Forwarded-For`の末尾にクライアントIPを追加するため、先頭IPを取得するとスプーフィング可能だった問題を修正
- 共通ユーティリティ `ta_hub.utils.get_client_ip()` を新規作成し、`community/views.py` と `event/views.py` の重複実装を統合（DRY改善）
- 単一IPはそのまま、2つ以上は末尾から2番目（LBが追加したクライアントIP）を返すロジックに変更

## Test plan
- [x] 単一IP → そのまま返す
- [x] 2つのIP（クライアント + LB） → 末尾から2番目を返す
- [x] 3つのIP（偽装 + クライアント + LB） → スプーフィングされたIPを無視して正しいIPを返す
- [x] REMOTE_ADDR フォールバック動作
- [x] `ta_hub.tests.test_utils` 8テストパス
- [x] `community.tests.test_community_report` 12テストパス

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)