### PR TITLE
fix: Cloud Run host判定の取りこぼしを防ぐ

### DIFF
--- a/app/website/middleware.py
+++ b/app/website/middleware.py
@@ -40,6 +40,14 @@ def _build_cloud_run_preview_host_pattern() -> re.Pattern[str]:
     )
 
 
+def _normalize_preview_host_candidate(value: str) -> str:
+    try:
+        return normalize_host(value)
+    except ValueError:
+        # 外部入力が壊れていても 500 にはせず、preview host 不一致として弾く。参照: PR #247
+        return ''
+
+
 class CanonicalCloudRunHostMiddleware:
     """Cloud Run のプレビューURLを正規ホストへ寄せる。"""
 
@@ -52,7 +60,7 @@ class CanonicalCloudRunHostMiddleware:
         host_meta_keys = ('HTTP_HOST', 'HTTP_X_FORWARDED_HOST', 'SERVER_NAME')
         # proxy 差分で absolute URL や host:port が混ざるので、判定前に host へ正規化する。参照: PR #247
         normalized_hosts = [
-            normalize_host(request.META.get(meta_key, ''))
+            _normalize_preview_host_candidate(request.META.get(meta_key, ''))
             for meta_key in host_meta_keys
         ]
         if any(

--- a/app/website/middleware.py
+++ b/app/website/middleware.py
@@ -50,6 +50,7 @@ class CanonicalCloudRunHostMiddleware:
 
     def __call__(self, request):
         host_meta_keys = ('HTTP_HOST', 'HTTP_X_FORWARDED_HOST', 'SERVER_NAME')
+        # proxy 差分で absolute URL や host:port が混ざるので、判定前に host へ正規化する。参照: PR #247
         normalized_hosts = [
             normalize_host(request.META.get(meta_key, ''))
             for meta_key in host_meta_keys

--- a/app/website/middleware.py
+++ b/app/website/middleware.py
@@ -3,7 +3,7 @@
 import os
 import re
 
-from website.hosts import get_canonical_host
+from website.hosts import get_canonical_host, normalize_host
 
 
 DEFAULT_CLOUD_RUN_SERVICE_NAMES = (
@@ -50,8 +50,14 @@ class CanonicalCloudRunHostMiddleware:
 
     def __call__(self, request):
         host_meta_keys = ('HTTP_HOST', 'HTTP_X_FORWARDED_HOST', 'SERVER_NAME')
-        raw_hosts = [request.META.get(meta_key, '') for meta_key in host_meta_keys]
-        if any(self.cloud_run_preview_host_pattern.match(raw_host) for raw_host in raw_hosts):
+        normalized_hosts = [
+            normalize_host(request.META.get(meta_key, ''))
+            for meta_key in host_meta_keys
+        ]
+        if any(
+            self.cloud_run_preview_host_pattern.match(raw_host)
+            for raw_host in normalized_hosts
+        ):
             for meta_key in host_meta_keys:
                 if request.META.get(meta_key):
                     request.META[meta_key] = self.canonical_host

--- a/app/website/tests/test_host_settings.py
+++ b/app/website/tests/test_host_settings.py
@@ -171,6 +171,23 @@ class AllowedHostsSettingsTest(SimpleTestCase):
         self.assertEqual(request.get_host(), 'vrc-ta-hub.com')
 
     @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+    )
+    def test_url_form_forwarded_host_is_canonicalized(self):
+        request = self.request_factory.get(
+            '/healthz/',
+            HTTP_X_FORWARDED_HOST='https://rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app:443/',
+        )
+        request.META.pop('HTTP_HOST', None)
+        request.META['SERVER_NAME'] = 'https://rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app:443/'
+
+        response = CanonicalCloudRunHostMiddleware(
+            lambda req: HttpResponse(req.get_host())
+        )(request)
+
+        self.assertEqual(response.content.decode(), 'vrc-ta-hub.com')
+
+    @override_settings(
         ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'preview.vrc-ta-hub.com'],
     )
     def test_cloud_run_revision_host_uses_normalized_canonical_host(self):

--- a/app/website/tests/test_host_settings.py
+++ b/app/website/tests/test_host_settings.py
@@ -188,6 +188,22 @@ class AllowedHostsSettingsTest(SimpleTestCase):
         self.assertEqual(response.content.decode(), 'vrc-ta-hub.com')
 
     @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+    )
+    def test_invalid_forwarded_host_does_not_crash_preview_host_detection(self):
+        request = self.request_factory.get(
+            '/healthz/',
+            HTTP_X_FORWARDED_HOST='[::1',
+        )
+        request.META.pop('HTTP_HOST', None)
+        request.META['SERVER_NAME'] = '[::1'
+
+        CanonicalCloudRunHostMiddleware(lambda req: HttpResponse('ok'))(request)
+
+        with self.assertRaises(DisallowedHost):
+            request.get_host()
+
+    @override_settings(
         ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'preview.vrc-ta-hub.com'],
     )
     def test_cloud_run_revision_host_uses_normalized_canonical_host(self):

--- a/docs/notes/logs/2026-04/cloud-run-05.md
+++ b/docs/notes/logs/2026-04/cloud-run-05.md
@@ -1,0 +1,10 @@
+## Cloud Run preview host の URL 形式入力を middleware 判定前に正規化した
+- 日付: 2026-04-16
+- 関連: #247
+- 状況: `DisallowedHost` 対応済みの Cloud Run preview host 判定でも、proxy や実行環境の差分で `HTTP_X_FORWARDED_HOST` / `SERVER_NAME` が absolute URL や `host:port` 形式で届くと、正規表現判定をすり抜ける余地があった。
+- 問題: preview host の許可方針自体は正しかったが、入力形式の揺れを吸収せずに regex へ渡していたため、raw host を canonical host へ寄せる前に取りこぼす可能性があった。
+- 対応:
+  1. `CanonicalCloudRunHostMiddleware` の判定前に `normalize_host()` を通した
+  2. `HTTP_X_FORWARDED_HOST` / `SERVER_NAME` が `https://rev-...a.run.app:443/` 形式で届くケースの回帰テストを追加した
+  3. middleware の判断コメントに `参照: PR #247` を残して背景追跡できるようにした
+- 教訓: Host header の安全性は「何を許可するか」だけでなく「何形式で届くか」を揃えて初めて担保できる。Cloud Run preview host 対応は、判定対象も canonical host と同じ正規化 helper に寄せるとズレに強い。


### PR DESCRIPTION
## なぜこの変更が必要か

Cloud Run の preview / revision URL 対応はすでに入っているものの、proxy や実行環境の差分で `HTTP_X_FORWARDED_HOST` / `SERVER_NAME` が absolute URL や `host:port` 形式で渡ると、middleware の preview host 判定をすり抜ける余地がありました。
その場合は正規ホストへの寄せ替えが走らず、`rev-...a.run.app` 系のアクセスで `DisallowedHost` が再発しうるため、Host 判定を入力形式の揺れに強くしておく必要があります。

## 変更内容

- Cloud Run preview host 判定の前に `normalize_host()` を通し、URL 形式や `host:port` 形式でも host 部分だけで判定するようにした
- `HTTP_X_FORWARDED_HOST` / `SERVER_NAME` が URL 形式で届くケースの回帰テストを追加した

## 意思決定

### 採用アプローチ
- 既存の `website.hosts.normalize_host()` を middleware 側でも使う方式を採用。理由: canonical host の正規化ロジックと判定前処理を同じ helper に寄せたほうが、settings / middleware 間のズレを増やさずに済むため

### 却下した代替案
- `ALLOWED_HOSTS` に `*.a.run.app` を追加する → 却下: 他サービス由来の Host まで許可範囲が広がるため
- proxy 層だけで吸収して Django 側の判定は据え置く → 却下: 実行環境差分やヘッダ形式の揺れをアプリ側で吸収できず、防御が片肺になるため

## テスト

- `docker compose -f docker-compose.test.yml run --rm test python -m pytest website/tests/test_host_settings.py website/tests/test_nginx_config.py website/tests/test_cloudbuild_config.py -q`
- `docker compose -f docker-compose.test.yml run --rm test python manage.py test website.tests.test_host_settings website.tests.test_nginx_config website.tests.test_cloudbuild_config --verbosity 1`
- `ruff check app/website/middleware.py app/website/tests/test_host_settings.py`

---
このPRはfix-flowによる自動修正です。