### PR TITLE
fix: ポスター転載可否バッジを画像の外に移動

### DIFF
--- a/app/community/templates/community/detail.html
+++ b/app/community/templates/community/detail.html
@@ -25,7 +25,7 @@
                 <div class="row g-4">
                     <!-- 左側：ポスター画像 -->
                     <div class="col-lg-5">
-                        <div class="position-relative">
+                        <div>
                             {% if community.poster_image %}
                                 <img src="{{ community.poster_image.url|cf_resize:'800' }}" alt="{{ community.name }}"
                                      class="img-fluid rounded shadow-sm w-100">
@@ -33,7 +33,7 @@
                                 <img src="https://vrc-ta-hub.com/poster/no-image.png" alt="{{ community.name }}"
                                      class="img-fluid rounded shadow-sm w-100">
                             {% endif %}
-                            <div class="position-absolute bottom-0 start-0 m-2">
+                            <div class="mt-2">
                                 {% if community.allow_poster_repost %}
                                     <span class="badge bg-success text-white">
                                         <i class="bi bi-check-circle"></i> 集会を紹介するためのポスターの転載可


### PR DESCRIPTION
## Summary

- ポスター転載可否バッジが画像内の文字と重なる問題を修正
- `position-absolute` による画像内オーバーレイから、画像下部への通常配置に変更

## Why

集会のポスター画像にバッジが重なり、ポスター内の文字が読みにくくなっていた。
画像の外に配置することで、ポスター・バッジ両方の視認性を確保する。

## Test plan

- [x] PC表示（1280px）でバッジが画像の下に表示されることを確認
- [x] モバイル表示（375px）でバッジが画像の下に表示されることを確認


🤖 Generated with [Claude Code](https://claude.com/claude-code)