### PR TITLE
fix: ツイートキュー画面UI改善 + プロンプト調整

### DIFF
--- a/app/twitter/templates/twitter/tweet_queue_detail.html
+++ b/app/twitter/templates/twitter/tweet_queue_detail.html
@@ -10,102 +10,111 @@
     {% include 'ta_hub/messages.html' %}
     <h1 class="fw-bold mb-4">ツイートキュー #{{ object.pk }}</h1>
 
-    {# 情報カード #}
-    <div class="card mb-4">
-        <div class="card-body">
-            <div class="row mb-3">
-                <div class="col-md-6">
-                    <strong>種別:</strong> {{ object.get_tweet_type_display }}
-                </div>
-                <div class="col-md-6">
-                    <strong>ステータス:</strong>
-                    <span class="badge bg-{{ object.status|status_badge_color }}">{{ object.get_status_display }}</span>
-                </div>
-            </div>
-            <div class="row mb-3">
-                <div class="col-md-6">
-                    <strong>集会:</strong>
-                    <a href="{% url 'community:detail' object.community.pk %}">{{ object.community.name }}</a>
-                </div>
-                <div class="col-md-6">
-                    <strong>作成日時:</strong> {{ object.created_at|date:"Y/m/d H:i" }}
-                </div>
-            </div>
-            {% if object.event %}
-            <div class="row mb-3">
-                <div class="col-md-6">
-                    <strong>イベント:</strong> {{ object.event.date|date:"Y/m/d" }}
-                </div>
-            </div>
-            {% endif %}
-            {% if object.tweet_id %}
-            <div class="row mb-3">
-                <div class="col-md-12">
-                    <strong>ツイートID:</strong>
-                    <a href="https://x.com/vrc_ta_hub/status/{{ object.tweet_id }}" target="_blank" rel="noopener">
-                        {{ object.tweet_id }} <i class="fas fa-external-link-alt fa-sm"></i>
-                    </a>
-                </div>
-            </div>
-            {% endif %}
-            {% if object.posted_at %}
-            <div class="row mb-3">
-                <div class="col-md-6">
-                    <strong>投稿日時:</strong> {{ object.posted_at|date:"Y/m/d H:i" }}
-                </div>
-            </div>
-            {% endif %}
-            {% if object.error_message %}
-            <div class="alert alert-danger mt-3 mb-0">
-                <i class="fas fa-exclamation-triangle me-2"></i>
-                <strong>エラー:</strong> {{ object.error_message }}
-            </div>
-            {% endif %}
-        </div>
-    </div>
-
-    {# 編集フォーム #}
+    {# メインレイアウト: 左（情報+テキスト） / 右（画像） #}
     <form method="post">
         {% csrf_token %}
         <input type="hidden" name="action" value="update">
 
-        <div class="mb-3">
-            <label for="id_generated_text" class="form-label fw-bold">生成テキスト</label>
-            <textarea name="generated_text" id="id_generated_text" class="form-control" rows="8">{{ object.generated_text }}</textarea>
-            <div class="form-text">{{ object.generated_text|length }}/280文字</div>
-        </div>
+        <div class="row mb-4">
+            {# 左カラム: 情報 + 生成テキスト #}
+            <div class="{% if object.image_url %}col-md-7{% else %}col-12{% endif %}">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <div class="row mb-2">
+                            <div class="col-sm-6">
+                                <strong>種別:</strong> {{ object.get_tweet_type_display }}
+                            </div>
+                            <div class="col-sm-6">
+                                <strong>ステータス:</strong>
+                                <span class="badge bg-{{ object.status|status_badge_color }}">{{ object.get_status_display }}</span>
+                            </div>
+                        </div>
+                        <div class="row mb-2">
+                            <div class="col-sm-6">
+                                <strong>集会:</strong>
+                                <a href="{% url 'community:detail' object.community.pk %}">{{ object.community.name }}</a>
+                            </div>
+                            <div class="col-sm-6">
+                                <strong>作成日時:</strong> {{ object.created_at|date:"Y/m/d H:i" }}
+                            </div>
+                        </div>
+                        {% if object.event %}
+                        <div class="row mb-2">
+                            <div class="col-sm-6">
+                                <strong>イベント:</strong> {{ object.event.date|date:"Y/m/d" }}
+                            </div>
+                        </div>
+                        {% endif %}
+                        {% if object.tweet_id %}
+                        <div class="mb-2">
+                            <strong>ツイートID:</strong>
+                            <a href="https://x.com/vrc_ta_hub/status/{{ object.tweet_id }}" target="_blank" rel="noopener">
+                                {{ object.tweet_id }} <i class="fas fa-external-link-alt fa-sm"></i>
+                            </a>
+                        </div>
+                        {% endif %}
+                        {% if object.posted_at %}
+                        <div class="mb-2">
+                            <strong>投稿日時:</strong> {{ object.posted_at|date:"Y/m/d H:i" }}
+                        </div>
+                        {% endif %}
+                        {% if object.error_message %}
+                        <div class="alert alert-danger mt-2 mb-0">
+                            <i class="fas fa-exclamation-triangle me-2"></i>
+                            <strong>エラー:</strong> {{ object.error_message }}
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
 
-        {% if object.image_url %}
-        <div class="mb-3">
-            <label class="form-label fw-bold">添付画像</label>
-            <div>
-                <img src="{{ object.image_url }}" alt="添付画像" style="max-width:300px; max-height:200px" class="rounded border">
+                <div class="mb-3">
+                    <label for="id_generated_text" class="form-label fw-bold">生成テキスト</label>
+                    <textarea name="generated_text" id="id_generated_text" class="form-control" rows="12">{{ object.generated_text }}</textarea>
+                    <div class="form-text">{{ object.generated_text|length }}/280文字</div>
+                </div>
+
+                <div class="mb-3">
+                    <label for="id_image_url" class="form-label fw-bold">画像URL</label>
+                    <input type="url" name="image_url" id="id_image_url" class="form-control" value="{{ object.image_url }}" placeholder="https://...">
+                </div>
+
+                <div class="d-flex flex-wrap gap-2">
+                    <a href="{% url 'twitter:tweet_queue_list' %}" class="btn btn-outline-secondary">
+                        <i class="fas fa-arrow-left me-1"></i>一覧に戻る
+                    </a>
+
+                    {% if object.status == 'generation_failed' or object.status == 'generating' %}
+                    <button type="submit" name="action" value="retry" class="btn btn-warning">
+                        <i class="fas fa-redo me-1"></i>リトライ生成
+                    </button>
+                    {% endif %}
+
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save me-1"></i>保存
+                    </button>
+
+                    {% if object.status == 'ready' %}
+                    <button type="submit" name="action" value="post_now" class="btn btn-outline-success"
+                            onclick="return confirm('このツイートを今すぐ投稿しますか？')">
+                        <i class="fab fa-x-twitter me-1"></i>今すぐ投稿
+                    </button>
+                    {% endif %}
+
+                    <button type="submit" name="action" value="delete" class="btn btn-outline-danger ms-auto"
+                            onclick="return confirm('このキューを削除しますか？')">
+                        <i class="fas fa-trash me-1"></i>削除
+                    </button>
+                </div>
             </div>
-            <div class="form-text mt-1">{{ object.image_url }}</div>
-        </div>
-        {% endif %}
 
-        <div class="d-flex flex-wrap gap-2">
-            <button type="submit" class="btn btn-primary">
-                <i class="fas fa-save me-1"></i>保存
-            </button>
-
-            {% if object.status == 'generation_failed' or object.status == 'generating' %}
-            <button type="submit" name="action" value="retry" class="btn btn-warning">
-                <i class="fas fa-redo me-1"></i>リトライ生成
-            </button>
+            {# 右カラム: 添付画像プレビュー #}
+            {% if object.image_url %}
+            <div class="col-md-5">
+                <div>
+                    <img src="{{ object.image_url }}" alt="添付画像" class="rounded border w-100">
+                </div>
+            </div>
             {% endif %}
-
-            {% if object.status == 'ready' %}
-            <button type="submit" name="action" value="post_now" class="btn btn-success"
-                    onclick="return confirm('このツイートを今すぐ投稿しますか？')">
-                <i class="fab fa-x-twitter me-1"></i>今すぐ投稿
-            </button>
-            {% endif %}
-
-            <a href="{% url 'twitter:tweet_queue_list' %}" class="btn btn-outline-secondary">
-                <i class="fas fa-arrow-left me-1"></i>一覧に戻る
-            </a>
         </div>
     </form>
 </div>

--- a/app/twitter/tweet_generator.py
+++ b/app/twitter/tweet_generator.py
@@ -164,7 +164,7 @@ def generate_new_community_tweet(community, first_event=None, target_chars=140) 
     event_info = ""
     if first_event:
         event_info = (
-            f"\n初回開催日: {first_event.date.strftime('%m/%d')}({WEEKDAY_NAMES.get(first_event.date.strftime('%a'), '')})"
+            f"\n初回開催日: {first_event.date.strftime('%-m/%-d')}({WEEKDAY_NAMES.get(first_event.date.strftime('%a'), '')})"
             f" {first_event.start_time.strftime('%H:%M')}~"
         )
 
@@ -220,20 +220,21 @@ def generate_lt_tweet(event_detail, target_chars=140) -> str | None:
     user_prompt = f"""以下のLT（ライトニングトーク）の告知ツイートを作成してください。
 
 集会名: {name}
-日時: {event.date.strftime('%m/%d')}({weekday}) {event.start_time.strftime('%H:%M')}~
+日時: {event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~
 発表者: {speaker}
 テーマ: {theme}
 
 ## 必須要素（必ず本文に含めること）
 1. 集会名（「{name}」）
-2. 開催日時（「{event.date.strftime('%m/%d')}({weekday}) {event.start_time.strftime('%H:%M')}~」の形式で）
+2. 開催日時（「{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~」の形式で）
 3. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
 4. 発表者名（敬称は「さん」を付ける）
-5. 「このテーマが気になる人は聞きに来て」という呼びかけ
+5. テーマの補足説明から自然につながる形で、次のアクション（聞きに来る・詳細を見る等）に誘導する一文
 
 ## スタイル
 - {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
 - テーマ名をそのまま書いた上で、何が聞けるかを1文で補足する
+- 誘導の一文は毎回異なる自然な表現にする（「このテーマが気になる人は聞きに来て」のような定型文の繰り返し禁止）
 - 末尾に以下を必ず含める:
   詳細はこちら https://vrc-ta-hub.com/community/{community.pk}/
   {hashtag_suffix}
@@ -284,12 +285,13 @@ def generate_slide_share_tweet(event_detail, target_chars=140) -> str | None:
 2. 発表者名（敬称は「さん」を付ける）
 3. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
 4. {resources_text}が公開されたこと
-5. 「こういう人はチェックして」という呼びかけ
+5. 内容の補足から自然につながる形で、次のアクション（資料を見る・チェックする等）に誘導する一文
 
 ## スタイル
 - {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
 - 日付は不要（過去のイベントなので）
 - テーマ名をそのまま書いた上で、「読むと何がわかるか」を1文で補足する
+- 誘導の一文は毎回異なる自然な表現にする（「〜な方はチェック」のような定型文の繰り返し禁止）
 - 末尾に以下を必ず含める:
   詳細はこちら https://vrc-ta-hub.com/event/detail/{event_detail.pk}/
   {hashtag_suffix}
@@ -374,21 +376,22 @@ def generate_special_event_tweet(event_detail, target_chars=140) -> str | None:
     user_prompt = f"""以下の特別イベントの告知ツイートを作成してください。
 
 集会名: {name}
-日時: {event.date.strftime('%m/%d')}({weekday}) {event.start_time.strftime('%H:%M')}~
+日時: {event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~
 発表者/ゲスト: {speaker}
 テーマ: {theme}
 
 ## 必須要素（必ず本文に含めること）
 1. 集会名（「{name}」）
 2. 「特別回」であること
-3. 開催日時（「{event.date.strftime('%m/%d')}({weekday}) {event.start_time.strftime('%H:%M')}~」の形式で）
+3. 開催日時（「{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~」の形式で）
 4. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
 5. 発表者/ゲスト名（敬称は「さん」を付ける）
-6. 「このテーマに興味ある人は来て」という呼びかけ
+6. テーマの補足説明から自然につながる形で、次のアクション（聞きに来る・詳細を見る等）に誘導する一文
 
 ## スタイル
 - {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
 - テーマ名をそのまま書いた上で、特別回ならではの見どころを1文で補足する
+- 誘導の一文は毎回異なる自然な表現にする（「このテーマに興味ある人は来て」のような定型文の繰り返し禁止）
 - 末尾に以下を必ず含める:
   詳細はこちら https://vrc-ta-hub.com/community/{community.pk}/
   {hashtag_suffix}

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -342,15 +342,25 @@ class TweetQueueDetailView(SuperuserRequiredMixin, DetailView):
             return self._handle_retry()
         elif action == 'post_now':
             return self._handle_post_now()
+        elif action == 'delete':
+            return self._handle_delete()
         else:
             return self._handle_update(request)
 
     def _handle_update(self, request):
-        """generated_text を更新する。"""
+        """generated_text と image_url を更新する。"""
         self.object.generated_text = request.POST.get('generated_text', '')
-        self.object.save(update_fields=['generated_text'])
-        messages.success(request, 'テキストを保存しました。')
+        self.object.image_url = request.POST.get('image_url', '')
+        self.object.save(update_fields=['generated_text', 'image_url'])
+        messages.success(request, '保存しました。')
         return redirect(reverse('twitter:tweet_queue_detail', kwargs={'pk': self.object.pk}))
+
+    def _handle_delete(self):
+        """キューを削除する。"""
+        pk = self.object.pk
+        self.object.delete()
+        messages.success(self.request, f'キュー #{pk} を削除しました。')
+        return redirect(reverse('twitter:tweet_queue_list'))
 
     def _handle_retry(self):
         """generating に戻してバックグラウンドでテキスト再生成を開始する。"""


### PR DESCRIPTION
## なぜこの変更が必要か

ツイートキュー詳細画面のUIが使いにくく、画像URLの変更やキューの削除が画面上からできなかった。また、ツイート本文の呼びかけ表現が毎回同じテンプレ文になっていた。

## 変更内容

### UI改善
- 2カラムレイアウト（左: 情報+テキスト+画像URL+ボタン、右: 画像プレビュー）
- テキストエリアを12行に拡大
- 画像URLをテキストボックスで編集可能に（保存時にDB反映）
- 削除ボタン追加（確認ダイアログ付き）
- ボタン配置最適化

### プロンプト調整
- 日付のゼロパディング廃止（04/09 → 4/9）
- 呼びかけ表現を毎回異なる自然な誘導文に変更（定型文の繰り返し禁止）

## テスト

- [x] twitter 全151テスト通過

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)