### PR TITLE
feat: LT申請一覧の導線をマイリストへ移動

### DIFF
--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -53,11 +53,16 @@
         </div>
 
         {# クイックアクション #}
-        {% if community %}
         <div class="d-flex flex-wrap gap-2 justify-content-center mb-4">
+            {% if community %}
             <a href="{% url 'event:calendar_create' %}" class="btn btn-primary">
                 <i class="fas fa-plus"></i> イベント登録
             </a>
+            {% endif %}
+            <a href="{% url 'account:lt_application_list' %}" class="btn btn-outline-secondary">
+                <i class="fa-solid fa-microphone"></i> LT申請一覧
+            </a>
+            {% if community %}
             <a href="{% url 'event:detail_history' %}?community_name={{ community.name }}" class="btn btn-outline-secondary">
                 <i class="fas fa-history"></i> LT履歴
             </a>
@@ -67,8 +72,8 @@
             <a href="{% url 'community:detail' community.pk %}" class="btn btn-outline-primary">
                 <i class="fas fa-eye"></i> 公開ページ
             </a>
+            {% endif %}
         </div>
-        {% endif %}
 
         {# Vketコラボバナー #}
         {% if vket_banner %}

--- a/app/event/tests/test_event_my_list_view.py
+++ b/app/event/tests/test_event_my_list_view.py
@@ -247,9 +247,43 @@ class EventMyListDashboardTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # クイックアクションボタンのテキストが含まれる
         self.assertContains(response, 'イベント登録')
+        self.assertContains(response, 'LT申請一覧')
         self.assertContains(response, 'LT履歴')
         self.assertContains(response, '集会設定')
         self.assertContains(response, '公開ページ')
+
+    def test_lt_application_link_is_next_to_calendar_create(self):
+        """LT申請一覧リンクがイベント登録ボタンの直後に表示される"""
+        self.client.login(username='Dashboard User', password='dashboardpass123')
+        response = self.client.get(reverse('event:my_list'))
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+
+        create_button_pos = content.find('イベント登録')
+        lt_application_pos = content.find('LT申請一覧')
+        lt_history_pos = content.find('LT履歴')
+
+        self.assertGreater(create_button_pos, -1)
+        self.assertGreater(lt_application_pos, create_button_pos)
+        self.assertGreater(lt_history_pos, lt_application_pos)
+        self.assertContains(response, reverse('account:lt_application_list'))
+
+    def test_lt_application_link_displayed_without_community(self):
+        """集会未所属ユーザーでもLT申請一覧リンクに到達できる"""
+        participant = User.objects.create_user(
+            user_name='Participant User',
+            email='participant@example.com',
+            password='participantpass123',
+        )
+
+        self.client.login(username='Participant User', password='participantpass123')
+        response = self.client.get(reverse('event:my_list'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'LT申請一覧')
+        self.assertContains(response, reverse('account:lt_application_list'))
+        self.assertNotContains(response, 'イベント登録')
 
     def test_pending_lt_shows_approve_reject_buttons(self):
         """承認待ちLT申請に承認・却下ボタンが表示される"""

--- a/app/user_account/templates/account/settings.html
+++ b/app/user_account/templates/account/settings.html
@@ -106,12 +106,6 @@
                                     </span>
                                 </a>
                             {% endif %}
-                            <a href="{% url 'account:lt_application_list' %}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                                <span>
-                                    <i class="fa-solid fa-microphone me-2"></i>LT申請一覧
-                                </span>
-                                <i class="fa-solid fa-chevron-right text-muted"></i>
-                            </a>
                         </div>
 
                         <!-- 管理セクション（スタッフのみ） -->

--- a/app/user_account/tests/test_views.py
+++ b/app/user_account/tests/test_views.py
@@ -271,6 +271,8 @@ class SettingsViewTests(TestCase):
         self.assertContains(response, 'パスワードを変更')
         # Discord連携が表示されていること
         self.assertContains(response, 'Discord連携')
+        # LT申請一覧はマイリストへ移動済み
+        self.assertNotContains(response, 'LT申請一覧')
         # ログアウトが表示されていること
         self.assertContains(response, 'ログアウト')
 


### PR DESCRIPTION
## なぜこの変更が必要か

Issue #179 では、LT申請一覧の導線をアカウント設定ページからイベント管理の導線へ寄せ、主催者がイベント登録やLT履歴と並べてアクセスできる状態が求められていた。
あわせて、集会未所属でもLT申請済みの参加者が一覧ページへの導線を失わないように、`event/my_list` 上では LT申請一覧だけ常時表示にする必要がある。

## 変更内容

- `event/my_list` の上部ボタン群で、`イベント登録` の右隣に `LT申請一覧` を追加
- `account/settings` から `LT申請一覧` リンクを削除
- 集会未所属ユーザーでも `event/my_list` 上に `LT申請一覧` が表示されるように調整
- 導線の表示位置と未所属ユーザー向け回帰を担保するテストを追加

## 意思決定

### 採用アプローチ
- `LT申請一覧` を `event/my_list` に移しつつ常時表示を採用。理由: Issue の移設要件を満たしながら、LT申請者の導線消失を防げるため

### 却下した代替案
- `account/settings` にリンクを残したまま `event/my_list` にも追加 → 却下: Issue の「移動」の意図が曖昧になり、導線が二重化するため

## テスト

- `docker exec vrc-ta-hub python manage.py test event.tests.test_event_my_list_view user_account.tests.test_views`（72 tests, OK）
- `curl -I http://localhost:8015/accounts/login/` でローカルHTTP確認を試行し、既存環境の `MultipleObjectsReturned` により `/accounts/login/` が 500 になることを確認

Closes #179

---
このPRはfix-flowによる自動実装です。