### PR TITLE
feat: 参加状況・申請ページに日程表を追加

### DIFF
--- a/app/vket/templates/vket/apply.html
+++ b/app/vket/templates/vket/apply.html
@@ -134,6 +134,17 @@
                 </div>
             </div>
         </form>
+
+        {% if rows and slots %}
+            <div class="card shadow-sm mt-4">
+                <div class="card-body">
+                    <h2 class="h5 fw-bold mb-3">
+                        <i class="fas fa-table me-2"></i>日程表
+                    </h2>
+                    {% include 'vket/includes/schedule_table.html' with show_warnings=False show_legend=True %}
+                </div>
+            </div>
+        {% endif %}
     </div>
 
     <script>

--- a/app/vket/templates/vket/includes/schedule_table.html
+++ b/app/vket/templates/vket/includes/schedule_table.html
@@ -1,0 +1,138 @@
+<style>
+    .vket-slot {
+        width: 64px;
+        text-align: center;
+        white-space: nowrap;
+    }
+    .vket-cell {
+        width: 64px;
+        min-width: 64px;
+        height: 28px;
+        padding: 0 !important;
+        position: relative;
+    }
+    .vket-bar {
+        width: 100%;
+        height: 100%;
+        background: rgba(13, 110, 253, 0.35);
+    }
+    .vket-bar.requested {
+        background: rgba(13, 110, 253, 0.15);
+        background-image: repeating-linear-gradient(
+            45deg,
+            transparent,
+            transparent 4px,
+            rgba(13, 110, 253, 0.15) 4px,
+            rgba(13, 110, 253, 0.15) 8px
+        );
+    }
+    .vket-bar.overlap {
+        background: rgba(220, 53, 69, 0.35);
+        outline: 1px solid rgba(220, 53, 69, 0.55);
+    }
+    .vket-lt-dots {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        display: flex;
+        gap: 4px;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+    }
+    .vket-lt-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #212529;
+        box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9);
+    }
+    .vket-lt-dot.overlap {
+        box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9), 0 0 0 4px rgba(220, 53, 69, 0.85);
+    }
+    .vket-community-requested {
+        opacity: 0.65;
+    }
+</style>
+
+{% if rows and slots %}
+    <div class="table-responsive">
+        <table class="table table-sm table-bordered align-middle">
+            <thead class="table-light">
+            <tr>
+                <th style="min-width: 140px;">日付</th>
+                <th style="min-width: 220px;">集会名</th>
+                {% for slot in slots %}
+                    <th class="vket-slot">{{ slot.start|date:"H:i" }}</th>
+                {% endfor %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for row in rows %}
+                <tr>
+                    <td>{{ row.date|date:"n/j（D）" }}</td>
+                    <td class="{% if not row.is_confirmed %}vket-community-requested{% endif %}">
+                        <span class="fw-bold">{{ row.participation.community.name }}</span>
+                        {% if not row.is_confirmed %}
+                            <span class="badge bg-secondary ms-1" style="font-size: 0.7em;">申請中</span>
+                        {% endif %}
+                    </td>
+                    {% for cell in row.cells %}
+                        <td class="vket-cell">
+                            {% if cell.occupied %}
+                                <div class="vket-bar {% if cell.overlap %}overlap{% elif not row.is_confirmed %}requested{% endif %}"></div>
+                            {% endif %}
+                            {% if cell.lt_times %}
+                                <div class="vket-lt-dots" title="LT開始: {{ cell.lt_tooltip }}">
+                                    {% for t in cell.lt_times %}
+                                        <span class="vket-lt-dot {% if cell.lt_overlap %}overlap{% endif %}"></span>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </td>
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    {% if show_legend %}
+        <div class="d-flex flex-wrap gap-3 mt-2 small text-muted">
+            <div class="d-flex align-items-center gap-1">
+                <span style="display:inline-block;width:20px;height:12px;background:rgba(13,110,253,0.35);border-radius:2px;"></span> 確定
+            </div>
+            <div class="d-flex align-items-center gap-1">
+                <span style="display:inline-block;width:20px;height:12px;background:rgba(13,110,253,0.15);background-image:repeating-linear-gradient(45deg,transparent,transparent 4px,rgba(13,110,253,0.15) 4px,rgba(13,110,253,0.15) 8px);border-radius:2px;border:1px dashed rgba(13,110,253,0.3);"></span> 申請中（未確定）
+            </div>
+            <div class="d-flex align-items-center gap-1">
+                <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#212529;"></span> LT開始
+            </div>
+        </div>
+    {% endif %}
+
+    {% if overlap_warnings %}
+        <div class="alert alert-warning mt-3">
+            <div class="fw-bold mb-2"><i class="fas fa-exclamation-triangle me-1"></i>重複（開催時間）</div>
+            <ul class="mb-0">
+                {% for w in overlap_warnings %}
+                    <li>{{ w }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    {% if show_warnings and warnings %}
+        <div class="alert alert-warning mt-3">
+            <div class="fw-bold mb-2"><i class="fas fa-exclamation-triangle me-1"></i>警告</div>
+            <ul class="mb-0">
+                {% for w in warnings %}
+                    <li>{{ w }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+{% else %}
+    <p class="text-muted">日程がまだ登録されていません。</p>
+{% endif %}

--- a/app/vket/templates/vket/manage_schedule.html
+++ b/app/vket/templates/vket/manage_schedule.html
@@ -3,51 +3,6 @@
     <title>{{ collaboration.name }} 管理（日程表） - VRChat 技術・学術系イベントHub</title>
 {% endblock %}
 {% block main %}
-    <style>
-        .vket-slot {
-            width: 64px;
-            text-align: center;
-            white-space: nowrap;
-        }
-        .vket-cell {
-            width: 64px;
-            min-width: 64px;
-            height: 28px;
-            padding: 0 !important;
-            position: relative;
-        }
-        .vket-bar {
-            width: 100%;
-            height: 100%;
-            background: rgba(13, 110, 253, 0.35);
-        }
-        .vket-bar.overlap {
-            background: rgba(220, 53, 69, 0.35);
-            outline: 1px solid rgba(220, 53, 69, 0.55);
-        }
-        .vket-lt-dots {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            display: flex;
-            gap: 4px;
-            align-items: center;
-            justify-content: center;
-            pointer-events: none;
-        }
-        .vket-lt-dot {
-            width: 10px;
-            height: 10px;
-            border-radius: 50%;
-            background: #212529;
-            box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9);
-        }
-        .vket-lt-dot.overlap {
-            box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9), 0 0 0 4px rgba(220, 53, 69, 0.85);
-        }
-    </style>
-
     <div class="container my-4">
         {% include 'ta_hub/messages.html' %}
 
@@ -60,66 +15,6 @@
 
         {% include 'vket/includes/manage_tabs.html' with active_tab='schedule' %}
 
-        {% if rows and slots %}
-            <div class="table-responsive">
-                <table class="table table-sm table-bordered align-middle">
-                    <thead class="table-light">
-                    <tr>
-                        <th style="min-width: 140px;">日付</th>
-                        <th style="min-width: 220px;">集会名</th>
-                        {% for slot in slots %}
-                            <th class="vket-slot">{{ slot.start|date:"H:i" }}</th>
-                        {% endfor %}
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for row in rows %}
-                        <tr>
-                            <td>{{ row.date|date:"n/j（D）" }}</td>
-                            <td class="fw-bold">{{ row.participation.community.name }}</td>
-                            {% for cell in row.cells %}
-                                <td class="vket-cell">
-                                    {% if cell.occupied %}
-                                        <div class="vket-bar {% if cell.overlap %}overlap{% endif %}"></div>
-                                    {% endif %}
-                                    {% if cell.lt_times %}
-                                        <div class="vket-lt-dots" title="LT開始: {{ cell.lt_tooltip }}">
-                                            {% for t in cell.lt_times %}
-                                                <span class="vket-lt-dot {% if cell.lt_overlap %}overlap{% endif %}"></span>
-                                            {% endfor %}
-                                        </div>
-                                    {% endif %}
-                                </td>
-                            {% endfor %}
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-
-            {% if overlap_warnings %}
-                <div class="alert alert-warning mt-3">
-                    <div class="fw-bold mb-2">⚠️ 重複（開催時間）</div>
-                    <ul class="mb-0">
-                        {% for w in overlap_warnings %}
-                            <li>{{ w }}</li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            {% endif %}
-
-            {% if warnings %}
-                <div class="alert alert-warning mt-3">
-                    <div class="fw-bold mb-2">⚠️ 警告</div>
-                    <ul class="mb-0">
-                        {% for w in warnings %}
-                            <li>{{ w }}</li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            {% endif %}
-        {% else %}
-            <p class="text-muted">日程がまだ登録されていません。</p>
-        {% endif %}
+        {% include 'vket/includes/schedule_table.html' with show_warnings=True show_legend=False %}
     </div>
 {% endblock %}

--- a/app/vket/templates/vket/participation_status.html
+++ b/app/vket/templates/vket/participation_status.html
@@ -285,6 +285,18 @@
                 </div>
             </div>
 
+            {# 日程表 #}
+            {% if rows and slots %}
+                <div class="card shadow-sm mb-4">
+                    <div class="card-body">
+                        <h2 class="h5 fw-bold mb-3">
+                            <i class="fas fa-table me-2"></i>日程表
+                        </h2>
+                        {% include 'vket/includes/schedule_table.html' with show_warnings=False show_legend=True %}
+                    </div>
+                </div>
+            {% endif %}
+
             {# Vketステージ登録（登録済みは最下部に表示） #}
             {% if participation.stage_registered_at and participation.progress != 'applied' %}
                 <div class="card shadow-sm mb-4 border-success">

--- a/app/vket/views.py
+++ b/app/vket/views.py
@@ -111,6 +111,253 @@ def _shift_time(t: time, delta: timedelta) -> time:
     return dt.time()
 
 
+def _build_schedule_context(
+    collaboration: VketCollaboration,
+    *,
+    include_requested: bool = False,
+) -> dict:
+    """日程表のコンテキストデータを構築する。
+
+    Args:
+        collaboration: 対象コラボ
+        include_requested: True なら requested_* のみの参加も含める
+    """
+    from django.db.models import Q
+
+    empty = {'slots': [], 'rows': [], 'overlap_warnings': [], 'warnings': []}
+
+    # クエリ: confirmed があるもの + (オプション) requested のみのもの
+    q_confirmed = Q(confirmed_date__isnull=False, confirmed_start_time__isnull=False)
+    if include_requested:
+        q_requested = Q(requested_date__isnull=False, requested_start_time__isnull=False)
+        date_filter = q_confirmed | q_requested
+    else:
+        date_filter = q_confirmed
+
+    participations = list(
+        VketParticipation.objects.filter(
+            collaboration=collaboration,
+        )
+        .filter(date_filter)
+        .select_related('community', 'published_event')
+        .prefetch_related(
+            Prefetch(
+                'published_event__details',
+                queryset=EventDetail.objects.filter(
+                    detail_type='LT', status='approved'
+                ).only(
+                    'id', 'event_id', 'start_time', 'duration',
+                    'speaker', 'theme', 'status', 'detail_type',
+                ).order_by('start_time', 'id'),
+            )
+        )
+    )
+
+    if not participations:
+        return empty
+
+    # 各参加の「表示用」日程を決定（confirmed 優先、なければ requested）
+    effective_data: dict[int, dict] = {}
+    for p in participations:
+        is_confirmed = p.confirmed_date is not None and p.confirmed_start_time is not None
+        e_date = p.confirmed_date if is_confirmed else p.requested_date
+        e_start = p.confirmed_start_time if is_confirmed else p.requested_start_time
+        e_duration = (p.confirmed_duration if is_confirmed else p.requested_duration) or 60
+        effective_data[p.id] = {
+            'date': e_date,
+            'start_time': e_start,
+            'duration': e_duration,
+            'is_confirmed': is_confirmed,
+        }
+
+    # date でソート
+    participations.sort(key=lambda p: (
+        effective_data[p.id]['date'],
+        effective_data[p.id]['start_time'],
+        p.community.name,
+    ))
+
+    slot_minutes = 30
+
+    def to_minutes(t: time) -> int:
+        return t.hour * 60 + t.minute
+
+    day_minutes = 24 * 60
+    min_start = None
+    max_end = None
+    warnings: list[str] = []
+
+    lt_times_by_pid: dict[int, list[time]] = {}
+
+    for p in participations:
+        eff = effective_data[p.id]
+        p_date = eff['date']
+        p_start = eff['start_time']
+        p_duration = eff['duration']
+
+        start_min = to_minutes(p_start)
+        end_min = start_min + p_duration
+        if end_min > day_minutes:
+            warnings.append(
+                f'{p_date.strftime("%Y/%m/%d")} {p.community.name} の開催時間が日跨ぎのため、0:00で切り捨て表示します'
+            )
+            end_min = day_minutes
+
+        lt_times: list[time] = []
+        if p.published_event:
+            lt_details = list(p.published_event.details.all())
+            lt_times = [d.start_time for d in lt_details] if lt_details else []
+        if not lt_times:
+            lt_times = [p_start]
+        lt_times_by_pid[p.id] = lt_times
+
+        lt_mins = [to_minutes(t) for t in lt_times]
+        lt_min = min(lt_mins)
+        lt_end_max = max(min(m + slot_minutes, day_minutes) for m in lt_mins)
+
+        candidate_min = min(start_min, lt_min)
+        candidate_max = max(end_min, lt_end_max)
+        min_start = candidate_min if min_start is None else min(min_start, candidate_min)
+        max_end = candidate_max if max_end is None else max(max_end, candidate_max)
+
+    if min_start is None or max_end is None:
+        return {**empty, 'warnings': warnings}
+
+    min_start = (min_start // slot_minutes) * slot_minutes
+    max_end = ((max_end + slot_minutes - 1) // slot_minutes) * slot_minutes
+    max_end = min(max_end, day_minutes)
+
+    slots: list[Slot] = []
+    current = min_start
+    base = timezone.localdate()
+    while current < max_end:
+        s_dt = datetime.combine(base, time(hour=current // 60, minute=current % 60))
+        e_dt = s_dt + timedelta(minutes=slot_minutes)
+        slots.append(Slot(start=s_dt.time(), end=e_dt.time()))
+        current += slot_minutes
+
+    def slot_index_for(t: time) -> int | None:
+        delta = to_minutes(t) - min_start
+        if delta < 0:
+            return None
+        idx = delta // slot_minutes
+        if idx >= len(slots):
+            return None
+        return idx
+
+    # 日付×スロットごとの占有数
+    occupancy: dict[tuple, int] = {}
+    for p in participations:
+        eff = effective_data[p.id]
+        p_start = eff['start_time']
+        p_duration = eff['duration']
+        start_dt = datetime.combine(base, p_start)
+        end_dt = start_dt + timedelta(minutes=p_duration)
+        for idx, slot in enumerate(slots):
+            slot_start = datetime.combine(base, slot.start)
+            slot_end = datetime.combine(base, slot.end)
+            if slot_start < end_dt and slot_end > start_dt:
+                key = (eff['date'], idx)
+                occupancy[key] = occupancy.get(key, 0) + 1
+
+    rows = []
+    overlap_warnings: list[str] = []
+
+    lt_slots_by_pid: dict[int, dict[int, list[time]]] = {}
+    lt_slot_communities: dict[tuple, set[str]] = {}
+
+    for p in participations:
+        eff = effective_data[p.id]
+        p_date = eff['date']
+        p_start = eff['start_time']
+        p_duration = eff['duration']
+        lt_times = lt_times_by_pid[p.id]
+
+        event_start_dt = datetime.combine(base, p_start)
+        event_end_dt = event_start_dt + timedelta(minutes=p_duration)
+
+        for lt_time in lt_times:
+            idx = slot_index_for(lt_time)
+            if idx is None:
+                warnings.append(
+                    f'{p_date.strftime("%Y/%m/%d")} {p.community.name} のLT開始時刻（{lt_time.strftime("%H:%M")}）が表示範囲外です'
+                )
+                continue
+
+            lt_slots_by_pid.setdefault(p.id, {}).setdefault(idx, []).append(lt_time)
+            key = (p_date, idx)
+            lt_slot_communities.setdefault(key, set()).add(p.community.name)
+
+            lt_dt = datetime.combine(base, lt_time)
+            if not (event_start_dt <= lt_dt < event_end_dt):
+                end_time = event_start_dt + timedelta(minutes=p_duration)
+                warnings.append(
+                    f'{p_date.strftime("%Y/%m/%d")} {p.community.name} のLT開始時刻（{lt_time.strftime("%H:%M")}）が開催時間（{p_start.strftime("%H:%M")}〜{end_time.strftime("%H:%M")}）の範囲外です'
+                )
+
+    # 同日に重複する参加のペアワーニング
+    for d, group in groupby(participations, key=lambda p: effective_data[p.id]['date']):
+        parts_on_date = list(group)
+        for p1, p2 in combinations(parts_on_date, 2):
+            eff1, eff2 = effective_data[p1.id], effective_data[p2.id]
+            if _time_ranges_overlap(
+                eff1['start_time'], eff1['duration'],
+                eff2['start_time'], eff2['duration'],
+            ):
+                overlap_start = max(eff1['start_time'], eff2['start_time'])
+                overlap_warnings.append(
+                    f'{d.strftime("%Y/%m/%d")} {overlap_start.strftime("%H:%M")} {p1.community.name} と {p2.community.name} が重複'
+                )
+
+    for (d, idx), communities in sorted(
+        lt_slot_communities.items(), key=lambda x: (x[0][0], x[0][1])
+    ):
+        if len(communities) <= 1:
+            continue
+        warnings.append(
+            f'{d.strftime("%Y/%m/%d")} {slots[idx].start.strftime("%H:%M")} LT開始が重複: {", ".join(sorted(communities))}'
+        )
+
+    for p in participations:
+        eff = effective_data[p.id]
+        p_start = eff['start_time']
+        p_duration = eff['duration']
+        p_date = eff['date']
+        event_start = datetime.combine(base, p_start)
+        event_end = event_start + timedelta(minutes=p_duration)
+        lt_slots = lt_slots_by_pid.get(p.id, {})
+        cells = []
+        for idx, slot in enumerate(slots):
+            slot_start = datetime.combine(base, slot.start)
+            slot_end = datetime.combine(base, slot.end)
+            occupied = slot_start < event_end and slot_end > event_start
+            overlap = occupied and occupancy.get((p_date, idx), 0) > 1
+            lt_times_in_slot = sorted(lt_slots.get(idx, []))
+            lt_overlap = bool(lt_times_in_slot) and len(lt_slot_communities.get((p_date, idx), set())) > 1
+            lt_tooltip = ', '.join([t.strftime('%H:%M') for t in lt_times_in_slot]) if lt_times_in_slot else ''
+            cells.append({
+                'occupied': occupied,
+                'overlap': overlap,
+                'lt_times': lt_times_in_slot,
+                'lt_overlap': lt_overlap,
+                'lt_tooltip': lt_tooltip,
+            })
+        rows.append({
+            'participation': p,
+            'date': p_date,
+            'start_time': p_start,
+            'duration': p_duration,
+            'is_confirmed': eff['is_confirmed'],
+            'cells': cells,
+        })
+
+    return {
+        'slots': slots,
+        'rows': rows,
+        'overlap_warnings': overlap_warnings,
+        'warnings': warnings,
+    }
+
 
 
 class CollaborationListView(ListView):
@@ -262,6 +509,7 @@ class ApplyView(LoginRequiredMixin, View):
             initial=initial,
         )
         formset = self._build_formset(participation=participation, permissions=permissions)
+        schedule_ctx = _build_schedule_context(collaboration, include_requested=True)
         return render(
             request,
             self.template_name,
@@ -272,6 +520,7 @@ class ApplyView(LoginRequiredMixin, View):
                 'form': form,
                 'formset': formset,
                 'permissions': permissions,
+                **schedule_ctx,
             },
         )
 
@@ -311,6 +560,7 @@ class ApplyView(LoginRequiredMixin, View):
             self._disable_formset(formset)
 
         if not (form.is_valid() and formset.is_valid()):
+            schedule_ctx = _build_schedule_context(collaboration, include_requested=True)
             return render(
                 request,
                 self.template_name,
@@ -321,6 +571,7 @@ class ApplyView(LoginRequiredMixin, View):
                     'form': form,
                     'formset': formset,
                     'permissions': permissions,
+                    **schedule_ctx,
                 },
             )
 
@@ -697,232 +948,8 @@ class ManageScheduleView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         collaboration = get_object_or_404(VketCollaboration, pk=kwargs['pk'])
-
-        # confirmed_date+start_time がある参加を表示（公開同期前でも日程表に出す）
-        participations = list(
-            VketParticipation.objects.filter(
-                collaboration=collaboration,
-                confirmed_date__isnull=False,
-                confirmed_start_time__isnull=False,
-            )
-            .select_related('community', 'published_event')
-            .prefetch_related(
-                Prefetch(
-                    'published_event__details',
-                    queryset=EventDetail.objects.filter(
-                        detail_type='LT', status='approved'
-                    ).only(
-                        'id', 'event_id', 'start_time', 'duration',
-                        'speaker', 'theme', 'status', 'detail_type',
-                    ).order_by('start_time', 'id'),
-                )
-            )
-            .order_by(
-                'confirmed_date',
-                'confirmed_start_time',
-                'community__name',
-            )
-        )
-
-        empty_ctx = {
-            'collaboration': collaboration,
-            'slots': [],
-            'rows': [],
-            'overlap_warnings': [],
-            'warnings': [],
-        }
-
-        if not participations:
-            context.update(empty_ctx)
-            return context
-
-        slot_minutes = 30
-
-        def to_minutes(t: time) -> int:
-            return t.hour * 60 + t.minute
-
-        day_minutes = 24 * 60
-        min_start = None
-        max_end = None
-        warnings = []
-
-        # 各参加ごとの LT 開始時刻リスト（participation.id → list[time]）
-        lt_times_by_pid: dict[int, list[time]] = {}
-
-        for p in participations:
-            p_date = p.confirmed_date
-            p_start = p.confirmed_start_time
-            p_duration = p.confirmed_duration or 60
-
-            start_min = to_minutes(p_start)
-            end_min = start_min + p_duration
-            if end_min > day_minutes:
-                warnings.append(
-                    f'{p_date.strftime("%Y/%m/%d")} {p.community.name} の開催時間が日跨ぎのため、0:00で切り捨て表示します'
-                )
-                end_min = day_minutes
-
-            # LT 情報: published_event があればそこから取得
-            lt_times = []
-            if p.published_event:
-                lt_details = list(p.published_event.details.all())
-                lt_times = [d.start_time for d in lt_details] if lt_details else []
-            if not lt_times:
-                lt_times = [p_start]
-            lt_times_by_pid[p.id] = lt_times
-
-            lt_mins = [to_minutes(t) for t in lt_times]
-            lt_min = min(lt_mins)
-            lt_end_max = max(min(m + slot_minutes, day_minutes) for m in lt_mins)
-
-            candidate_min = min(start_min, lt_min)
-            candidate_max = max(end_min, lt_end_max)
-            min_start = candidate_min if min_start is None else min(min_start, candidate_min)
-            max_end = candidate_max if max_end is None else max(max_end, candidate_max)
-
-        if min_start is None or max_end is None:
-            context.update(empty_ctx | {'warnings': warnings})
-            return context
-
-        min_start = (min_start // slot_minutes) * slot_minutes
-        max_end = ((max_end + slot_minutes - 1) // slot_minutes) * slot_minutes
-        max_end = min(max_end, day_minutes)
-
-        slots: list[Slot] = []
-        current = min_start
-        base = timezone.localdate()
-        while current < max_end:
-            s_dt = datetime.combine(base, time(hour=current // 60, minute=current % 60))
-            e_dt = s_dt + timedelta(minutes=slot_minutes)
-            slots.append(Slot(start=s_dt.time(), end=e_dt.time()))
-            current += slot_minutes
-
-        def slot_index_for(t: time) -> int | None:
-            delta = to_minutes(t) - min_start
-            if delta < 0:
-                return None
-            idx = delta // slot_minutes
-            if idx >= len(slots):
-                return None
-            return idx
-
-        # 日付×スロットごとの占有数
-        occupancy: dict[tuple, int] = {}
-        for p in participations:
-            p_start = p.confirmed_start_time
-            p_duration = p.confirmed_duration or 60
-            start_dt = datetime.combine(base, p_start)
-            end_dt = start_dt + timedelta(minutes=p_duration)
-            for idx, slot in enumerate(slots):
-                slot_start = datetime.combine(base, slot.start)
-                slot_end = datetime.combine(base, slot.end)
-                if slot_start < end_dt and slot_end > start_dt:
-                    key = (p.confirmed_date, idx)
-                    occupancy[key] = occupancy.get(key, 0) + 1
-
-        rows = []
-        overlap_warnings = []
-
-        lt_slots_by_pid: dict[int, dict[int, list[time]]] = {}
-        lt_slot_communities: dict[tuple, set[str]] = {}
-
-        for p in participations:
-            p_date = p.confirmed_date
-            p_start = p.confirmed_start_time
-            p_duration = p.confirmed_duration or 60
-            lt_times = lt_times_by_pid[p.id]
-
-            event_start_dt = datetime.combine(base, p_start)
-            event_end_dt = event_start_dt + timedelta(minutes=p_duration)
-            invalid_lt_times = []
-
-            for lt_time in lt_times:
-                idx = slot_index_for(lt_time)
-                if idx is None:
-                    warnings.append(
-                        f'{p_date.strftime("%Y/%m/%d")} {p.community.name} のLT開始時刻（{lt_time.strftime("%H:%M")}）が表示範囲外です'
-                    )
-                    continue
-
-                lt_slots_by_pid.setdefault(p.id, {}).setdefault(idx, []).append(lt_time)
-                key = (p_date, idx)
-                lt_slot_communities.setdefault(key, set()).add(p.community.name)
-
-                lt_dt = datetime.combine(base, lt_time)
-                if not (event_start_dt <= lt_dt < event_end_dt):
-                    invalid_lt_times.append(lt_time)
-
-            if invalid_lt_times:
-                times_label = ', '.join(sorted({t.strftime('%H:%M') for t in invalid_lt_times}))
-                end_time = event_start_dt + timedelta(minutes=p_duration)
-                warnings.append(
-                    f'{p_date.strftime("%Y/%m/%d")} {p.community.name} のLT開始時刻（{times_label}）が開催時間（{p_start.strftime("%H:%M")}〜{end_time.strftime("%H:%M")}）の範囲外です'
-                )
-
-        # 同日に重複する参加のペアワーニング
-        for d, group in groupby(participations, key=lambda p: p.confirmed_date):
-            parts_on_date = list(group)
-            for p1, p2 in combinations(parts_on_date, 2):
-                if _time_ranges_overlap(
-                    p1.confirmed_start_time, p1.confirmed_duration or 60,
-                    p2.confirmed_start_time, p2.confirmed_duration or 60,
-                ):
-                    overlap_start = max(p1.confirmed_start_time, p2.confirmed_start_time)
-                    overlap_warnings.append(
-                        f'{d.strftime("%Y/%m/%d")} {overlap_start.strftime("%H:%M")} {p1.community.name} と {p2.community.name} が重複'
-                    )
-
-        for (d, idx), communities in sorted(
-            lt_slot_communities.items(), key=lambda x: (x[0][0], x[0][1])
-        ):
-            if len(communities) <= 1:
-                continue
-            warnings.append(
-                f'{d.strftime("%Y/%m/%d")} {slots[idx].start.strftime("%H:%M")} LT開始が重複: {", ".join(sorted(communities))}'
-            )
-
-        for p in participations:
-            p_start = p.confirmed_start_time
-            p_duration = p.confirmed_duration or 60
-            base_date = timezone.localdate()
-            event_start = datetime.combine(base_date, p_start)
-            event_end = event_start + timedelta(minutes=p_duration)
-            lt_slots = lt_slots_by_pid.get(p.id, {})
-            cells = []
-            for idx, slot in enumerate(slots):
-                slot_start = datetime.combine(base_date, slot.start)
-                slot_end = datetime.combine(base_date, slot.end)
-                occupied = slot_start < event_end and slot_end > event_start
-                overlap = occupied and occupancy.get((p.confirmed_date, idx), 0) > 1
-                lt_times = sorted(lt_slots.get(idx, []))
-                lt_overlap = bool(lt_times) and len(lt_slot_communities.get((p.confirmed_date, idx), set())) > 1
-                lt_tooltip = ', '.join([t.strftime('%H:%M') for t in lt_times]) if lt_times else ''
-                cells.append(
-                    {
-                        'occupied': occupied,
-                        'overlap': overlap,
-                        'lt_times': lt_times,
-                        'lt_overlap': lt_overlap,
-                        'lt_tooltip': lt_tooltip,
-                    }
-                )
-            rows.append({
-                'participation': p,
-                'date': p.confirmed_date,
-                'start_time': p_start,
-                'duration': p_duration,
-                'cells': cells,
-            })
-
-        context.update(
-            {
-                'collaboration': collaboration,
-                'slots': slots,
-                'rows': rows,
-                'overlap_warnings': overlap_warnings,
-                'warnings': warnings,
-            }
-        )
+        schedule_ctx = _build_schedule_context(collaboration, include_requested=False)
+        context.update({'collaboration': collaboration, **schedule_ctx})
         return context
 
 
@@ -1040,6 +1067,11 @@ class ParticipationStatusView(LoginRequiredMixin, View):
                 .order_by('start_time', 'id')
             )
 
+        # 日程表データ（承認済みメンバーなら閲覧可能）
+        schedule_ctx = {}
+        if membership:
+            schedule_ctx = _build_schedule_context(collaboration, include_requested=True)
+
         return render(
             request,
             self.template_name,
@@ -1054,6 +1086,7 @@ class ParticipationStatusView(LoginRequiredMixin, View):
                 'is_admin': _is_vket_admin(request.user),
                 'stage_url': stage_url,
                 'event_details': event_details,
+                **schedule_ctx,
             },
         )
 


### PR DESCRIPTION
## なぜこの変更が必要か

Vketコラボの参加者（集会主催者）は、他の集会がいつ開催予定かを確認する手段がなかった。
管理者のみが見られる日程表テーブルを、参加状況ページと申請ページにも表示することで、
主催者が日程を決める際に他の集会との重複を自分で確認できるようになる。

## 変更内容

- `ManageScheduleView` のスロット計算ロジック（約230行）を `_build_schedule_context()` ヘルパー関数に抽出
- `include_requested=True` で申請中（未確定）エントリも含められるパラメータを追加
- 共有パーシャルテンプレート `schedule_table.html` を作成し、管理画面・参加状況・申請ページで再利用
- 確定済み（青バー）と申請中（ストライプ柄 + 「申請中」バッジ）を色分け表示
- 凡例（確定/申請中/LT開始）を参加者向けページに表示

## 意思決定

### 採用アプローチ
- ヘルパー関数 + パーシャルテンプレートでDRY化。理由: 3ページで同じテーブルを使うため、ロジックとUIの両方を共有する必要があった

### 却下した代替案
- タブ方式で日程表を別ページ表示 → 却下: ユーザーが「ページ内セクションとして追加」を希望
- 日程表を上部に配置 → 却下: ユーザーが「一番下に移動」を指示

### トレードオフ
- 全参加者の日程が見える > プライバシー: コラボ参加者同士の日程共有はイベント運営上必要

## テスト

- [x] 既存91テスト全パス
- [x] 確定済みエントリ: 青バー表示を確認
- [x] 申請中エントリ: ストライプ柄 + 「申請中」バッジ表示を確認
- [x] 管理画面の日程表: パーシャル化後も従来通り動作を確認
- [x] 申請ページ: フォーム下に日程表カード表示を確認

Closes #136

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)