### PR TITLE
fix: gathering-list schema生成エラーを修正

### DIFF
--- a/app/api_v1/serializers.py
+++ b/app/api_v1/serializers.py
@@ -50,7 +50,7 @@ class CommunitySerializer(serializers.ModelSerializer):
         return _extract_group_id(obj.group_url)
 
 
-class GatheringListSerializer(serializers.BaseSerializer):
+class GatheringListSerializer(serializers.Serializer):
     """TaAGatheringListSys 向けの JSON 形式に変換する。"""
 
     GENRE_LABELS = {
@@ -68,6 +68,31 @@ class GatheringListSerializer(serializers.BaseSerializer):
         'Sat': 6,
         'Other': 7,
     }
+    FIELD_DEFINITIONS = (
+        ('ジャンル', serializers.CharField),
+        ('曜日', serializers.CharField),
+        ('イベント名', serializers.CharField),
+        ('開始時刻', serializers.CharField),
+        ('開催周期', serializers.CharField),
+        ('主催・副主催', serializers.CharField),
+        ('Join先', serializers.CharField),
+        ('グループID', serializers.CharField),
+        ('Discord', serializers.CharField),
+        ('Twitter', serializers.CharField),
+        ('ハッシュタグ', serializers.CharField),
+        ('ポスター', serializers.URLField),
+        ('イベント紹介', serializers.CharField),
+        ('ポスター転載可', serializers.BooleanField),
+    )
+
+    def get_fields(self):
+        fields = {}
+        for field_name, field_class in self.FIELD_DEFINITIONS:
+            field_kwargs = {'allow_null': True}
+            if field_class is serializers.CharField:
+                field_kwargs['allow_blank'] = True
+            fields[field_name] = field_class(**field_kwargs)
+        return fields
 
     @classmethod
     def normalize_choice_list(cls, value):

--- a/app/api_v1/tests/test_schema_api.py
+++ b/app/api_v1/tests/test_schema_api.py
@@ -1,0 +1,24 @@
+import json
+
+from django.test import TestCase
+from django.urls import reverse
+
+
+class SchemaAPITest(TestCase):
+    def test_schema_endpoint_includes_gathering_list_response_schema(self):
+        response = self.client.get(f"{reverse('schema')}?format=json")
+
+        self.assertEqual(response.status_code, 200)
+
+        payload = json.loads(response.content)
+        response_schema = payload['paths']['/api/v1/community/gathering-list/']['get']['responses']['200']
+        item_schema = response_schema['content']['application/json']['schema']['items']
+        self.assertEqual(item_schema['$ref'], '#/components/schemas/GatheringList')
+
+        gathering_list_schema = payload['components']['schemas']['GatheringList']
+        properties = gathering_list_schema['properties']
+
+        self.assertEqual(gathering_list_schema['type'], 'object')
+        self.assertIn('ジャンル', properties)
+        self.assertIn('ポスター転載可', properties)
+        self.assertEqual(properties['ポスター転載可']['type'], 'boolean')

--- a/docs/notes/how/drf-spectacular.md
+++ b/docs/notes/how/drf-spectacular.md
@@ -1,0 +1,6 @@
+# DRF Spectacular パターン
+
+## `BaseSerializer` を schema の response にそのまま渡さない
+- 問題: `drf-spectacular` は serializer schema 生成時に `.fields` を参照するため、`BaseSerializer` を `extend_schema(responses=...)` に渡すと `AttributeError` で `/api/schema/` が 500 になることがある
+- 解決: 実レスポンス変換が `to_representation()` 中心でも、schema に出す serializer は `serializers.Serializer` を使い、`get_fields()` などで OpenAPI 用フィールド定義を持たせる
+- 教訓: 実レスポンス用ロジックと OpenAPI 定義を別々に持つと乖離しやすいので、可能なら同じ serializer クラス内で両方を管理する

--- a/docs/notes/index.md
+++ b/docs/notes/index.md
@@ -5,12 +5,19 @@
 | ファイル | 概要 |
 |----------|------|
 | cloud-run.md | Cloud Run 運用パターン |
+| drf-spectacular.md | DRF Spectacular パターン |
 | django-pagination.md | Djangoページネーション入力検証パターン |
 | discord-auth.md | Discord OAuth 競合解消パターン |
 | github-pages-json.md | VRChatワールド向けJSON配信（toGithubPagesJson） |
 | vket-collab.md | Vketコラボ運営パターン |
 
 ## logs/
+
+### 2026-04/
+
+| ファイル | 日付 | 概要 |
+|----------|------|------|
+| drf-spectacular-01.md | 04-01 | GatheringListSerializer の schema 生成エラー修正 |
 
 ### 2026-03/
 

--- a/docs/notes/logs/2026-04/drf-spectacular-01.md
+++ b/docs/notes/logs/2026-04/drf-spectacular-01.md
@@ -1,0 +1,7 @@
+## GatheringListSerializer の schema 生成エラー修正
+- 日付: 2026-04-01
+- 関連: #150
+- 状況: `GatheringListSerializer` を使った `/api/v1/community/gathering-list/` の OpenAPI schema を生成していた
+- 問題: `GatheringListSerializer` が `BaseSerializer` だったため、drf-spectacular が `.fields` を読めず `AttributeError` で `/api/schema/` が 500 になった
+- 対応: `GatheringListSerializer` を `Serializer` ベースに変更し、`get_fields()` で schema 用フィールド定義を追加した。加えて `/api/schema/?format=json` に `GatheringList` schema が含まれるテストを追加した
+- → how/drf-spectacular.md に知識として追記済み


### PR DESCRIPTION
## なぜこの変更が必要か

`/api/schema/` の OpenAPI 生成時に `GatheringListSerializer` が `.fields` を持たない `BaseSerializer` だったため、drf-spectacular が `AttributeError` を起こしていました。Swagger / Redoc の参照や schema 配布が 500 になり、API 利用者と開発者の両方が仕様を確認できない状態だったため修正が必要です。

## 変更内容

- `GatheringListSerializer` を drf-spectacular が解決できる `Serializer` に変更し、schema 用フィールド定義を追加
- `to_representation()` は維持し、TaAGatheringListSys 向けの既存 JSON 形式は変更しないまま schema 生成だけを修正
- `/api/schema/` に gathering-list の schema が含まれることを確認する再発防止テストを追加

## 意思決定

### 採用アプローチ
- `GatheringListSerializer` 自体を `Serializer` に寄せる方式を採用。理由: 実レスポンスと OpenAPI 定義を同じクラスで管理でき、`extend_schema` 側だけを特殊対応するより追跡しやすく、今後の差分でも乖離しにくいため

### 却下した代替案
- `extend_schema` に別の inline serializer や生の OpenAPI schema を渡す案 → 却下: 実レスポンスの変換ロジックと schema 定義が分離され、フォーマット変更時に片方だけ更新漏れするリスクがあるため

## テスト

- `docker run --rm --env-file /Users/ms25/project/vrc-ta-hub/.env.local -e DEFAULT_GENERATE_MONTHS=1 -e DEBUG=True -e PYTHONPATH=/app -v /Users/ms25/worktrees/vrc-ta-hub/app:/app -v /Users/ms25/worktrees/vrc-ta-hub/docs:/docs --network my_network vrc-ta-hub-vrc-ta-hub python manage.py test api_v1.tests`
- `docker run --rm --env-file /Users/ms25/project/vrc-ta-hub/.env.local -e DEFAULT_GENERATE_MONTHS=1 -e DEBUG=True -e PYTHONPATH=/app -v /Users/ms25/worktrees/vrc-ta-hub/app:/app -v /Users/ms25/worktrees/vrc-ta-hub/docs:/docs --network my_network vrc-ta-hub-vrc-ta-hub python manage.py spectacular --format openapi-json`

---
このPRはfix-flowによる自動修正です。