### PR TITLE
DX: 外部サービスの初期設定手順を明記

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,56 +1,64 @@
+# ===== 必須: アプリ起動に必要 =====
+
 SECRET_KEY=
 DEBUG=True
 HTTP_HOST=localhost
 CSRF_TRUSTED_ORIGIN=http://localhost:8015
 HTTP_X_FORWARDED_PROTO=http  # ローカル開発はhttp、本番は設定不要（nginxが付加）
 
-# データベースの設定
+# データベースの設定（MySQL）
 DB_NAME=
 DB_USER=
 DB_PASSWORD=
 DB_HOST=
 
-# Cloudflare R2の設定
+# ===== 推奨: 主要機能に必要 =====
+
+# Google Calendar API — イベントカレンダー同期
+# 取得先: https://console.cloud.google.com/ > API とサービス > 認証情報
+GOOGLE_API_KEY=
+GOOGLE_CALENDAR_ID=
+GOOGLE_CALENDAR_CREDENTIALS=/app/credentials.json
+
+# Gemini API — AI コンテンツ自動生成（ブログ記事・要約・メタディスクリプション）
+# 取得先: https://aistudio.google.com/ > Get API key
+GEMINI_API_KEY=
+GEMINI_MODEL=google/gemini-2.5-flash-lite-preview-06-17
+
+# Discord OAuth — ユーザーの Discord ログイン
+# 取得先: https://discord.com/developers/applications > OAuth2
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+ACCOUNT_DEFAULT_HTTP_PROTOCOL=http  # 開発環境のみ設定（本番はデフォルトhttps）
+
+# ===== 任意: なくても基本開発は可能 =====
+
+# OpenRouter API — AI 処理のバックアップ（ブログ生成・定期イベント生成・ツイート文生成）
+# 取得先: https://openrouter.ai/ > Keys
+OPENAI_API_KEY=
+OPENROUTER_API_KEY=
+
+# バッチ処理の認証トークン（カレンダー同期 curl 実行時に使用）
+REQUEST_TOKEN=
+
+# イベント自動生成の設定
+DEFAULT_GENERATE_MONTHS=3  # デフォルトの生成月数（開発環境では1に設定推奨）
+
+# Cloudflare R2 — 静的ファイルストレージ（本番用）
+# ローカル開発では未設定でOK（ローカルファイルシステムにフォールバック）
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_STORAGE_BUCKET_NAME=
 AWS_S3_ENDPOINT_URL=
 AWS_S3_CUSTOM_DOMAIN=
 
-# ローカル開発では settings.py が以下のデフォルトを使います
-# STATICFILES_STORAGE=django.contrib.staticfiles.storage.StaticFilesStorage
-# DEFAULT_FILE_STORAGE=django.core.files.storage.FileSystemStorage
-# AWS_QUERYSTRING_AUTH=False
-
-# Google APIの設定
-GOOGLE_API_KEY=
-GEMINI_API_KEY=
-GEMINI_MODEL=google/gemini-2.5-flash-lite-preview-06-17
-
-# Google Calendar
-GOOGLE_CALENDAR_ID=
-GOOGLE_CALENDAR_CREDENTIALS=/app/credentials.json
-
-# バッチ処理の認証トークン
-REQUEST_TOKEN=
-
-# OpenAI / OpenRouter
-OPENAI_API_KEY=
-OPENROUTER_API_KEY=
-
-# イベント自動生成の設定
-DEFAULT_GENERATE_MONTHS=3  # デフォルトの生成月数（開発環境では1に設定推奨）
-
-# Discord OAuth設定
-DISCORD_CLIENT_ID=
-DISCORD_CLIENT_SECRET=
-ACCOUNT_DEFAULT_HTTP_PROTOCOL=http  # 開発環境のみ設定（本番はデフォルトhttps）
-
-# Discord Webhook（管理者通知用）
+# Discord Webhook — 管理者通知用
 DISCORD_WEBHOOK_URL=
 DISCORD_REPORT_WEBHOOK_URL=
 
-# X (Twitter) API設定（OAuth 1.0a 自動告知用）
+# X (Twitter) API — OAuth 1.0a 自動告知用
+# 取得先: https://developer.x.com/ でアプリ作成
+# アクセストークン生成: python manage.py generate_x_token
 X_API_KEY=
 X_API_SECRET=
 X_ACCESS_TOKEN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,14 +84,27 @@ docker compose exec vrc-ta-hub python scripts/generate_custom_events.py
 ログインが必要な動作確認時は `.env.local` の `TEST_USER_NAME` と `TEST_USER_PASSWORD` を参照。
 
 ## 環境変数（.env.local）
-- `OPENROUTER_API_KEY`: OpenRouter APIキー
-- `GOOGLE_API_KEY`: Google APIキー
-- `GEMINI_MODEL`: 使用するGeminiモデル（例: google/gemini-2.0-flash-001）
-- `DEBUG`: デバッグモード設定
 - `SECRET_KEY`: Djangoシークレットキー
-- `REQUEST_TOKEN`: カレンダー更新用トークン
-- `DISCORD_CLIENT_ID`: Discord OAuth用クライアントID
-- `DISCORD_CLIENT_SECRET`: Discord OAuth用シークレット
+- `DEBUG`: デバッグモード設定
+- `GOOGLE_API_KEY`: Google Calendar API キー
+- `GOOGLE_CALENDAR_ID`: 同期先の Google Calendar ID
+- `GEMINI_API_KEY`: Gemini API キー（コンテンツ自動生成）
+- `GEMINI_MODEL`: 使用するGeminiモデル（デフォルト: google/gemini-2.5-flash-lite-preview-06-17）
+- `OPENROUTER_API_KEY`: OpenRouter API キー（AI バックアップ）
+- `REQUEST_TOKEN`: バッチ処理認証用トークン
+- `DISCORD_CLIENT_ID`: Discord OAuth 用クライアント ID
+- `DISCORD_CLIENT_SECRET`: Discord OAuth 用シークレット
+
+### 外部サービスの初期設定
+
+各 API キーの取得手順は [docs/setup.md](docs/setup.md) を参照。
+
+| サービス | 設定する環境変数 | 取得先 |
+|----------|-----------------|--------|
+| Google Calendar API | `GOOGLE_API_KEY`, `GOOGLE_CALENDAR_ID` | [GCP Console](https://console.cloud.google.com/) |
+| Gemini API | `GEMINI_API_KEY` | [Google AI Studio](https://aistudio.google.com/) |
+| OpenRouter API | `OPENROUTER_API_KEY` | [OpenRouter](https://openrouter.ai/) |
+| Discord OAuth | `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET` | [Discord Developer Portal](https://discord.com/developers/applications) |
 
 ### Discord OAuth設定
 - 環境変数で設定するため、DBのSocialAppは使用しない

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,114 @@
+# 外部サービスの初期設定
+
+新規開発者が各外部サービスの認証情報を取得し、`.env.local` に設定するための手順。
+
+## Google Calendar API
+
+イベントカレンダーの同期に使用。
+
+1. [Google Cloud Console](https://console.cloud.google.com/) でプロジェクトを開く
+2. 「API とサービス」>「ライブラリ」で **Google Calendar API** を有効化
+3. 「認証情報」> API キーを作成（またはサービスアカウントを作成して JSON キーをダウンロード）
+4. `.env.local` に設定:
+
+```bash
+GOOGLE_API_KEY=取得したAPIキー
+GOOGLE_CALENDAR_ID=d80eac7bdea1505cd9bc16153047c261be94e78607896c5ca567f8cfa78f0be1@group.calendar.google.com
+```
+
+- `GOOGLE_CALENDAR_ID` の開発用 / 本番用の値は `CLAUDE.md` を参照
+- サービスアカウントの JSON キーを使う場合は `GOOGLE_CALENDAR_CREDENTIALS` にパスを設定
+
+## Gemini API
+
+AI によるコンテンツ自動生成（ブログ記事・要約・メタディスクリプション）に使用。
+
+1. [Google AI Studio](https://aistudio.google.com/) にアクセス
+2. 「Get API key」から API キーを取得
+3. `.env.local` に設定:
+
+```bash
+GEMINI_API_KEY=取得したAPIキー
+GEMINI_MODEL=google/gemini-2.5-flash-lite-preview-06-17
+```
+
+- `GEMINI_MODEL` は省略可（デフォルト値あり）
+
+## OpenRouter API
+
+AI 処理のバックアップ（ブログ生成・定期イベント生成・ツイート文生成）に使用。
+
+1. [OpenRouter](https://openrouter.ai/) でアカウント作成
+2. 「Keys」から API キーを取得
+3. `.env.local` に設定:
+
+```bash
+OPENROUTER_API_KEY=取得したAPIキー
+```
+
+## Discord OAuth
+
+ユーザーの Discord ログインに使用。
+
+1. [Discord Developer Portal](https://discord.com/developers/applications) でアプリケーションを作成
+2. 「OAuth2」タブを開く
+3. 「Redirects」にコールバック URL を追加:
+   - 開発環境: `http://localhost:8015/accounts/discord/login/callback/`
+4. 「Client ID」と「Client Secret」を取得
+5. `.env.local` に設定:
+
+```bash
+DISCORD_CLIENT_ID=取得したクライアントID
+DISCORD_CLIENT_SECRET=取得したクライアントシークレット
+ACCOUNT_DEFAULT_HTTP_PROTOCOL=http
+```
+
+- `ACCOUNT_DEFAULT_HTTP_PROTOCOL=http` は開発環境のみ（本番はデフォルト `https`）
+
+## Discord Webhook（任意）
+
+管理者通知に使用。開発時は未設定でも動作する。
+
+1. Discord サーバーの「チャンネル設定」>「連携サービス」>「ウェブフック」で作成
+2. `.env.local` に設定:
+
+```bash
+DISCORD_WEBHOOK_URL=ウェブフックURL
+DISCORD_REPORT_WEBHOOK_URL=レポート用ウェブフックURL
+```
+
+## X (Twitter) API（任意）
+
+イベント情報の自動ツイートに使用。開発時は未設定でも動作する。
+
+1. [X Developer Portal](https://developer.x.com/) でアプリを作成
+2. OAuth 1.0a の API Key / Secret を取得
+3. アクセストークンの生成:
+
+```bash
+docker compose exec vrc-ta-hub python manage.py generate_x_token
+```
+
+4. `.env.local` に設定:
+
+```bash
+X_API_KEY=取得したAPIキー
+X_API_SECRET=取得したAPIシークレット
+X_ACCESS_TOKEN=生成されたアクセストークン
+X_ACCESS_TOKEN_SECRET=生成されたアクセストークンシークレット
+```
+
+## 最低限必要な環境変数
+
+以下が設定されていれば基本的な開発が可能:
+
+| 環境変数 | 必須度 | 用途 |
+|----------|--------|------|
+| `SECRET_KEY` | 必須 | Django セッション・CSRF |
+| `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_HOST` | 必須 | MySQL 接続 |
+| `GOOGLE_API_KEY` | 推奨 | カレンダー同期 |
+| `GOOGLE_CALENDAR_ID` | 推奨 | 同期先カレンダー |
+| `GEMINI_API_KEY` | 推奨 | AI コンテンツ生成 |
+| `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET` | 推奨 | Discord ログイン |
+| `OPENROUTER_API_KEY` | 任意 | AI バックアップ |
+| `REQUEST_TOKEN` | 任意 | バッチ処理認証 |


### PR DESCRIPTION
Closes #202

## Summary

- 外部サービス（Google Calendar API / Gemini API / OpenRouter API / Discord OAuth / X API）の API キー取得手順を `docs/setup.md` に集約
- `CLAUDE.md` に「外部サービスの初期設定」セクションを追加し、サービス・環境変数・取得先の一覧テーブルと `docs/setup.md` へのリンクを配置
- `.env.example` を必須度別（必須 / 推奨 / 任意）にセクション分けし、各キーに用途と取得先のコメントを追記

## Test plan

- [ ] `docs/setup.md` の各リンク（GCP Console / AI Studio / OpenRouter / Discord Developer Portal / X Developer Portal）が正しく開けることを確認
- [ ] `.env.example` の全キーが `settings.py` の `os.environ.get()` / `os.getenv()` と一致していることを確認
- [ ] `CLAUDE.md` のテーブルが正しくレンダリングされることを確認

Generated with [Claude Code](https://claude.com/claude-code)