### PR TITLE
fix: post_saveシグナルの例外防御とツイート一覧リンク追加

### DIFF
--- a/app/twitter/signals.py
+++ b/app/twitter/signals.py
@@ -124,7 +124,15 @@ def queue_new_community_tweet(sender, instance, created, **kwargs):
 
     pending -> approved への遷移時のみトリガーされる。
     同一 community の重複キューは作成しない。
+    ツイートキューは補助機能のため、失敗しても本体の保存処理に影響させない。
     """
+    try:
+        _queue_new_community_tweet(instance, created)
+    except Exception:
+        logger.exception("Failed to queue new community tweet for %s", instance.pk)
+
+
+def _queue_new_community_tweet(instance, created):
     # 遅延インポートで循環インポートを回避
     from twitter.models import TweetQueue
 
@@ -165,7 +173,17 @@ def queue_new_community_tweet(sender, instance, created, **kwargs):
 def queue_slide_share_tweet(sender, instance, created, **kwargs):
     """スライド/記事が初めてアップロードされた時にツイートキューに追加する。
 
-    以下の条件をすべて満たす場合にキューを追加する:
+    ツイートキューは補助機能のため、失敗しても本体の保存処理に影響させない。
+    """
+    try:
+        _queue_slide_share_tweet(instance, created)
+    except Exception:
+        logger.exception("Failed to queue slide share tweet for EventDetail %s", instance.pk)
+
+
+def _queue_slide_share_tweet(instance, created):
+    """以下の条件をすべて満たす場合にキューを追加する:
+
     - slide_url, youtube_url, slide_file のいずれかが初めて設定された
     - status が approved（承認済み）
     - event.date が過去（発表日が終わっている）
@@ -228,7 +246,17 @@ def queue_slide_share_tweet(sender, instance, created, **kwargs):
 def queue_event_detail_tweet(sender, instance, created, **kwargs):
     """LT/特別回の EventDetail が承認された時にツイートキューに追加する。
 
-    以下の場合にキューを追加する:
+    ツイートキューは補助機能のため、失敗しても本体の保存処理に影響させない。
+    """
+    try:
+        _queue_event_detail_tweet(instance, created)
+    except Exception:
+        logger.exception("Failed to queue event detail tweet for EventDetail %s", instance.pk)
+
+
+def _queue_event_detail_tweet(instance, created):
+    """以下の場合にキューを追加する:
+
     - 新規作成 (created=True) かつ status='approved'
     - 既存更新で _old_status != 'approved' から status='approved' に遷移
 

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -1544,3 +1544,69 @@ class SlideShareSignalTest(AutoTweetTestBase):
         self.assertEqual(TweetQueue.objects.count(), 1)
         queue = TweetQueue.objects.first()
         self.assertEqual(queue.tweet_type, "slide_share")
+
+
+class SignalErrorHandlingTest(AutoTweetTestBase):
+    """シグナルハンドラの例外がメインの保存処理を妨げないことをテスト。
+
+    参照: PR #TBD - tweet_queue テーブル未作成時に EventDetail 保存が
+    500 エラーになるインシデントの再発防止テスト。
+    """
+
+    def setUp(self):
+        super().setUp()
+        # community を approved にしておく
+        with patch("twitter.signals.threading.Thread") as mock_thread_cls:
+            mock_thread_cls.return_value = MagicMock()
+            self.community.status = "approved"
+            self.community.save()
+        TweetQueue.objects.all().delete()
+
+    @patch("twitter.signals._queue_new_community_tweet", side_effect=Exception("DB error"))
+    def test_community_save_succeeds_on_signal_error(self, mock_queue):
+        """シグナルが例外を投げても Community の保存は成功する"""
+        new_community = Community.objects.create(
+            name="Signal Error Test",
+            start_time=datetime.time(21, 0),
+            duration=60,
+            weekdays=["Tue"],
+            frequency="毎週",
+            organizers="Test",
+            description="テスト",
+            platform="All",
+            status="approved",
+        )
+        # 保存が成功していることを確認
+        self.assertTrue(Community.objects.filter(pk=new_community.pk).exists())
+
+    @patch("twitter.signals._queue_event_detail_tweet", side_effect=Exception("DB error"))
+    def test_event_detail_save_succeeds_on_signal_error(self, mock_queue):
+        """シグナルが例外を投げても EventDetail の保存は成功する"""
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type="LT",
+            status="approved",
+            speaker="テスト太郎",
+            theme="テスト発表",
+            start_time=datetime.time(22, 15),
+        )
+        # 保存が成功していることを確認
+        self.assertTrue(EventDetail.objects.filter(pk=detail.pk).exists())
+
+    @patch("twitter.signals._queue_slide_share_tweet", side_effect=Exception("DB error"))
+    def test_event_detail_update_succeeds_on_signal_error(self, mock_queue):
+        """シグナルが例外を投げても EventDetail の更新は成功する"""
+        with patch("twitter.signals.threading.Thread") as mock_thread_cls:
+            mock_thread_cls.return_value = MagicMock()
+            detail = EventDetail.objects.create(
+                event=self.event,
+                detail_type="LT",
+                status="approved",
+                speaker="テスト太郎",
+                theme="テスト発表",
+                start_time=datetime.time(22, 15),
+            )
+        detail.theme = "更新された発表"
+        detail.save()
+        detail.refresh_from_db()
+        self.assertEqual(detail.theme, "更新された発表")

--- a/app/user_account/templates/account/settings.html
+++ b/app/user_account/templates/account/settings.html
@@ -124,6 +124,12 @@
                                     </span>
                                     <i class="fa-solid fa-chevron-right text-muted"></i>
                                 </a>
+                                <a href="{% url 'twitter:tweet_queue_list' %}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                                    <span>
+                                        <i class="fa-brands fa-x-twitter me-2"></i>ツイート一覧
+                                    </span>
+                                    <i class="fa-solid fa-chevron-right text-muted"></i>
+                                </a>
                             </div>
                         {% endif %}
 


### PR DESCRIPTION
## なぜこの変更が必要か

2026-04-05 06:07 JST に、LTイベント作成時に `tweet_queue` テーブルが本番DBに存在しないため
`post_save` シグナル（`queue_event_detail_tweet`）で500エラーが発生した。
EventDetail のデータ自体は正常に保存されていたが、シグナルの例外がそのまま伝播してユーザーに500が返っていた。

ツイートキューは補助機能であり、失敗してもメインの保存処理を妨げるべきではない。

## 変更内容

- `twitter/signals.py`: 3つの `post_save` シグナルハンドラ（`queue_new_community_tweet`, `queue_slide_share_tweet`, `queue_event_detail_tweet`）に try/except ラッパーを追加。例外発生時は `logger.exception` でログに記録し、本体の保存処理は正常完了させる
- `account/settings.html`: アカウント設定ページにツイート一覧へのリンクを追加（スタッフ権限以上で表示）
- 再発防止テスト3件追加（シグナル例外時にCommunity/EventDetailの保存が成功することを検証）

## 意思決定

### 採用アプローチ
- try/except ラッパー + 内部関数分離を採用。理由: テーブル不存在に限らず、DB接続タイムアウトやその他の例外もカバーできる汎用的な防御

### 却下した代替案
- テーブル存在チェック (`_tweet_queue_table_exists`) → 却下: 特定の障害パターンしかカバーできない

## テスト

- [x] `twitter` アプリ全125テストパス
- [x] 新規テスト3件: シグナル例外時にCommunity/EventDetailの保存が500にならないことを確認
- [x] スタッフユーザーでツイート一覧リンク表示を確認（スクリーンショット）
- [x] 一般ユーザーでリンク非表示を確認（スクリーンショット）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)