### PR TITLE
fix: GoogleCalendarEventCreateView の未認証アクセスで500エラーを修正

### DIFF
--- a/app/event/views.py
+++ b/app/event/views.py
@@ -1454,6 +1454,9 @@ class GoogleCalendarEventCreateView(LoginRequiredMixin, FormView):
         return None
 
     def dispatch(self, request, *args, **kwargs):
+        # LoginRequiredMixin の認証チェックを先に実行
+        if not request.user.is_authenticated:
+            return super().dispatch(request, *args, **kwargs)
         # コミュニティの承認状態をチェック
         community = self._get_active_community()
         if not community or community.status != 'approved':


### PR DESCRIPTION
## Summary

- 未認証ユーザー（ボット等）が `/event/calendar/create/` にアクセスすると500エラーが発生していた
- `dispatch()` が `LoginRequiredMixin` の認証チェックより前に `_get_active_community()` を呼んでいたのが原因
- 未認証の場合は先に `super().dispatch()` に委譲してログインページへリダイレクトするよう修正

## Test plan

- [x] 既存テスト通過確認（`event.tests` calendar関連 12件 OK）
- [x] 未認証アクセスで302リダイレクト確認（`curl` で `/account/login/` へリダイレクト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)