### PR TITLE
fix: waiting_list の group_url 表示崩れを修正

### DIFF
--- a/app/community/templates/community/waiting_list.html
+++ b/app/community/templates/community/waiting_list.html
@@ -62,7 +62,7 @@
                                 <p>
                                     {% if community.group_url %}
                                         <strong>VRChatグループ:</strong><a href="{{ community.group_url }}"
-                                                                           target="_blank">{{ community.group_url|slice:"18:" }}</a>
+                                                                           target="_blank">グループページ</a>
                                     {% endif %}
                                     {% if community.join_type == 'user_page' %}
                                         <strong>Join先:</strong><a href="{{ community.organizer_url }}"


### PR DESCRIPTION
## Summary

- `waiting_list.html` の `slice:"18:"` が `vrc.group` 短縮URLにしか対応しておらず、`vrchat.com` 正規URLの場合に `/home/group/grp_xxx` と壊れた表示になっていた
- リンクテキストをURL依存の `slice` から固定テキスト「グループページ」に変更
- `detail.html` の「VRChatグループに参加」ボタンと同じアプローチで統一

## Test plan

- [x] 短縮URL（`vrc.group/VRCTS.5197`）で「グループページ」と表示されることを確認
- [x] 正規URL（`vrchat.com/home/group/grp_xxx`）で「グループページ」と表示されることを確認
- [x] リンク先が正しい group_url を指していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)