### PR TITLE
fix: ハッシュタグの先頭文字トリミング問題を修正

### DIFF
--- a/app/community/models.py
+++ b/app/community/models.py
@@ -125,6 +125,20 @@ class Community(models.Model):
         return self.name
 
     @property
+    def hashtag_list(self):
+        """#付きハッシュタグのリストを返す（表示用）"""
+        if not self.twitter_hashtag:
+            return []
+        return [f'#{tag.strip()}' for tag in self.twitter_hashtag.split('#') if tag.strip()]
+
+    @property
+    def hashtag_names(self):
+        """#なしハッシュタグのリストを返す（URL用）"""
+        if not self.twitter_hashtag:
+            return []
+        return [tag.strip() for tag in self.twitter_hashtag.split('#') if tag.strip()]
+
+    @property
     def end_time(self):
         return (timezone.datetime.combine(timezone.datetime.today(), self.start_time) + timedelta(
             minutes=self.duration)).time()

--- a/app/community/templates/community/detail.html
+++ b/app/community/templates/community/detail.html
@@ -166,12 +166,12 @@
                                         <i class="bi bi-globe me-2"></i>VRChatグループに参加
                                     </a>
                                 {% endif %}
-                                {% if community.twitter_hashtag %}
-                                    <a href="https://twitter.com/hashtag/{{ community.twitter_hashtag|slice:"1:" }}?f=live"
+                                {% for name in community.hashtag_names %}
+                                    <a href="https://twitter.com/hashtag/{{ name }}?f=live"
                                        target="_blank" class="btn text-white" style="background-color: #1DA1F2;">
-                                        <i class="bi bi-hash me-1"></i>{{ community.twitter_hashtag|slice:"1:" }}
+                                        <i class="bi bi-hash me-1"></i>{{ name }}
                                     </a>
-                                {% endif %}
+                                {% endfor %}
                             </div>
                             {% if community.discord %}
                                 <div>

--- a/app/community/templates/community/waiting_list.html
+++ b/app/community/templates/community/waiting_list.html
@@ -86,12 +86,12 @@
                                                                     target="_blank">{{ community.get_sns_display }}</a>
                                     </p>
                                 {% endif %}
-                                {% if community.twitter_hashtags %}
+                                {% if community.hashtag_names %}
                                     <p>
                                         <strong>Twitterハッシュタグ:</strong>
-                                        {% for hashtag in community.twitter_hashtags %}
-                                            <a href="https://twitter.com/hashtag/{{ hashtag|slice:"1:" }}?f=live"
-                                               target="_blank">{{ hashtag }}</a>{% if not forloop.last %}, {% endif %}
+                                        {% for name in community.hashtag_names %}
+                                            <a href="https://twitter.com/hashtag/{{ name }}?f=live"
+                                               target="_blank">#{{ name }}</a>{% if not forloop.last %}, {% endif %}
                                         {% endfor %}
                                     </p>
                                 {% endif %}

--- a/app/community/tests/test_models.py
+++ b/app/community/tests/test_models.py
@@ -12,6 +12,65 @@ from community.models import Community
 CustomUser = get_user_model()
 
 
+class CommunityHashtagPropertyTestCase(TestCase):
+    """Community.hashtag_list / hashtag_names プロパティのテスト"""
+
+    def _make_community(self, twitter_hashtag=''):
+        return Community(
+            name='テスト集会',
+            frequency='毎週',
+            organizers='テスト主催者',
+            twitter_hashtag=twitter_hashtag,
+        )
+
+    def test_hashtag_list_empty_string(self):
+        """twitter_hashtagが空文字の場合、空リストを返す"""
+        c = self._make_community('')
+        self.assertEqual(c.hashtag_list, [])
+        self.assertEqual(c.hashtag_names, [])
+
+    def test_hashtag_list_single_tag_with_leading_hash(self):
+        """先頭#付き単一タグ: '#VRChat' -> ['#VRChat']"""
+        c = self._make_community('#VRChat')
+        self.assertEqual(c.hashtag_list, ['#VRChat'])
+        self.assertEqual(c.hashtag_names, ['VRChat'])
+
+    def test_hashtag_list_single_tag_without_leading_hash(self):
+        """先頭#なし単一タグ: 'VRChat' -> ['#VRChat']"""
+        c = self._make_community('VRChat')
+        self.assertEqual(c.hashtag_list, ['#VRChat'])
+        self.assertEqual(c.hashtag_names, ['VRChat'])
+
+    def test_hashtag_list_multiple_tags(self):
+        """複数タグ: '#VRChat#技術' -> ['#VRChat', '#技術']"""
+        c = self._make_community('#VRChat#技術')
+        self.assertEqual(c.hashtag_list, ['#VRChat', '#技術'])
+        self.assertEqual(c.hashtag_names, ['VRChat', '技術'])
+
+    def test_hashtag_list_multiple_tags_with_spaces(self):
+        """空白付き複数タグ: '#VRChat # 技術 ' -> ['#VRChat', '#技術']"""
+        c = self._make_community('#VRChat # 技術 ')
+        self.assertEqual(c.hashtag_list, ['#VRChat', '#技術'])
+        self.assertEqual(c.hashtag_names, ['VRChat', '技術'])
+
+    def test_hashtag_names_does_not_trim_first_char(self):
+        """先頭文字がトリミングされないことを確認（修正前のバグの再発防止）
+
+        修正前は slice:"1:" で先頭文字が無条件にトリミングされていた。
+        例: 'VRChat' -> 'RChat' になっていた。
+        """
+        c = self._make_community('VRChat')
+        self.assertEqual(c.hashtag_names, ['VRChat'])
+        self.assertNotEqual(c.hashtag_names, ['RChat'])
+
+    def test_hashtag_list_none_value(self):
+        """twitter_hashtagがNoneの場合（blank=True）、空リストを返す"""
+        c = self._make_community('')
+        c.twitter_hashtag = None
+        self.assertEqual(c.hashtag_list, [])
+        self.assertEqual(c.hashtag_names, [])
+
+
 class CommunitySaveMethodTestCase(TestCase):
     """Community.save()メソッドのテスト"""
 

--- a/app/community/views.py
+++ b/app/community/views.py
@@ -155,9 +155,6 @@ class CommunityDetailView(DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         community = context['community']
-        if community.twitter_hashtag:
-            community.twitter_hashtags = [f'#{tag.strip()}' for tag in community.twitter_hashtag.split('#') if
-                                          tag.strip()]
         community.join_type = get_join_type(community.organizer_url)
 
         now = timezone.now()
@@ -327,9 +324,6 @@ class WaitingCommunityListView(LoginRequiredMixin, UserPassesTestMixin, ListView
         context['form'] = form
         context['search_count'] = self.get_queryset().count()
         for community in context['communities']:
-            if community.twitter_hashtag:
-                community.twitter_hashtags = [f'#{tag.strip()}' for tag in community.twitter_hashtag.split('#') if
-                                              tag.strip()]
             community.join_type = get_join_type(community.organizer_url)
 
         # 曜日の選択肢をコンテキストに追加


### PR DESCRIPTION
## Summary

- テンプレートの `slice:"1:"` による先頭文字の無条件トリミングを廃止
- モデルプロパティ (`hashtag_list` / `hashtag_names`) に正規化ロジックを集約
- View 2箇所の重複コードを削除（DRY改善）
- `detail.html` の複数ハッシュタグ未対応も同時に修正

Supersedes #118 — PR #118 のテンプレート側対応をView/モデル層での根本対応に置き換え

## Test plan

- [x] `Community.hashtag_list` / `hashtag_names` プロパティのユニットテスト 7件追加・全パス
- [x] 既存テスト 11件 リグレッションなし
- [x] ブラウザで detail ページのハッシュタグリンク表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)