### PR TITLE
docs: 承認待ち案内文の承認主体を明確化

### DIFF
--- a/app/user_account/tests/test_views.py
+++ b/app/user_account/tests/test_views.py
@@ -214,6 +214,8 @@ class SettingsViewTests(TestCase):
 
         # 承認待ちメッセージが含まれていること
         self.assertIn('承認待ち', message_text)
+        self.assertIn('Hub運営スタッフに承認されると公開されるようになります。', message_text)
+        self.assertNotIn('既に公開されている技術・学術系集会に承認されると', message_text)
         # Discordリンクが含まれていること
         self.assertIn('https://discord.gg/6jCkUUb9VN', message_text)
         self.assertIn('技術・学術系Hub', message_text)

--- a/app/user_account/views.py
+++ b/app/user_account/views.py
@@ -136,7 +136,7 @@ class SettingsView(LoginRequiredMixin, TemplateView):
         # 承認されていない場合はメッセージを追加
         if context['community'] and not context['community'].is_accepted:
             message = mark_safe(
-                'この集会は現在承認待ちです。既に公開されている技術・学術系集会に承認されると公開されるようになります。'
+                'この集会は現在承認待ちです。Hub運営スタッフに承認されると公開されるようになります。'
                 'Discord <a href="https://discord.gg/6jCkUUb9VN" target="_blank" rel="noopener noreferrer" class="alert-link">技術・学術系Hub</a>にご参加ください。'
             )
             messages.warning(self.request, message)

--- a/docs/issue-228-approval-message.md
+++ b/docs/issue-228-approval-message.md
@@ -1,0 +1,32 @@
+# Issue #228 調査メモ
+
+## 対象
+
+- 画面: アカウント設定
+- URL: `http://localhost:8016/account/settings/`
+- Issue: `noricha-vr/vrc-ta-hub#228`
+
+## 観測結果
+
+- 承認待ち案内文は `app/user_account/views.py` の `SettingsView.get_context_data()` で `messages.warning()` により組み立てられていた。
+- 現行文言の「既に公開されている技術・学術系集会に承認されると」は、承認主体が既存集会側だと誤読できる。
+- 既存テスト `app/user_account/tests/test_views.py` には、警告表示と Discord リンクの存在確認があり、文言の意味までは固定していなかった。
+
+## 原因
+
+- 承認フローの説明文が、承認主体ではなく承認先のように読める表現になっていた。
+
+## 改善案
+
+- `SettingsView` の承認待ちメッセージを、承認主体が明示される「Hub運営スタッフに承認されると公開されるようになります。」へ修正する。
+- 回帰防止として、設定画面テストに新文言の存在確認と旧文言の不在確認を追加する。
+
+## 影響範囲の確認
+
+- 同系統の文言は `app/user_account/templates/account/email/welcome.html` にも存在するが、Issue #228 の再現箇所はアカウント設定画面に限定されている。
+- 今回は Issue の要求範囲に合わせて設定画面のみ変更し、追加展開は別Issueで扱える状態に留める。
+
+## 検証手順
+
+1. `app/user_account/tests/test_views.py` の対象テストを実行する。
+2. 承認待ち集会を持つユーザーで設定画面へアクセスした際、警告メッセージに新文言と Discord リンクが含まれることを確認する。


### PR DESCRIPTION
## なぜこの変更が必要か

Issue #228 では、アカウント設定画面の承認待ち案内文が「既に公開されている技術・学術系集会に承認されると」と読めるため、承認主体が既存集会側だと誤解される状態だった。
承認主体が Hub運営スタッフであることを画面上で明確にし、あわせて調査根拠と検証方法をリポジトリ内に残す必要がある。

## 変更内容

- アカウント設定画面の承認待ち案内文を「Hub運営スタッフに承認されると公開されるようになります。」へ修正
- 設定画面テストに新文言の存在確認と旧文言の不在確認を追加
- 調査結果、原因、影響範囲、検証手順を `docs/issue-228-approval-message.md` に記録

## 意思決定

### 採用アプローチ
- SettingsView のメッセージ文言のみを最小差分で修正。理由: Issue の再現箇所がアカウント設定画面に限定されており、既存の表示ロジックや Discord 導線はそのまま維持できるため。

### 却下した代替案
- 同系統の文言を含む welcome メールまで同時修正 → 却下: 今回の Issue で求められている修正範囲を超えるため。関連箇所として調査メモには残した。

## テスト

- `ruff check app/user_account/views.py app/user_account/tests/test_views.py`
- `docker compose exec -T vrc-ta-hub python manage.py test user_account.tests.test_views.SettingsViewTests`

Closes #228

---
このPRはfix-flowによる自動調査です。