### PR TITLE
fix: 当日リマインドのPhase 0補完を復活

### DIFF
--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -794,10 +794,11 @@ class PostScheduledTweetsViewTest(AutoTweetTestBase):
         self.assertFalse(TweetQueue.objects.filter(tweet_type="daily_reminder").exists())
 
     @patch("twitter.views.post_tweet")
-    @patch("twitter.signals.threading.Thread")
-    def test_post_scheduled_tweets_does_not_create_missing_daily_reminder(self, mock_thread_cls, mock_post):
-        """daily_reminder が未作成ならスケジューラは補完作成しない"""
-        mock_thread_cls.return_value = MagicMock()
+    @patch("twitter.tweet_generator.generate_daily_reminder_tweet")
+    def test_post_scheduled_tweets_creates_missing_daily_reminder(self, mock_generate, mock_post):
+        """daily_reminder が未作成ならスケジューラが補完作成して同じ実行で投稿する"""
+        mock_generate.return_value = "今日の発表リマインド"
+        mock_post.return_value = {"id": "dr-missing-1", "text": "今日の発表リマインド"}
 
         today_event = Event.objects.create(
             community=self.community,
@@ -821,9 +822,13 @@ class PostScheduledTweetsViewTest(AutoTweetTestBase):
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertEqual(data["created"], 0)
-        self.assertFalse(TweetQueue.objects.filter(tweet_type="daily_reminder").exists())
-        mock_post.assert_not_called()
+        self.assertEqual(data["created"], 1)
+        self.assertEqual(data["processed"], 1)
+        reminder_queue = TweetQueue.objects.get(tweet_type="daily_reminder")
+        self.assertEqual(reminder_queue.event, today_event)
+        self.assertEqual(reminder_queue.status, "posted")
+        self.assertEqual(reminder_queue.generated_text, "今日の発表リマインド")
+        mock_post.assert_called_once_with("今日の発表リマインド", media_ids=None)
 
     @patch("twitter.views.post_tweet")
     def test_post_scheduled_tweets_with_pregenerated_text(self, mock_post):

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
-from django.db import models
+from django.db import IntegrityError, models, transaction
 from django.http import Http404, HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
@@ -29,6 +29,7 @@ from .utils import format_event_info, generate_tweet, generate_tweet_url
 from .x_api import post_tweet, upload_media
 
 TWEET_QUEUE_PAGINATE_BY = 20
+REMINDER_DETAIL_TYPES = ("LT", "SPECIAL")
 SAME_DAY_INDIVIDUAL_SKIP_REASON = '当日リマインドに統合したため個別告知は投稿しません'
 
 
@@ -204,10 +205,50 @@ def _retry_generation(queue_item) -> None:
         logger.error("Retry generation failed for queue %d", queue_item.pk)
 
 
+def _create_daily_reminder_queues(today=None) -> int:
+    """当日開催イベント向けの missing なリマインドキューを補完作成する。"""
+    today = today or timezone.localdate()
+    today_events = (
+        Event.objects.filter(
+            date=today,
+            details__status='approved',
+            details__detail_type__in=REMINDER_DETAIL_TYPES,
+        )
+        .select_related('community')
+        .distinct()
+    )
+
+    created_count = 0
+    for event in today_events:
+        try:
+            with transaction.atomic():
+                queue_item, created = TweetQueue.objects.get_or_create(
+                    event=event,
+                    tweet_type='daily_reminder',
+                    defaults={
+                        'community': event.community,
+                    },
+                )
+        except IntegrityError:
+            logger.info("Skipped concurrent daily reminder tweet for event %d", event.pk)
+            continue
+
+        if not created:
+            continue
+
+        # 同じ 19:00 実行で投稿対象に含めるため、作成後すぐ生成まで進める。
+        _retry_generation(queue_item)
+        created_count += 1
+        logger.info("Queued daily reminder tweet for event %d", event.pk)
+
+    return created_count
+
+
 @require_http_methods(["GET"])
 def post_scheduled_tweets(request):
     """Cloud Scheduler から毎日 19:00 JST に呼ばれるエンドポイント。
 
+    Phase 0: 当日イベントの missing なリマインドキュー作成
     Phase 1: 生成失敗/停滞キューのリトライ
     Phase 2: ready キューの投稿
     """
@@ -215,7 +256,7 @@ def post_scheduled_tweets(request):
     if request_token != os.environ.get("REQUEST_TOKEN", ""):
         return HttpResponse("Unauthorized", status=401)
 
-    created_count = 0
+    created_count = _create_daily_reminder_queues()
 
     # Phase 1: 生成リトライ（generation_failed + 1時間以上前の generating）
     retry_threshold = timezone.now() - timedelta(hours=RETRY_THRESHOLD_HOURS)


### PR DESCRIPTION
## なぜこの変更が必要か

2026年4月14日の変更で、19:00 バッチが当日イベントの `daily_reminder` を補完作成する Phase 0 が外れていました。
その結果、当日に EventDetail の保存が発生しないイベントでは当日リマインドキューが作成されず、4月15日以降の本番運用で予約されるべき告知がキュー一覧に現れない状態になっていました。

## 変更内容

- `post_scheduled_tweets` に当日 `daily_reminder` の missing 分を補完する Phase 0 を復活
- 同一 19:00 実行の中でそのまま投稿対象に入るよう、作成直後に `_retry_generation` を実行
- `PostScheduledTweetsViewTest` を更新し、missing な当日リマインドが補完作成されて同じ実行で投稿されることを固定

## 意思決定

### 採用アプローチ
- 4月14日以前の Scheduler 主導の補完ロジックを最小差分で戻しました。理由は、当日編集が入らないイベントでも確実にリマインドを作れるためです。

### 却下した代替案
- signal ベースの当日同期だけで維持する案
  - 却下理由: 当日に EventDetail の保存が発生しないケースを拾えず、運用欠落を再発させるためです。

### トレードオフ
- signal と scheduler の二段構えになりますが、重複は `get_or_create` と既存の一意制約で抑えられるため、確実性を優先しました。

## テスト

- [x] `docker compose exec -e DB_HOST=host.docker.internal -e DB_PORT=3306 -e DB_NAME=local_vrc_ta_hub -e DB_USER=root -e DB_PASSWORD=root vrc-ta-hub python manage.py test twitter.tests.test_auto_tweet.PostScheduledTweetsViewTest --verbosity 1`
- [x] 本番DBをローカルへ復元後、対象の承認済み LT/SPECIAL からポストキューを再構築して想定件数を確認
- [x] ローカル `/twitter/queue/` で対象集会名と `投稿待ち` / `スキップ` 表示を確認

---
🤖 Generated with [Codex](https://codex.com)