### PR TITLE
fix: Vket参加の欠損カラムを再検査する

### DIFF
--- a/app/vket/migrations/0008_recheck_stage_registered_at_column.py
+++ b/app/vket/migrations/0008_recheck_stage_registered_at_column.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+def recheck_stage_registered_at_column(apps, schema_editor):
+    VketParticipation = apps.get_model("vket", "VketParticipation")
+    table_name = VketParticipation._meta.db_table
+
+    with schema_editor.connection.cursor() as cursor:
+        existing_columns = {
+            column.name
+            for column in schema_editor.connection.introspection.get_table_description(
+                cursor,
+                table_name,
+            )
+        }
+
+    if "stage_registered_at" in existing_columns:
+        return
+
+    field = models.DateTimeField("ステージ登録日時", null=True, blank=True)
+    field.set_attributes_from_name("stage_registered_at")
+    schema_editor.add_field(VketParticipation, field)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("vket", "0007_ensure_stage_registered_at_column"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            recheck_stage_registered_at_column,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/app/vket/tests/test_schedule_lock.py
+++ b/app/vket/tests/test_schedule_lock.py
@@ -1,5 +1,6 @@
 """Vketコラボ期間中の日時変更・削除ロックのテスト（参照: PR #138）"""
 
+from importlib import import_module
 from datetime import time, timedelta
 
 from django.contrib.auth import get_user_model
@@ -15,6 +16,86 @@ from vket.models import VketCollaboration, VketParticipation
 from vket.services import get_vket_lock_info, is_event_locked_by_vket, get_vket_lock_message
 
 User = get_user_model()
+
+
+class _MigrationColumn:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _MigrationCursor:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _MigrationIntrospection:
+    def __init__(self, column_names):
+        self.column_names = column_names
+        self.inspected_table = None
+
+    def get_table_description(self, cursor, table_name):
+        self.inspected_table = table_name
+        return [_MigrationColumn(name) for name in self.column_names]
+
+
+class _MigrationConnection:
+    def __init__(self, column_names):
+        self.introspection = _MigrationIntrospection(column_names)
+
+    def cursor(self):
+        return _MigrationCursor()
+
+
+class _MigrationSchemaEditor:
+    def __init__(self, column_names):
+        self.connection = _MigrationConnection(column_names)
+        self.added_fields = []
+
+    def add_field(self, model, field):
+        self.added_fields.append((model, field))
+
+
+class _MigrationApps:
+    @staticmethod
+    def get_model(app_label, model_name):
+        assert app_label == "vket"
+        assert model_name == "VketParticipation"
+
+        class HistoricalVketParticipation:
+            class _meta:
+                db_table = "vket_participation"
+
+        return HistoricalVketParticipation
+
+
+class VketStageRegisteredAtMigrationTests(TestCase):
+    def setUp(self):
+        module = import_module("vket.migrations.0008_recheck_stage_registered_at_column")
+        self.migration_func = module.recheck_stage_registered_at_column
+
+    def test_recheck_migration_adds_stage_registered_at_when_missing(self):
+        schema_editor = _MigrationSchemaEditor(["id", "progress", "updated_at"])
+
+        self.migration_func(_MigrationApps(), schema_editor)
+
+        self.assertEqual(schema_editor.connection.introspection.inspected_table, "vket_participation")
+        self.assertEqual(len(schema_editor.added_fields), 1)
+        model, field = schema_editor.added_fields[0]
+        self.assertEqual(model._meta.db_table, "vket_participation")
+        self.assertEqual(field.name, "stage_registered_at")
+        self.assertEqual(field.verbose_name, "ステージ登録日時")
+        self.assertTrue(field.null)
+        self.assertTrue(field.blank)
+
+    def test_recheck_migration_skips_existing_stage_registered_at(self):
+        schema_editor = _MigrationSchemaEditor(["id", "stage_registered_at", "updated_at"])
+
+        self.migration_func(_MigrationApps(), schema_editor)
+
+        self.assertEqual(schema_editor.added_fields, [])
 
 
 class VketScheduleLockServiceTests(TestCase):


### PR DESCRIPTION
## なぜこの変更が必要か

本番系の Vket 参加テーブルで `stage_registered_at` カラムの有無が migration 履歴と実スキーマでずれると、Vket 参加のロック判定やステージ登録状態の参照で再び落ちる可能性がある。
運用者が migration 履歴だけでは検知できないスキーマ欠損を安全に補修できるよう、冪等な再検査 migration が必要だった。

## 変更内容

- `vket` に `0008_recheck_stage_registered_at_column` migration を追加
- migration 実行時に実テーブルのカラム一覧を introspection し、欠けている場合だけ `stage_registered_at` を追加
- 既にカラムがある環境では何もしないようにして冪等性を確保
- カラム欠損時に追加されること、既存時にスキップされることの migration 単体テストを追加

## 意思決定

### 採用アプローチ
- `RunPython` で実スキーマを直接確認して `schema_editor.add_field()` する方式を採用。理由: migration 履歴が正常でも実テーブルだけ欠けた状態を補修するには、Django の状態定義だけでなく DB 実体を見に行く必要があるため。

### 却下した代替案
- 通常の `AddField` migration を再度置く → 却下: 既にカラムがある環境で重複追加になり得るため。
- 手動 SQL 運用で直す → 却下: 環境差分をコード化できず、再発時に同じ確認が必要になるため。

### トレードオフ
- migration に introspection 処理が入るが、欠損環境と正常環境の両方で安全に走る冪等性を優先した。

## テスト

- [x] GitHub Actions `lint`
- [x] GitHub Actions `test`
- [x] GitGuardian Security Checks
- [x] Cloud Build preview deploy `vrc-ta-hub-dev (vrc-ta-hub)`

---
🤖 Generated with [Codex](https://Codex.com/Codex)