### PR TITLE
Fix Twitter hashtag link generation in waiting_list.html

### DIFF
--- a/app/community/templates/community/waiting_list.html
+++ b/app/community/templates/community/waiting_list.html
@@ -90,7 +90,7 @@
                                     <p>
                                         <strong>Twitterハッシュタグ:</strong>
                                         {% for hashtag in community.twitter_hashtags %}
-                                            <a href="https://twitter.com/hashtag/{{ hashtag|slice:"1:" }}?f=live"
+                                            <a href="https://twitter.com/hashtag/{% if hashtag|slice:':1' == '#' %}{{ hashtag|slice:'1:' }}{% else %}{{ hashtag }}{% endif %}?f=live"
                                                target="_blank">{{ hashtag }}</a>{% if not forloop.last %}, {% endif %}
                                         {% endfor %}
                                     </p>


### PR DESCRIPTION
Fix Twitter hashtag link generation in waiting_list.html with initial hash sign detection

先頭にハッシュ記号があるときにだけ先頭の 1 文字を取り除くように修正しました。