### PR TITLE
feat: aboutページのスタッフ情報を更新

### DIFF
--- a/app/ta_hub/templates/ta_hub/about.html
+++ b/app/ta_hub/templates/ta_hub/about.html
@@ -184,14 +184,19 @@
 
                 <h2 class="mb-4 text-center">公式アカウント</h2>
                 <div class="row justify-content-center mb-5">
-                    <div class="col-6 col-md-3 text-center">
-                        <a href="https://x.com/vrc_ta_hub" class="text-primary" target="_blank"
-                           style="text-decoration: none;">
-                            <img src="https://gh-image-uploader.kaisha3.com/uploads/2026/03/e1eda72e4ae4-vrc_ta_hub_official.avif"
-                                 alt="技術・学術系イベントHub"
-                                 height="100" width="100"
-                                 class="rounded-circle object-fit-cover mb-2">
-                            <div>技術・学術系イベントHub</div>
+                    <div class="col-md-6">
+                        <a href="https://x.com/vrc_ta_hub" class="text-decoration-none" target="_blank">
+                            <div class="d-flex align-items-center bg-light rounded-4 p-3">
+                                <img src="https://gh-image-uploader.kaisha3.com/uploads/2026/03/e1eda72e4ae4-vrc_ta_hub_official.avif"
+                                     alt="技術・学術系イベントHub"
+                                     height="80" width="80"
+                                     class="rounded-circle object-fit-cover flex-shrink-0">
+                                <div class="ms-3">
+                                    <div class="fw-bold text-dark">技術・学術系イベントHub</div>
+                                    <div class="text-muted small">@vrc_ta_hub</div>
+                                    <div class="text-secondary mt-1" style="font-size: 0.875rem;">最新のイベント情報はXでお届けしています</div>
+                                </div>
+                            </div>
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

- スタッフ全員に肩書きを追加（アセット制作者、スタッフ、広報担当、撮影担当）
- えーさん（技術担当）を新規追加
- くままぬい（セキュリティーエンジニア）を新規追加
- 新規メンバーの画像はR2にAVIF形式で保存

## Test plan

- [ ] http://localhost:8015/about/ でスタッフセクションに6名が表示されること
- [ ] 各スタッフの肩書きが名前の下に表示されること
- [ ] えーさん・くままぬいのアバター画像がR2から正しく表示されること
- [ ] 各メンバーのXリンクが正しく遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)