### PR TITLE
fix: Cloud Run host正規化を強化

### DIFF
--- a/app/website/hosts.py
+++ b/app/website/hosts.py
@@ -1,0 +1,24 @@
+"""Host 関連の正規化ユーティリティ。"""
+
+import os
+from urllib.parse import urlsplit
+
+
+def normalize_host(value: str | None) -> str:
+    """URL/host どちらで渡されても host 部分だけを取り出す。"""
+    if not value:
+        return ''
+
+    candidate = value.strip().rstrip('/')
+    if '://' not in candidate:
+        candidate = f'//{candidate}'
+
+    parsed = urlsplit(candidate)
+    if parsed.hostname:
+        return parsed.hostname
+
+    return parsed.netloc.split('/')[0]
+
+
+def get_canonical_host() -> str:
+    return normalize_host(os.environ.get('APP_CANONICAL_HOST', 'vrc-ta-hub.com'))

--- a/app/website/middleware.py
+++ b/app/website/middleware.py
@@ -3,6 +3,8 @@
 import os
 import re
 
+from website.hosts import get_canonical_host
+
 
 DEFAULT_CLOUD_RUN_SERVICE_NAMES = (
     'vrc-ta-hub',
@@ -43,13 +45,16 @@ class CanonicalCloudRunHostMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
-        self.canonical_host = os.environ.get('APP_CANONICAL_HOST', 'vrc-ta-hub.com')
+        self.canonical_host = get_canonical_host()
         self.cloud_run_preview_host_pattern = _build_cloud_run_preview_host_pattern()
 
     def __call__(self, request):
-        raw_host = request.META.get('HTTP_HOST', '')
-        if self.cloud_run_preview_host_pattern.match(raw_host):
-            request.META['HTTP_HOST'] = self.canonical_host
+        host_meta_keys = ('HTTP_HOST', 'HTTP_X_FORWARDED_HOST', 'SERVER_NAME')
+        raw_hosts = [request.META.get(meta_key, '') for meta_key in host_meta_keys]
+        if any(self.cloud_run_preview_host_pattern.match(raw_host) for raw_host in raw_hosts):
+            for meta_key in host_meta_keys:
+                if request.META.get(meta_key):
+                    request.META[meta_key] = self.canonical_host
             request.META['SERVER_NAME'] = self.canonical_host
 
         return self.get_response(request)

--- a/app/website/settings.py
+++ b/app/website/settings.py
@@ -154,7 +154,7 @@ CORS_URLS_REGEX = r'^/api/.*$'
 AUTH_USER_MODEL = 'user_account.CustomUser'
 
 MIDDLEWARE = [
-    # Cloud Run preview host は raw Host のまま下流へ流さない。参照: PR #TODO
+    # Cloud Run preview host は raw Host のまま下流へ流さない。参照: PR #237
     'website.middleware.CanonicalCloudRunHostMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',

--- a/app/website/settings.py
+++ b/app/website/settings.py
@@ -14,6 +14,8 @@ import os
 import sys
 from pathlib import Path
 
+from website.hosts import get_canonical_host, normalize_host
+
 _settings_logger = logging.getLogger('django.settings')
 
 
@@ -30,15 +32,22 @@ def _split_csv_env(env_name: str) -> list[str]:
     return [item.strip() for item in value.split(',') if item.strip()]
 
 
+def _get_canonical_host() -> str:
+    return get_canonical_host()
+
+
+APP_CANONICAL_HOST = _get_canonical_host()
+
+
 def _build_allowed_hosts() -> list[str]:
     hosts = [
-        'vrc-ta-hub.com',
+        _get_canonical_host(),
         'localhost',
         '127.0.0.1',
         *_split_csv_env('ALLOWED_HOSTS'),
     ]
 
-    http_host = os.environ.get('HTTP_HOST')
+    http_host = normalize_host(os.environ.get('HTTP_HOST'))
     if http_host:
         hosts.append(http_host)
 
@@ -145,8 +154,9 @@ CORS_URLS_REGEX = r'^/api/.*$'
 AUTH_USER_MODEL = 'user_account.CustomUser'
 
 MIDDLEWARE = [
-    'corsheaders.middleware.CorsMiddleware',
+    # Cloud Run preview host は raw Host のまま下流へ流さない。参照: PR #TODO
     'website.middleware.CanonicalCloudRunHostMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/app/website/tests/test_host_settings.py
+++ b/app/website/tests/test_host_settings.py
@@ -45,17 +45,20 @@ class AllowedHostsSettingsTest(SimpleTestCase):
             else:
                 os.environ['CLOUD_RUN_SERVICE_NAMES'] = original_service_names
 
-    def test_build_allowed_hosts_includes_env_hosts_without_run_app_wildcard(self):
+    def test_build_allowed_hosts_includes_canonical_and_env_hosts_without_run_app_wildcard(self):
         original_allowed_hosts = os.environ.get('ALLOWED_HOSTS')
+        original_app_canonical_host = os.environ.get('APP_CANONICAL_HOST')
         original_http_host = os.environ.get('HTTP_HOST')
 
         try:
             os.environ['ALLOWED_HOSTS'] = 'example.com, api.example.com'
-            os.environ['HTTP_HOST'] = 'preview.example.com'
+            os.environ['APP_CANONICAL_HOST'] = 'https://preview.vrc-ta-hub.com:8443/'
+            os.environ['HTTP_HOST'] = 'https://preview.example.com:9443/'
 
             allowed_hosts = website_settings._build_allowed_hosts()
 
             self.assertNotIn('.a.run.app', website_settings.ALLOWED_HOSTS)
+            self.assertIn('preview.vrc-ta-hub.com', allowed_hosts)
             self.assertIn('example.com', allowed_hosts)
             self.assertIn('api.example.com', allowed_hosts)
             self.assertIn('preview.example.com', allowed_hosts)
@@ -64,6 +67,11 @@ class AllowedHostsSettingsTest(SimpleTestCase):
                 os.environ.pop('ALLOWED_HOSTS', None)
             else:
                 os.environ['ALLOWED_HOSTS'] = original_allowed_hosts
+
+            if original_app_canonical_host is None:
+                os.environ.pop('APP_CANONICAL_HOST', None)
+            else:
+                os.environ['APP_CANONICAL_HOST'] = original_app_canonical_host
 
             if original_http_host is None:
                 os.environ.pop('HTTP_HOST', None)
@@ -149,3 +157,47 @@ class AllowedHostsSettingsTest(SimpleTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode(), 'vrc-ta-hub.com')
+
+    @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+    )
+    def test_server_name_is_canonicalized_when_http_host_is_absent(self):
+        request = self.request_factory.get('/healthz/')
+        request.META.pop('HTTP_HOST', None)
+        request.META['SERVER_NAME'] = 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app'
+
+        CanonicalCloudRunHostMiddleware(lambda req: HttpResponse(req.get_host()))(request)
+
+        self.assertEqual(request.get_host(), 'vrc-ta-hub.com')
+
+    @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'preview.vrc-ta-hub.com'],
+    )
+    def test_cloud_run_revision_host_uses_normalized_canonical_host(self):
+        original_app_canonical_host = os.environ.get('APP_CANONICAL_HOST')
+
+        try:
+            os.environ['APP_CANONICAL_HOST'] = 'https://preview.vrc-ta-hub.com/'
+            request = self.request_factory.get(
+                '/healthz/',
+                HTTP_HOST='rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+            )
+
+            response = CanonicalCloudRunHostMiddleware(
+                lambda req: HttpResponse(req.get_host())
+            )(request)
+
+            self.assertEqual(response.content.decode(), 'preview.vrc-ta-hub.com')
+        finally:
+            if original_app_canonical_host is None:
+                os.environ.pop('APP_CANONICAL_HOST', None)
+            else:
+                os.environ['APP_CANONICAL_HOST'] = original_app_canonical_host
+
+    def test_host_canonicalization_middleware_runs_before_cors(self):
+        middleware = website_settings.MIDDLEWARE
+
+        self.assertLess(
+            middleware.index('website.middleware.CanonicalCloudRunHostMiddleware'),
+            middleware.index('corsheaders.middleware.CorsMiddleware'),
+        )

--- a/docs/notes/how/cloud-run.md
+++ b/docs/notes/how/cloud-run.md
@@ -28,6 +28,11 @@
 - 解決: Django middleware 側も `vrc-ta-hub` / `vrc-ta-hub-dev` を既定値に持つ service 名リストで preview host を判定し、nginx テストも同じ正規表現ソースを参照して整合を固定する。
 - 教訓: Host 正規化の条件は proxy とアプリで別々に推測させず、同じ service 群を前提にテストで縛るほうが追跡しやすい。
 
+## canonical host は helper で正規化して複数ヘッダ経路をまとめて潰す
+- 問題: `APP_CANONICAL_HOST` や `HTTP_HOST` が URL / host:port 形式で入ると、`ALLOWED_HOSTS` と middleware の正規化先がズレやすく、`HTTP_HOST` 以外の `SERVER_NAME` / `X-Forwarded-Host` に raw host が残る経路も取りこぼしやすい。
+- 解決: host 正規化 helper を settings / middleware で共通化し、Cloud Run preview host を検知したら `HTTP_HOST` / `HTTP_X_FORWARDED_HOST` / `SERVER_NAME` をまとめて canonical host へ寄せる。あわせて middleware を最上流に置き、下流 middleware より先に raw host を潰す。
+- 教訓: Host 正規化は「どの値を canonical とみなすか」と「どのヘッダ経路を潰すか」を別実装にしないほうが再発しにくい。
+
 ## toGithubPagesJson 再生成
 - 問題: VRChat ワールド表示用 JSON は `noricha-vr/toGithubPagesJson` 側の GitHub Actions が生成しており、`vrc-ta-hub` 本番反映だけでは更新されない
 - 解決:

--- a/docs/notes/index.md
+++ b/docs/notes/index.md
@@ -32,6 +32,7 @@
 | db-sync-01.md | 04-06 | 本番DBからローカルへの初回同期 |
 | cloud-run-02.md | 04-06 | Cloud Run preview host を nginx 前段でも正規化 |
 | cloud-run-03.md | 04-07 | Cloud Run preview host 判定を明示 service 名に寄せた |
+| cloud-run-04.md | 04-09 | Cloud Run host 正規化を helper ベースで強化した |
 | cloud-run-01.md | 04-05 | Cloud Run の古い tagged revision URL cleanup |
 | drf-spectacular-01.md | 04-01 | GatheringListSerializer の schema 生成エラー修正 |
 

--- a/docs/notes/logs/2026-04/cloud-run-04.md
+++ b/docs/notes/logs/2026-04/cloud-run-04.md
@@ -1,0 +1,11 @@
+## Cloud Run host 正規化を helper ベースで強化した
+- 日付: 2026-04-09
+- 関連: #237
+- 状況: `rev-24d1224---vrc-ta-hub-...a.run.app` の `DisallowedHost` 再発に対し、既存実装は `HTTP_HOST` 前提と `vrc-ta-hub.com` 固定のままで、proxy / env 差分の取りこぼし余地が残っていた。
+- 問題: `APP_CANONICAL_HOST` や `HTTP_HOST` が URL / host:port で入るケース、または `SERVER_NAME` / `HTTP_X_FORWARDED_HOST` に raw preview host が残るケースを一箇所で吸収できていなかった。
+- 対応:
+  1. `website.hosts` に canonical host 正規化 helper を追加した
+  2. settings と middleware の両方で同じ helper を使うようにした
+  3. preview host 検知時は `HTTP_HOST` / `HTTP_X_FORWARDED_HOST` / `SERVER_NAME` をまとめて canonical host へ寄せるようにした
+  4. middleware を `corsheaders` より前に移動し、順序もテストで固定した
+- → how/cloud-run.md に知識として追記済み


### PR DESCRIPTION
## なぜこの変更が必要か

Cloud Run の preview / revision URL で `DisallowedHost` が再発しており、既存実装では `HTTP_HOST` だけに寄せた正規化と `vrc-ta-hub.com` 固定の前提に依存していた。
そのため、proxy や実行環境の違いで `SERVER_NAME` / `X-Forwarded-Host` 側に raw host が残る経路や、`APP_CANONICAL_HOST` が URL 形式で設定されたときの取りこぼしを防いで、Host 正規化をより堅くしておく必要があった。

## 変更内容

- `website.hosts` を追加し、`APP_CANONICAL_HOST` / `HTTP_HOST` を URL 形式でも host だけに正規化できるようにした
- Cloud Run preview host の補正対象を `HTTP_HOST` だけでなく `HTTP_X_FORWARDED_HOST` / `SERVER_NAME` に広げた
- Host 正規化 middleware を `corsheaders` より前へ移動し、下流 middleware が raw host を見る前に補正するようにした
- canonical host の URL 正規化、`SERVER_NAME` 経路、middleware 順序を検証する回帰テストを追加した

## 意思決定

### 採用アプローチ
- host 正規化 helper を `settings.py` から分離し、settings と middleware の両方で同じロジックを使う方式を採用。理由: `website.middleware` 単体 import 時に settings の assert 群へ巻き込まれず、Host 正規化の責務も一箇所に寄せられるため
- `*.a.run.app` を `ALLOWED_HOSTS` に広く許可するのではなく、このサービスの preview host だけを canonical host へ寄せる方針を維持。理由: 他サービス由来の Host まで通さずに済むため

### 却下した代替案
- `ALLOWED_HOSTS` に `.a.run.app` を追加 → 却下: Cloud Run 上の別サービス Host まで許可範囲が広がるため
- `HTTP_HOST` のみ補正したままにする → 却下: proxy / 実行環境差分で `SERVER_NAME` や `X-Forwarded-Host` に raw host が残る経路を防ぎ切れないため

## テスト

- `DJANGO_SETTINGS_MODULE=website.settings PYTHONPATH=app TESTING=1 SECRET_KEY=test-key GOOGLE_API_KEY=dummy GOOGLE_CALENDAR_ID=dummy GEMINI_API_KEY=dummy REQUEST_TOKEN=dummy ./.venv/bin/python -m pytest app/website/tests/test_host_settings.py app/website/tests/test_nginx_config.py app/website/tests/test_cloudbuild_config.py -q`
- `DJANGO_SETTINGS_MODULE=website.settings PYTHONPATH=app TESTING=1 SECRET_KEY=test-key GOOGLE_API_KEY=dummy GOOGLE_CALENDAR_ID=dummy GEMINI_API_KEY=dummy REQUEST_TOKEN=dummy ./.venv/bin/python app/manage.py test website.tests --verbosity 1`
- `ruff check app/website/hosts.py app/website/settings.py app/website/middleware.py app/website/tests/test_host_settings.py`

---
このPRはfix-flowによる自動修正です。