### PR TITLE
fix: ツイート生成をOpenRouter+Geminiに移行し、Vketコラボ画像の表示改善

### DIFF
--- a/app/ta_hub/templates/ta_hub/index.html
+++ b/app/ta_hub/templates/ta_hub/index.html
@@ -611,7 +611,7 @@
                                             <img src="{{ achievement.image }}"
                                                  class="card-img-top"
                                                  alt="{{ achievement.title }}"
-                                                 style="height: 230px; object-fit: cover;">
+                                                 style="height: 320px; object-fit: cover;">
                                         </div>
                                     {% endif %}
                                     <div class="card-body">

--- a/app/twitter/utils.py
+++ b/app/twitter/utils.py
@@ -1,16 +1,14 @@
 import logging
+import os
 from typing import Optional
 from urllib.parse import urlencode
 
-from django.conf import settings
 from openai import OpenAI
 
 from event.models import Event
 from twitter.models import TwitterTemplate
 
 logger = logging.getLogger(__name__)
-# OpenAI API の設定
-client = OpenAI(api_key=settings.OPENAI_API_KEY)
 
 
 def format_event_info(event):
@@ -30,7 +28,7 @@ def format_event_info(event):
 
 
 def generate_tweet(template, event_info):
-    """OpenAI APIを使用してツイートを生成する"""
+    """OpenRouter API経由でツイートを生成する"""
     prompt = f"""
     過去のツイートのフォーマットに合わせて、イベントの告知ツイートを作成してください。
     テンプレートのスタイルを模倣しつつ、与えられたイベント情報を自然に組み込んでください。
@@ -49,15 +47,32 @@ def generate_tweet(template, event_info):
     ツイートのみを出力し、追加の説明は不要です。
     """
 
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        logger.error("OPENROUTER_API_KEY environment variable is not set")
+        return None
+
+    model = os.environ.get('GEMINI_MODEL', 'google/gemini-3.1-flash-lite-preview')
+    if ':' in model:
+        model = model.split(':')[0]
+
     try:
+        client = OpenAI(
+            base_url="https://openrouter.ai/api/v1",
+            api_key=api_key,
+        )
         response = client.chat.completions.create(
-            model="gpt-4o-mini",
+            extra_headers={
+                "HTTP-Referer": "https://vrc-ta-hub.com/",
+                "X-Title": "VRC TA Hub",
+            },
+            model=model,
             messages=[
                 {"role": "system", "content": "あなたはイベント告知ツイートを作成する専門家です。"},
                 {"role": "user", "content": prompt}
             ],
             temperature=0.7,
-            max_tokens=280
+            max_tokens=280,
         )
         return response.choices[0].message.content.strip()
     except Exception as e:

--- a/app/website/settings.py
+++ b/app/website/settings.py
@@ -317,10 +317,6 @@ assert GEMINI_API_KEY is not None, 'Please set GEMINI_API_KEY'
 GEMINI_MODEL = os.environ.get('GEMINI_MODEL', 'google/gemini-2.5-flash-lite-preview-06-17')
 _settings_logger.info('GEMINI_MODEL: %s', GEMINI_MODEL)
 
-# OpenAI API
-OPENAI_API_KEY = os.environ.get('OPENAI_API_KEY')
-assert OPENAI_API_KEY is not None, 'Please set OPENAI_API_KEY'
-
 REQUEST_TOKEN = os.environ.get('REQUEST_TOKEN')
 assert REQUEST_TOKEN is not None, 'Please set REQUEST_TOKEN'
 


### PR DESCRIPTION
## なぜこの変更が必要か

ユーザーからテンプレートからツイート文面が生成されないバグが報告された。原因はtwitter appがOpenAI GPT-4o-miniを使用しており、APIキーのクォータが切れていたため。また、トップページのVketコラボセクションの画像が上下に大きく切れすぎて見栄えが悪い問題があった。

## 変更内容

- `twitter/utils.py`: OpenAI API → OpenRouter + Gemini に切り替え（他機能と統一）
- `website/settings.py`: 不要になった `OPENAI_API_KEY` のassertを削除
- `index.html`: Vketコラボカード画像の高さを230px→320pxに拡大

## 意思決定

### 採用アプローチ
- OpenRouter + Gemini に統一。理由: 他機能（ブログ生成等）と同じパターンで、OpenAI APIキーへの依存を排除できる

### 却下した代替案
- OpenAI にクレジットチャージ → 却下: 他機能は既にOpenRouterで統一済みで、APIキーの二重管理になる

## テスト

- [x] twitter アプリのテスト全13件パス
- [x] ツイート生成の動作確認（Docker内でAPI呼び出し成功）
- [x] ブラウザでポストプレビュー画面にテキスト表示を確認（スクリーンショット取得済み）
- [x] Vketコラボ画像の表示をスクリーンショットで確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)