### PR TITLE
fix: APIのポスター画像をオリジナルURLで返すように修正

### DIFF
--- a/app/api_v1/serializers.py
+++ b/app/api_v1/serializers.py
@@ -5,7 +5,6 @@ from rest_framework import serializers
 
 from community.models import Community, WEEKDAY_CHOICES
 from event.models import Event, EventDetail, RecurrenceRule
-from ta_hub.libs import cloudflare_image_url
 
 
 def _extract_group_id(group_url):
@@ -44,7 +43,7 @@ class CommunitySerializer(serializers.ModelSerializer):
 
     def get_poster_image(self, obj):
         if obj.poster_image:
-            return cloudflare_image_url(obj.poster_image.url, width=800)
+            return obj.poster_image.url
         return None
 
     def get_group_id(self, obj):


### PR DESCRIPTION
## Summary

- Cloudflare Image Resizing導入(#165)により、API経由のポスター画像も`width=800`にリサイズされるようになった
- VRChatワールド内のポスター設置用途では解像度が不足するため、APIではオリジナル画像URLを返すように修正
- Web側のテンプレートは`cf_resize`フィルタで独自にリサイズしているため影響なし

## 変更内容

- `CommunitySerializer.get_poster_image()`: `cloudflare_image_url(url, width=800)` → `obj.poster_image.url`（オリジナルURL）
- 不要になった`cloudflare_image_url` importを削除

## Test plan

- [x] `api_v1` の全33テストがパス
- [x] APIレスポンスでオリジナルURL（`/cdn-cgi/image/`なし）が返ることを確認
- [x] Web側テンプレートの画像表示に影響がないことを確認（テンプレートはAPIを使わず直接`cf_resize`フィルタを使用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)