### PR TITLE
fix: X API エラー時にレスポンスボディもログ出力

### DIFF
--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -1584,18 +1584,23 @@ class PostTweetFunctionTest(TestCase):
 
     @patch("twitter.x_api.requests.post")
     def test_post_tweet_api_error_with_response(self, mock_post):
-        """API エラー時にレスポンスがある場合もステータスコードをログ出力する"""
+        """API エラー時にレスポンスがある場合はステータスコードとボディをログ出力する"""
         import requests
         mock_response = MagicMock()
         mock_response.status_code = 403
+        mock_response.text = '{"detail": "You are not permitted to perform this action."}'
         error = requests.RequestException("Forbidden")
         error.response = mock_response
         mock_post.side_effect = error
 
         with patch.dict("os.environ", self.OAUTH1_ENV):
             from twitter.x_api import post_tweet
-            result = post_tweet("テスト")
+            with self.assertLogs("twitter.x_api", level="ERROR") as log_ctx:
+                result = post_tweet("テスト")
         self.assertIsNone(result)
+        combined = "\n".join(log_ctx.output)
+        self.assertIn("403", combined)
+        self.assertIn("not permitted", combined)
 
     def test_post_tweet_missing_partial_credentials(self):
         """一部の認証情報だけ設定されている場合は None を返す"""
@@ -1686,6 +1691,30 @@ class UploadMediaFunctionTest(TestCase):
             result = upload_media(self.ALLOWED_IMAGE_URL)
 
         self.assertIsNone(result)
+
+    @patch("twitter.x_api.requests.post")
+    @patch("twitter.x_api.requests.get")
+    def test_upload_media_upload_failure_with_response(self, mock_get, mock_post):
+        """X API アップロード失敗時にレスポンスがある場合はステータスとボディをログ出力する"""
+        import requests
+
+        mock_get.return_value = self._make_stream_response(content_type="image/png")
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.text = '{"errors": [{"message": "media type not allowed"}]}'
+        error = requests.RequestException("Forbidden")
+        error.response = mock_response
+        mock_post.side_effect = error
+
+        with patch.dict("os.environ", self.OAUTH1_ENV):
+            from twitter.x_api import upload_media
+            with self.assertLogs("twitter.x_api", level="ERROR") as log_ctx:
+                result = upload_media(self.ALLOWED_IMAGE_URL)
+
+        self.assertIsNone(result)
+        combined = "\n".join(log_ctx.output)
+        self.assertIn("403", combined)
+        self.assertIn("media type not allowed", combined)
 
     # --- SSRF防止テスト ---
     def test_upload_media_blocks_untrusted_domain(self):

--- a/app/twitter/x_api.py
+++ b/app/twitter/x_api.py
@@ -112,6 +112,12 @@ def upload_media(image_url: str) -> str | None:
         return media_id
     except requests.RequestException as e:
         logger.error("Failed to upload media: %s", e)
+        if hasattr(e, "response") and e.response is not None:
+            logger.error(
+                "Response status: %s body: %s",
+                e.response.status_code,
+                e.response.text[:1000],
+            )
         return None
 
 
@@ -160,5 +166,9 @@ def post_tweet(text: str, media_ids: list[str] | None = None) -> dict | None:
     except requests.RequestException as e:
         logger.error("Failed to post tweet: %s", e)
         if hasattr(e, "response") and e.response is not None:
-            logger.error("Response status: %s", e.response.status_code)
+            logger.error(
+                "Response status: %s body: %s",
+                e.response.status_code,
+                e.response.text[:1000],
+            )
         return None


### PR DESCRIPTION
## 背景

queue 38/39 の投稿が `POST https://api.x.com/2/tweets` で 403 Forbidden となり失敗した（2026-04-18 19:00 JST の Cloud Scheduler 実行）。ログには以下しか残っておらず、具体的な拒否理由が判別できなかった:

\`\`\`
ERROR Failed to post tweet: 403 Client Error: Forbidden for url: https://api.x.com/2/tweets
ERROR Response status: 403
\`\`\`

同じバッチで queue 40 は成功しているため、認証情報やレート制限ではなく**投稿内容/メディア起因**の可能性が高い。原因特定のためレスポンスボディを可視化する。

## 変更内容

- \`app/twitter/x_api.py\` の \`post_tweet\` / \`upload_media\` の \`except requests.RequestException\` で、\`e.response.text[:1000]\` をログに追加
- 1000 文字で切って CDN 由来の巨大 HTML エラーページ対策
- テスト追加: \`test_post_tweet_api_error_with_response\` を強化、\`test_upload_media_upload_failure_with_response\` を新規追加

## セキュリティ

- X API のエラーレスポンスは \`{"detail": ...}\` / \`{"errors": [{"message": ...}]}\` 形式で、**OAuth トークンやリクエストヘッダはエコーされない**
- \`requests.RequestException.response\` はサーバ応答のみ保持し、送信側認証情報は含まれない
- 機密情報漏洩リスクは構造上なし（security-checker レビュー済み）

## 検証

- \`twitter.tests.test_auto_tweet\` の対象4テストすべて PASS
  - \`test_post_tweet_api_error\`
  - \`test_post_tweet_api_error_with_response\`
  - \`test_upload_media_upload_failure\`
  - \`test_upload_media_upload_failure_with_response\`

## デプロイ後の運用

このログ改善により、次回の失敗時は具体的な拒否理由（重複投稿 / 禁止語 / メディア権限 等）が判別可能になる。