### PR TITLE
fix: ツイート文字数バリデーションをTwitter重み付きカウントに修正

### DIFF
--- a/app/twitter/tests/test_tweet_length.py
+++ b/app/twitter/tests/test_tweet_length.py
@@ -1,0 +1,128 @@
+"""ツイート文字数カウントとリトライ機能のテスト"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from twitter.tweet_generator import (
+    TWEET_MAX_WEIGHTED_LENGTH,
+    _generate_with_retry,
+    count_tweet_length,
+)
+
+
+class CountTweetLengthTest(TestCase):
+    """count_tweet_length のテスト"""
+
+    def test_ascii_only(self):
+        """ASCII文字は重み1"""
+        self.assertEqual(count_tweet_length("hello"), 5)
+
+    def test_japanese_only(self):
+        """日本語文字（U+1100以上）は重み2"""
+        self.assertEqual(count_tweet_length("こんにちは"), 10)
+
+    def test_mixed(self):
+        """ASCII + 日本語の混在"""
+        # "LT" = 2, "告知" = 4, total = 6
+        self.assertEqual(count_tweet_length("LT告知"), 6)
+
+    def test_url_counts_as_23(self):
+        """URLは実際の長さに関係なく23としてカウント"""
+        text = "詳細はこちら https://vrc-ta-hub.com/event/123/"
+        # "詳細はこちら " = 6*2+1 = 13, URL = 23, total = 36
+        self.assertEqual(count_tweet_length(text), 36)
+
+    def test_multiple_urls(self):
+        """複数URLはそれぞれ23としてカウント"""
+        text = "https://example.com https://example.org"
+        # space = 1, URL*2 = 46, total = 47
+        self.assertEqual(count_tweet_length(text), 47)
+
+    def test_empty_string(self):
+        self.assertEqual(count_tweet_length(""), 0)
+
+    def test_boundary_u10ff(self):
+        """U+10FF (weight 1) の境界テスト"""
+        self.assertEqual(count_tweet_length("\u10FF"), 1)
+
+    def test_boundary_u1100(self):
+        """U+1100 (weight 2) の境界テスト"""
+        self.assertEqual(count_tweet_length("\u1100"), 2)
+
+    def test_realistic_tweet(self):
+        """実際のツイートに近いテキストの文字数確認"""
+        text = (
+            "【LT告知】次回の #個人開発集会 は4/9(木) 22:00から！\n"
+            "\n"
+            "発表者はネバーさん。テーマは「テスト」です！\n"
+            "\n"
+            "詳細はこちら https://vrc-ta-hub.com/event/123/\n"
+            "#VRChat技術学術"
+        )
+        length = count_tweet_length(text)
+        self.assertLessEqual(length, TWEET_MAX_WEIGHTED_LENGTH)
+
+
+class GenerateWithRetryTest(TestCase):
+    """_generate_with_retry のテスト"""
+
+    def test_returns_on_first_success(self):
+        """初回生成が280以内なら即返す"""
+        def fake_generator(target_chars=140):
+            return "short tweet"
+
+        result = _generate_with_retry(fake_generator)
+        self.assertEqual(result, "short tweet")
+
+    def test_retries_on_too_long(self):
+        """超過時にtarget_charsを減らしてリトライする"""
+        call_count = 0
+
+        def fake_generator(target_chars=140):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                # 最初の2回: 長すぎるテキスト（日本語280文字 ≈ 560 weighted）
+                return "あ" * 200
+            # 3回目: 短いテキスト
+            return "OK" * 10
+
+        result = _generate_with_retry(fake_generator)
+        self.assertEqual(result, "OK" * 10)
+        self.assertEqual(call_count, 3)
+
+    def test_returns_last_result_after_all_retries(self):
+        """全リトライ後も超過なら最後の結果を返す"""
+        def fake_generator(target_chars=140):
+            return "あ" * 200
+
+        result = _generate_with_retry(fake_generator, max_retries=3)
+        self.assertEqual(result, "あ" * 200)
+
+    def test_returns_none_on_generation_failure(self):
+        """生成失敗(None)時はリトライせずNoneを返す"""
+        def fake_generator(target_chars=140):
+            return None
+
+        result = _generate_with_retry(fake_generator)
+        self.assertIsNone(result)
+
+    def test_target_chars_decreases_on_retry(self):
+        """リトライごとにtarget_charsが20ずつ減少する"""
+        targets = []
+
+        def fake_generator(target_chars=140):
+            targets.append(target_chars)
+            return "あ" * 200  # Always too long
+
+        _generate_with_retry(fake_generator, max_retries=3)
+        self.assertEqual(targets, [140, 120, 100, 80])
+
+    def test_with_positional_args(self):
+        """位置引数付きの生成関数が正しく呼ばれる"""
+        def fake_generator(arg1, arg2, target_chars=140):
+            return f"{arg1}-{arg2}-{target_chars}"
+
+        result = _generate_with_retry(fake_generator, "a", "b")
+        self.assertEqual(result, "a-b-140")

--- a/app/twitter/tweet_generator.py
+++ b/app/twitter/tweet_generator.py
@@ -6,6 +6,7 @@ OpenRouter API 経由で LLM を呼び出し、各種告知ツイートを生成
 
 import logging
 import os
+import re
 
 from django.conf import settings
 from openai import OpenAI
@@ -18,10 +19,73 @@ MAX_TWEET_TOKENS = 280
 LLM_TEMPERATURE = 0.7
 SANITIZE_MAX_LENGTH = 200
 
+TWEET_MAX_WEIGHTED_LENGTH = 280
+URL_WEIGHTED_LENGTH = 23
+RETRY_TARGET_CHARS_STEP = 20
+
 WEEKDAY_NAMES = {
     "Sun": "日", "Mon": "月", "Tue": "火", "Wed": "水",
     "Thu": "木", "Fri": "金", "Sat": "土",
 }
+
+
+def count_tweet_length(text: str) -> int:
+    """Twitter/X の重み付きカウント方式で文字数を返す。
+
+    - URL (https?://\S+): 常に23としてカウント
+    - U+0000〜U+10FF の文字: 重み1
+    - U+1100 以上の文字 (CJK等): 重み2
+    """
+    url_pattern = re.compile(r"https?://\S+")
+    urls = url_pattern.findall(text)
+    text_without_urls = url_pattern.sub("", text)
+
+    weight = 0
+    for ch in text_without_urls:
+        weight += 2 if ord(ch) >= 0x1100 else 1
+
+    weight += len(urls) * URL_WEIGHTED_LENGTH
+    return weight
+
+
+def _generate_with_retry(generate_fn, *args, max_retries=3, **kwargs) -> str | None:
+    """生成関数をリトライラッパーで実行する。
+
+    1. target_chars=140 で生成
+    2. count_tweet_length() でバリデーション（上限 TWEET_MAX_WEIGHTED_LENGTH）
+    3. 超過していたら target_chars を RETRY_TARGET_CHARS_STEP ずつ減らしてリトライ
+    4. max_retries 回リトライ後も超過している場合は最後の結果を返す
+    """
+    target_chars = 140
+    result = None
+
+    for attempt in range(max_retries + 1):
+        result = generate_fn(*args, target_chars=target_chars, **kwargs)
+        if result is None:
+            return None
+
+        length = count_tweet_length(result)
+        if length <= TWEET_MAX_WEIGHTED_LENGTH:
+            if attempt > 0:
+                logger.info(
+                    "Tweet length OK after %d retries (weighted=%d, target_chars=%d)",
+                    attempt,
+                    length,
+                    target_chars,
+                )
+            return result
+
+        logger.warning(
+            "Tweet length exceeded (weighted=%d > %d, attempt=%d/%d, target_chars=%d). Retrying.",
+            length,
+            TWEET_MAX_WEIGHTED_LENGTH,
+            attempt + 1,
+            max_retries + 1,
+            target_chars,
+        )
+        target_chars -= RETRY_TARGET_CHARS_STEP
+
+    return result
 
 
 def _sanitize_for_prompt(text: str, max_length: int = SANITIZE_MAX_LENGTH) -> str:
@@ -82,12 +146,13 @@ def _build_hashtag_suffix(community) -> str:
     return f"#VRChat技術学術{hashtag}"
 
 
-def generate_new_community_tweet(community, first_event=None) -> str | None:
+def generate_new_community_tweet(community, first_event=None, target_chars=140) -> str | None:
     """新規集会の告知ツイートを生成する。
 
     Args:
         community: Community モデルインスタンス
         first_event: 初回 Event (あれば日程を含める)
+        target_chars: LLM に指示する目標文字数
     """
     system_prompt = (
         "あなたはVRChat技術学術系集会の告知ツイートを作成する専門家です。"
@@ -116,7 +181,7 @@ def generate_new_community_tweet(community, first_event=None) -> str | None:
 紹介: {description}{event_info}
 
 以下のルールを守ってください:
-- 280文字以内
+- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
 - 新しい集会が始まることへの期待感を伝える
 - 末尾に以下を含める:
   詳細はこちら https://vrc-ta-hub.com/community/{community.pk}/
@@ -126,11 +191,12 @@ def generate_new_community_tweet(community, first_event=None) -> str | None:
     return _call_llm(system_prompt, user_prompt)
 
 
-def generate_lt_tweet(event_detail) -> str | None:
+def generate_lt_tweet(event_detail, target_chars=140) -> str | None:
     """LT 告知ツイートを生成する。
 
     Args:
         event_detail: EventDetail モデルインスタンス (detail_type='LT')
+        target_chars: LLM に指示する目標文字数
     """
     system_prompt = (
         "あなたはVRChat技術学術系集会のLT（ライトニングトーク）告知ツイートを作成する専門家です。"
@@ -153,7 +219,7 @@ def generate_lt_tweet(event_detail) -> str | None:
 テーマ: {theme}
 
 以下のルールを守ってください:
-- 280文字以内
+- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
 - LTの内容への期待感を伝える
 - 末尾に以下を含める:
   詳細はこちら https://vrc-ta-hub.com/event/{event.pk}/
@@ -163,11 +229,12 @@ def generate_lt_tweet(event_detail) -> str | None:
     return _call_llm(system_prompt, user_prompt)
 
 
-def generate_slide_share_tweet(event_detail) -> str | None:
+def generate_slide_share_tweet(event_detail, target_chars=140) -> str | None:
     """スライド/記事共有ツイートを生成する。
 
     Args:
         event_detail: EventDetail モデルインスタンス（slide_url または youtube_url が設定済み）
+        target_chars: LLM に指示する目標文字数
     """
     system_prompt = (
         "あなたはVRChat技術学術系集会のLT発表後の共有ツイートを作成する専門家です。"
@@ -199,7 +266,7 @@ def generate_slide_share_tweet(event_detail) -> str | None:
 公開された資料: {resources_text}
 
 以下のルールを守ってください:
-- 280文字以内
+- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
 - 発表後の共有であること（事後報告のトーン）
 - {resources_text}が公開されたことへの嬉しさ・見てほしい気持ちを伝える
 - 末尾に以下を含める:
@@ -213,14 +280,22 @@ def generate_slide_share_tweet(event_detail) -> str | None:
 def get_generator(tweet_type: str):
     """tweet_type に応じた生成関数を返す。
 
+    各生成関数は _generate_with_retry でラップされ、文字数バリデーションとリトライを行う。
+
     Returns:
         生成関数 (queue_item -> str | None)。未知の tweet_type の場合は None。
     """
     generator_map = {
-        "new_community": lambda qi: generate_new_community_tweet(qi.community, qi.event),
-        "lt": lambda qi: generate_lt_tweet(qi.event_detail),
-        "special": lambda qi: generate_special_event_tweet(qi.event_detail),
-        "slide_share": lambda qi: generate_slide_share_tweet(qi.event_detail),
+        "new_community": lambda qi: _generate_with_retry(
+            generate_new_community_tweet, qi.community, qi.event
+        ),
+        "lt": lambda qi: _generate_with_retry(generate_lt_tweet, qi.event_detail),
+        "special": lambda qi: _generate_with_retry(
+            generate_special_event_tweet, qi.event_detail
+        ),
+        "slide_share": lambda qi: _generate_with_retry(
+            generate_slide_share_tweet, qi.event_detail
+        ),
     }
     return generator_map.get(tweet_type)
 
@@ -252,11 +327,12 @@ def get_poster_image_url(community) -> str:
     return ""
 
 
-def generate_special_event_tweet(event_detail) -> str | None:
+def generate_special_event_tweet(event_detail, target_chars=140) -> str | None:
     """特別回告知ツイートを生成する。
 
     Args:
         event_detail: EventDetail モデルインスタンス (detail_type='SPECIAL')
+        target_chars: LLM に指示する目標文字数
     """
     system_prompt = (
         "あなたはVRChat技術学術系集会の特別イベント告知ツイートを作成する専門家です。"
@@ -280,7 +356,7 @@ def generate_special_event_tweet(event_detail) -> str | None:
 テーマ: {theme}
 
 以下のルールを守ってください:
-- 280文字以内
+- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
 - 特別回ならではのワクワク感を伝える
 - 末尾に以下を含める:
   詳細はこちら https://vrc-ta-hub.com/event/{event.pk}/


### PR DESCRIPTION
## なぜこの変更が必要か

LLMが生成するツイートの文字数が上限を超過していた。原因はプロンプトで「280文字以内」と指示していたが、Twitter/X はCJK文字を2文字としてカウントするため、280文字の日本語テキストは実際には約500重み付き文字となり大幅にオーバーしていた。

## 変更内容

- `count_tweet_length()`: Twitter/X の重み付きカウント方式（CJK=2, URL=23固定）を実装
- 各 `generate_*` 関数のプロンプトを「280文字以内」→「140文字以内」に修正
- `_generate_with_retry()`: 生成後にバリデーションし、超過時は `target_chars` を20ずつ減らして最大3回リトライ（140→120→100→80）
- テスト15件追加（文字数カウント9件、リトライ6件）

## 意思決定

### 採用アプローチ
- 生成後バリデーション + リトライ方式を採用。理由: LLMの文字数制御は不正確なので、事後検証 + リトライが確実

### 却下した代替案
- LLMプロンプトのみの修正 → 却下: LLMの文字数制御は不正確なため超過を防げない
- テンプレートベース生成への切り替え → 却下: 表現の多様性が失われる

### 技術的負債
- Twitterの正確な文字数カウント仕様（twitter-text ライブラリ）は完全には再現していない。U+0000-U+10FF を weight 1、U+1100 以上を weight 2 とする近似値で実用上十分

## テスト

- [x] `twitter` アプリ全140テストパス
- [x] 文字数カウント: ASCII, 日本語, 混在, URL, 境界値のテスト
- [x] リトライ: 成功, 超過→リトライ成功, 全リトライ失敗, None返却, target_chars減少, 位置引数

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)