### PR TITLE
fix: group_id抽出がvrchat.com/events付きURLで誤動作する

### DIFF
--- a/app/api_v1/serializers.py
+++ b/app/api_v1/serializers.py
@@ -8,11 +8,23 @@ from event.models import Event, EventDetail, RecurrenceRule
 
 
 def _extract_group_id(group_url):
-    """group_url からグループIDを抽出する。"""
+    """group_url からVRChatグループIDを抽出する。
+
+    vrc.group: パス直下のコード（例: VRCTS.5197）
+    vrchat.com: grp_ で始まるセグメント（例: grp_ad1356bc-...）
+    """
     if not group_url:
         return None
-    path = urlparse(group_url).path.strip('/')
-    return path.split('/')[-1] if path else None
+    parsed = urlparse(group_url)
+    host = parsed.netloc.lower()
+    segments = [s for s in parsed.path.split('/') if s]
+    if not segments:
+        return None
+    if 'vrc.group' in host:
+        return segments[0]
+    if 'vrchat.com' in host:
+        return next((s for s in segments if s.startswith('grp_')), None)
+    return None
 
 
 class CommunitySerializer(serializers.ModelSerializer):

--- a/app/api_v1/tests/test_community_api.py
+++ b/app/api_v1/tests/test_community_api.py
@@ -125,3 +125,42 @@ class CommunityAPITest(TestCase):
         response = self.client.get(self.list_url)
         community = next(c for c in response.data if c['name'] == '技術集会A')
         self.assertTrue(community['allow_poster_repost'])
+
+    def test_group_id_from_vrchat_long_url(self):
+        """vrchat.com長URLからgrp_IDが抽出される"""
+        Community.objects.create(
+            name='長URL集会',
+            start_time=time(21, 0), duration=60, weekdays=['Wed'],
+            frequency='毎週', organizers='主催者Y',
+            group_url='https://vrchat.com/home/group/grp_ad1356bc-ae44-4483-8409-d0c69585b296',
+            tags=['tech'], status='approved',
+        )
+        response = self.client.get(self.list_url)
+        community = next(c for c in response.data if c['name'] == '長URL集会')
+        self.assertEqual(community['group_id'], 'grp_ad1356bc-ae44-4483-8409-d0c69585b296')
+
+    def test_group_id_from_vrchat_url_with_events_suffix(self):
+        """vrchat.com/events付きURLでもgrp_IDが正しく抽出される（参照: PR #137）"""
+        Community.objects.create(
+            name='events付きURL集会',
+            start_time=time(21, 0), duration=60, weekdays=['Thu'],
+            frequency='毎週', organizers='主催者Z',
+            group_url='https://vrchat.com/home/group/grp_fd884689-2a62-474d-af7c-86894644d0b3/events',
+            tags=['tech'], status='approved',
+        )
+        response = self.client.get(self.list_url)
+        community = next(c for c in response.data if c['name'] == 'events付きURL集会')
+        self.assertEqual(community['group_id'], 'grp_fd884689-2a62-474d-af7c-86894644d0b3')
+
+    def test_group_id_none_for_unknown_domain(self):
+        """未知ドメインのURLではgroup_idがnull"""
+        Community.objects.create(
+            name='未知ドメイン集会',
+            start_time=time(21, 0), duration=60, weekdays=['Fri'],
+            frequency='毎週', organizers='主催者W',
+            group_url='https://example.com/some/path',
+            tags=['tech'], status='approved',
+        )
+        response = self.client.get(self.list_url)
+        community = next(c for c in response.data if c['name'] == '未知ドメイン集会')
+        self.assertIsNone(community['group_id'])


### PR DESCRIPTION
## Summary

- `_extract_group_id` をドメイン別ロジックに変更
- `vrc.group`: パス直下のコード（例: `VRCTS.5197`）
- `vrchat.com`: `grp_` で始まるセグメントを探索（`/events` 等のサブパスを無視）
- その他ドメイン: `null`（セキュリティ対策）

## Test plan

- [x] vrc.group 短縮URL → コード抽出
- [x] vrchat.com 長URL → grp_ID 抽出
- [x] vrchat.com/events 付きURL → grp_ID 正しく抽出（バグ修正）
- [x] 未知ドメイン → null
- [x] 全14テスト通過

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)