### PR TITLE
fix: Cloud Run preview hostをnginxで正規化

### DIFF
--- a/app/website/tests/test_nginx_config.py
+++ b/app/website/tests/test_nginx_config.py
@@ -1,0 +1,24 @@
+"""nginx の host 正規化設定テスト。"""
+
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class NginxConfigTest(SimpleTestCase):
+    def setUp(self):
+        self.nginx_config = (REPO_ROOT / 'nginx-app.conf').read_text()
+
+    def test_cloud_run_preview_host_is_rewritten_before_proxy(self):
+        self.assertIn('map $http_host $django_upstream_host {', self.nginx_config)
+        self.assertIn(
+            '~^(?:[a-z0-9-]+---)?vrc-ta-hub-[a-z0-9]+-[a-z0-9]+\\.a\\.run\\.app(?::\\d+)?$ vrc-ta-hub.com;',
+            self.nginx_config,
+        )
+        self.assertIn('proxy_set_header Host $django_upstream_host;', self.nginx_config)
+
+    def test_nginx_does_not_forward_raw_cloud_run_host(self):
+        self.assertNotIn('proxy_set_header Host $http_host;', self.nginx_config)

--- a/app/website/tests/test_nginx_config.py
+++ b/app/website/tests/test_nginx_config.py
@@ -15,10 +15,13 @@ class NginxConfigTest(SimpleTestCase):
     def test_cloud_run_preview_host_is_rewritten_before_proxy(self):
         self.assertIn('map $http_host $django_upstream_host {', self.nginx_config)
         self.assertIn(
-            '~^(?:[a-z0-9-]+---)?vrc-ta-hub-[a-z0-9]+-[a-z0-9]+\\.a\\.run\\.app(?::\\d+)?$ vrc-ta-hub.com;',
+            '~^(?:[a-z0-9-]+---)?vrc-ta-hub(?:-dev)?-[a-z0-9]+-[a-z0-9]+\\.a\\.run\\.app(?::\\d+)?$ vrc-ta-hub.com;',
             self.nginx_config,
         )
         self.assertIn('proxy_set_header Host $django_upstream_host;', self.nginx_config)
+
+    def test_nginx_rule_covers_dev_service_preview_host(self):
+        self.assertIn('vrc-ta-hub(?:-dev)?', self.nginx_config)
 
     def test_nginx_does_not_forward_raw_cloud_run_host(self):
         self.assertNotIn('proxy_set_header Host $http_host;', self.nginx_config)

--- a/docs/notes/how/cloud-run.md
+++ b/docs/notes/how/cloud-run.md
@@ -18,6 +18,11 @@
 - 解決: デプロイ時の SHA 固定 tag をやめ、`gcloud run services update-traffic --update-tags=preview=LATEST` で stable な preview URL 1本へ集約する。あわせて `--remove-tags` で既存の `rev-*` tag を掃除し、設定をテストで固定する。
 - 教訓: アプリ側の host 対応だけでは「昔の revision URL がまだ外に残る」問題は止まらない。Cloud Run の tag 運用もセットで閉じないと、古いリビジョンがエラー源として居残る。
 
+## preview host は nginx 前段でも正規化する
+- 問題: Django middleware で preview host を正規化していても、nginx が raw `Host` を upstream にそのまま流すと、middleware より前で host を参照する経路や設定差分に対して `DisallowedHost` の再発余地が残る。
+- 解決: nginx の `map` で `vrc-ta-hub` 向け Cloud Run preview host だけを `vrc-ta-hub.com` に写像し、`proxy_set_header Host` で upstream へは正規ホストを渡す。Django 側 middleware は後段の防御として残す。
+- 教訓: Cloud Run preview URL 対応は Django だけで完結させず、proxy 前段でも raw host を止める二段構えにすると運用差分に強い。
+
 ## toGithubPagesJson 再生成
 - 問題: VRChat ワールド表示用 JSON は `noricha-vr/toGithubPagesJson` 側の GitHub Actions が生成しており、`vrc-ta-hub` 本番反映だけでは更新されない
 - 解決:

--- a/docs/notes/how/cloud-run.md
+++ b/docs/notes/how/cloud-run.md
@@ -20,8 +20,8 @@
 
 ## preview host は nginx 前段でも正規化する
 - 問題: Django middleware で preview host を正規化していても、nginx が raw `Host` を upstream にそのまま流すと、middleware より前で host を参照する経路や設定差分に対して `DisallowedHost` の再発余地が残る。
-- 解決: nginx の `map` で `vrc-ta-hub` 向け Cloud Run preview host だけを `vrc-ta-hub.com` に写像し、`proxy_set_header Host` で upstream へは正規ホストを渡す。Django 側 middleware は後段の防御として残す。
-- 教訓: Cloud Run preview URL 対応は Django だけで完結させず、proxy 前段でも raw host を止める二段構えにすると運用差分に強い。
+- 解決: nginx の `map` で `vrc-ta-hub` / `vrc-ta-hub-dev` 向け Cloud Run preview host を `vrc-ta-hub.com` に写像し、`proxy_set_header Host` で upstream へは正規ホストを渡す。Django 側 middleware は後段の防御として残す。
+- 教訓: Cloud Run preview URL 対応は Django だけで完結させず、proxy 前段でも raw host を止める二段構えにすると運用差分に強い。service 名を片系に固定すると dev 環境だけ再発するので、デプロイ先一覧とセットで見直す。
 
 ## toGithubPagesJson 再生成
 - 問題: VRChat ワールド表示用 JSON は `noricha-vr/toGithubPagesJson` 側の GitHub Actions が生成しており、`vrc-ta-hub` 本番反映だけでは更新されない

--- a/docs/notes/index.md
+++ b/docs/notes/index.md
@@ -19,6 +19,7 @@
 | ファイル | 日付 | 概要 |
 |----------|------|------|
 | db-sync-01.md | 04-06 | 本番DBからローカルへの初回同期 |
+| cloud-run-02.md | 04-06 | Cloud Run preview host を nginx 前段でも正規化 |
 | cloud-run-01.md | 04-05 | Cloud Run の古い tagged revision URL cleanup |
 | drf-spectacular-01.md | 04-01 | GatheringListSerializer の schema 生成エラー修正 |
 

--- a/docs/notes/logs/2026-04/cloud-run-02.md
+++ b/docs/notes/logs/2026-04/cloud-run-02.md
@@ -1,0 +1,10 @@
+## Cloud Run preview host を nginx 前段でも正規化した
+- 日付: 2026-04-06
+- 関連: #193
+- 状況: `rev-24d1224---vrc-ta-hub-...a.run.app` へのアクセスで `DisallowedHost` が再度観測され、Django middleware 側の補正だけでは前段の raw host 通過を完全には潰し切れていなかった。
+- 問題: nginx が `proxy_set_header Host $http_host;` のままで、Cloud Run preview host をそのまま Django に渡していた。
+- 対応:
+  1. `nginx-app.conf` に `vrc-ta-hub` 向け preview host だけを `vrc-ta-hub.com` に写像する `map` を追加
+  2. upstream に渡す `Host` を `$django_upstream_host` に切り替えた
+  3. `website.tests.test_nginx_config` を追加し、nginx 側の host 正規化ルールを回帰テスト化した
+- 関連PR: https://github.com/noricha-vr/vrc-ta-hub/pull/193

--- a/docs/notes/logs/2026-04/cloud-run-02.md
+++ b/docs/notes/logs/2026-04/cloud-run-02.md
@@ -4,7 +4,7 @@
 - 状況: `rev-24d1224---vrc-ta-hub-...a.run.app` へのアクセスで `DisallowedHost` が再度観測され、Django middleware 側の補正だけでは前段の raw host 通過を完全には潰し切れていなかった。
 - 問題: nginx が `proxy_set_header Host $http_host;` のままで、Cloud Run preview host をそのまま Django に渡していた。
 - 対応:
-  1. `nginx-app.conf` に `vrc-ta-hub` 向け preview host だけを `vrc-ta-hub.com` に写像する `map` を追加
+  1. `nginx-app.conf` に `vrc-ta-hub` / `vrc-ta-hub-dev` 向け preview host を `vrc-ta-hub.com` に写像する `map` を追加
   2. upstream に渡す `Host` を `$django_upstream_host` に切り替えた
   3. `website.tests.test_nginx_config` を追加し、nginx 側の host 正規化ルールを回帰テスト化した
 - 関連PR: https://github.com/noricha-vr/vrc-ta-hub/pull/193

--- a/nginx-app.conf
+++ b/nginx-app.conf
@@ -1,7 +1,7 @@
 # nginx-app.conf
 
 # Cloud Run の tagged preview host だけを正規ホストへ寄せて、
-# Django に raw run.app host が届かないようにする。
+# Django に raw run.app host が届かないようにする。参照: PR #193（Cloud Run preview host を nginx 前段で正規化した理由）
 map $http_host $django_upstream_host {
     default $http_host;
     ~^(?:[a-z0-9-]+---)?vrc-ta-hub-[a-z0-9]+-[a-z0-9]+\.a\.run\.app(?::\d+)?$ vrc-ta-hub.com;

--- a/nginx-app.conf
+++ b/nginx-app.conf
@@ -4,7 +4,7 @@
 # Django に raw run.app host が届かないようにする。参照: PR #193（Cloud Run preview host を nginx 前段で正規化した理由）
 map $http_host $django_upstream_host {
     default $http_host;
-    ~^(?:[a-z0-9-]+---)?vrc-ta-hub-[a-z0-9]+-[a-z0-9]+\.a\.run\.app(?::\d+)?$ vrc-ta-hub.com;
+    ~^(?:[a-z0-9-]+---)?vrc-ta-hub(?:-dev)?-[a-z0-9]+-[a-z0-9]+\.a\.run\.app(?::\d+)?$ vrc-ta-hub.com;
 }
 
 # the upstream component nginx needs to connect to

--- a/nginx-app.conf
+++ b/nginx-app.conf
@@ -1,5 +1,12 @@
 # nginx-app.conf
 
+# Cloud Run の tagged preview host だけを正規ホストへ寄せて、
+# Django に raw run.app host が届かないようにする。
+map $http_host $django_upstream_host {
+    default $http_host;
+    ~^(?:[a-z0-9-]+---)?vrc-ta-hub-[a-z0-9]+-[a-z0-9]+\.a\.run\.app(?::\d+)?$ vrc-ta-hub.com;
+}
+
 # the upstream component nginx needs to connect to
 upstream django {
     # server unix:/app.sock; # for a file socket
@@ -36,7 +43,7 @@ server {
     # Finally, send all non-media requests to the Django server.
     location / {
         proxy_pass  http://127.0.0.1:8000;
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $django_upstream_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## なぜこの変更が必要か

Cloud Run の tagged preview URL へのアクセスで `rev-24d1224---vrc-ta-hub-...a.run.app` のような host が nginx からそのまま Django へ渡り、`DisallowedHost` が発生していました。
Django 側には既に preview host 正規化があるものの、`Host` ヘッダをアプリに渡す前段でも正規ホストへ寄せておかないと、ミドルウェアより前で host を参照する経路や設定差分に対して脆く、再発余地が残ります。

## 変更内容

- nginx に、このサービスの Cloud Run preview host だけを `vrc-ta-hub.com` へ写像する `map` を追加
- upstream に渡す `Host` ヘッダを `$http_host` から `$django_upstream_host` に変更
- `nginx-app.conf` の host 正規化ルールを検証する回帰テストを追加

## 意思決定

### 採用アプローチ
- Cloud Run preview host を nginx で先に正規化し、Django ミドルウェアは後段の防御として残す方式を採用。理由: `DisallowedHost` の発火点より手前で raw host を止められ、既存の安全策も維持できるため

### 却下した代替案
- `ALLOWED_HOSTS` をさらに広げる → 却下: 許可範囲が広がるだけで、raw host がアプリに届く経路自体は残るため
- `Host` を常に固定文字列へ上書きする → 却下: 他 host の拒否まで潰してしまい、host ベースの防御を弱めるため

## テスト

- `docker run --rm -v "$PWD":/src -w /src/app -e DJANGO_SETTINGS_MODULE=website.settings -e DEBUG=True -e SECRET_KEY=test-key -e GOOGLE_API_KEY=dummy -e GOOGLE_CALENDAR_ID=dummy -e GEMINI_API_KEY=dummy -e OPENAI_API_KEY=dummy -e REQUEST_TOKEN=dummy -e TESTING=True -e EMAIL_FILE_PATH=/tmp/emails vrc-ta-hub-vrc-ta-hub python manage.py test website.tests.test_host_settings website.tests.test_cloudbuild_config website.tests.test_nginx_config -v 1`
- `docker run --rm -v "$PWD":/src -w /src/app -e DJANGO_SETTINGS_MODULE=website.settings -e DEBUG=True -e SECRET_KEY=test-key -e GOOGLE_API_KEY=dummy -e GOOGLE_CALENDAR_ID=dummy -e GEMINI_API_KEY=dummy -e OPENAI_API_KEY=dummy -e REQUEST_TOKEN=dummy -e TESTING=True -e EMAIL_FILE_PATH=/tmp/emails vrc-ta-hub-vrc-ta-hub python manage.py test website.tests ta_hub.tests.test_about_page event.tests.test_detail_history_rate_limit community.tests user_account.tests.test_discord_notification api_v1.tests -v 1`
- `docker run --rm -v "$PWD":/src -w /src vrc-ta-hub-vrc-ta-hub sh -lc 'cp /src/nginx-app.conf /etc/nginx/sites-available/default && nginx -t -c /etc/nginx/nginx.conf'`

---
このPRはfix-flowによる自動修正です。