### PR TITLE
fix: aboutページのスタッフ名表記を統一

### DIFF
--- a/app/ta_hub/templates/ta_hub/about.html
+++ b/app/ta_hub/templates/ta_hub/about.html
@@ -140,10 +140,10 @@
                         <a href="https://x.com/kimkim0106_3218" class="text-primary" target="_blank"
                            style="text-decoration: none;">
                             <img src="https://pbs.twimg.com/profile_images/1642121096106496000/SBpdEBag_400x400.jpg"
-                                 alt="kimkimさん"
+                                 alt="kimkim0106"
                                  height="100" width="100"
                                  class="rounded-circle object-fit-cover mb-2">
-                            <div>kimkimさん</div>
+                            <div>kimkim0106</div>
                             <small class="text-muted">広報担当</small>
                         </a>
                     </div>
@@ -151,10 +151,10 @@
                         <a href="https://x.com/MadaoVeryPoor" class="text-primary" target="_blank"
                            style="text-decoration: none;">
                             <img src="https://pbs.twimg.com/profile_images/1984045911878905856/7AIZXUqz_400x400.jpg"
-                                 alt="madaoさん"
+                                 alt="madao"
                                  height="100" width="100"
                                  class="rounded-circle object-fit-cover mb-2">
-                            <div>madaoさん</div>
+                            <div>madao</div>
                             <small class="text-muted">撮影担当</small>
                         </a>
                     </div>
@@ -162,10 +162,10 @@
                         <a href="https://x.com/a1678991" class="text-primary" target="_blank"
                            style="text-decoration: none;">
                             <img src="https://gh-image-uploader.kaisha3.com/uploads/2026/03/1a8869c17588-esan_staff.avif"
-                                 alt="えーさん"
+                                 alt="えー"
                                  height="100" width="100"
                                  class="rounded-circle object-fit-cover mb-2">
-                            <div>えーさん</div>
+                            <div>えー</div>
                             <small class="text-muted">技術担当</small>
                         </a>
                     </div>


### PR DESCRIPTION
## Summary

- スタッフ名の「さん」付きを統一して全員さんなしに変更
- kimkim → kimkim0106 に名前変更

## Test plan

- [x] aboutページのスタッフセクションで名前が正しく表示される
- [x] 既存テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)