### PR TITLE
fix: テスト環境で X API への実投稿を防止するガード追加

### DIFF
--- a/app/twitter/tests/test_x_api_guard.py
+++ b/app/twitter/tests/test_x_api_guard.py
@@ -1,0 +1,24 @@
+"""X API テスト環境ガードのテスト
+
+settings.TESTING=True の場合、post_tweet / upload_media が
+実際の X API を呼ばずに None を返すことを確認する。
+"""
+
+from django.test import TestCase, override_settings
+
+from twitter.x_api import post_tweet, upload_media
+
+
+@override_settings(TESTING=True)
+class XApiTestGuardTest(TestCase):
+    """テスト環境での X API ガードテスト"""
+
+    def test_post_tweet_blocked_in_test_environment(self):
+        """TESTING=True の場合、post_tweet は None を返す"""
+        result = post_tweet("テスト投稿")
+        self.assertIsNone(result)
+
+    def test_upload_media_blocked_in_test_environment(self):
+        """TESTING=True の場合、upload_media は None を返す"""
+        result = upload_media("https://data.vrc-ta-hub.com/test.png")
+        self.assertIsNone(result)

--- a/app/twitter/x_api.py
+++ b/app/twitter/x_api.py
@@ -59,6 +59,11 @@ def upload_media(image_url: str) -> str | None:
         成功時: media_id 文字列
         失敗時: None
     """
+    from django.conf import settings
+    if getattr(settings, 'TESTING', False):
+        logger.warning("Blocked X API media upload in test environment")
+        return None
+
     auth = _get_oauth1()
     if not auth:
         return None
@@ -112,6 +117,11 @@ def post_tweet(text: str, media_ids: list[str] | None = None) -> dict | None:
         成功時: {"id": "...", "text": "..."} の dict
         失敗時: None
     """
+    from django.conf import settings
+    if getattr(settings, 'TESTING', False):
+        logger.warning("Blocked X API tweet post in test environment")
+        return None
+
     if not text or len(text) > MAX_TWEET_LENGTH:
         logger.error(
             "Tweet text is empty or exceeds %d characters: %d",


### PR DESCRIPTION
## Summary

- `post_tweet()` と `upload_media()` の先頭に `settings.TESTING` チェックを追加
- テスト実行時にモック漏れがあっても本番 X アカウントに誤投稿されなくなる

## Test plan

- [x] `TESTING=True` で `post_tweet()` が None を返す
- [x] `TESTING=True` で `upload_media()` が None を返す
- [x] 既存テスト121件全パス

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)