### PR TITLE
fix: 集会一覧の検索件数取得を軽量化

### DIFF
--- a/app/community/tests/test_views.py
+++ b/app/community/tests/test_views.py
@@ -1,9 +1,12 @@
-from django.test import TestCase, Client
+from django.test import TestCase, Client, RequestFactory
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.core import mail
 from datetime import date, timedelta, time
 
+from community.views.public import CommunityListView
 from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
 
@@ -42,6 +45,27 @@ class TestCommunityListViewPagination(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.community.name)
+
+    def test_count_query_does_not_group_by_events(self):
+        Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=7),
+            start_time=time(21, 0),
+            duration=60,
+        )
+        request = RequestFactory().get(reverse('community:list'))
+        view = CommunityListView()
+        view.setup(request)
+
+        with CaptureQueriesContext(connection) as captured:
+            self.assertEqual(view.get_queryset().count(), 1)
+
+        count_sql = ' '.join(
+            query['sql'] for query in captured.captured_queries
+            if 'COUNT' in query['sql'].upper()
+        ).upper()
+        self.assertIn('COUNT', count_sql)
+        self.assertNotIn('GROUP BY', count_sql)
 
 
 class AcceptViewTest(TestCase):

--- a/app/community/views/public.py
+++ b/app/community/views/public.py
@@ -2,7 +2,7 @@
 import logging
 
 from django.core.paginator import InvalidPage
-from django.db.models import Min, Q, F
+from django.db.models import Q, F, OuterRef, Subquery
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils import timezone
@@ -43,23 +43,17 @@ class CommunityListView(ListView):
 
         return super().get(request, *args, **kwargs)
 
-    def get_queryset(self):
+    def get_filtered_queryset(self):
+        if hasattr(self, '_filtered_queryset'):
+            return self._filtered_queryset
+
         queryset = super().get_queryset()
-        now = timezone.now()
         # 承認済みでアクティブな集会（終了日がない）、かつポスター画像がある
         queryset = queryset.filter(
             status='approved',
             end_at__isnull=True,
             poster_image__isnull=False
         ).exclude(poster_image='')
-
-        # 最新のイベント日を取得
-        queryset = queryset.annotate(
-            latest_event_date=Min(
-                'events__date',
-                filter=Q(events__date__gte=now.date())
-            )
-        )
 
         form = CommunitySearchForm(self.request.GET)
         if form.is_valid():
@@ -77,14 +71,40 @@ class CommunityListView(ListView):
                     tag_filters |= Q(tags__contains=[tag])
                 queryset = queryset.filter(tag_filters)
 
+        self._filtered_queryset = queryset
+        return queryset
+
+    def get_search_count(self):
+        if not hasattr(self, '_search_count'):
+            self._search_count = self.get_filtered_queryset().count()
+        return self._search_count
+
+    def get_queryset(self):
+        if hasattr(self, '_ordered_queryset'):
+            return self._ordered_queryset
+
+        queryset = self.get_filtered_queryset()
+        now = timezone.now()
+
+        latest_event_date = Event.objects.filter(
+            community=OuterRef('pk'),
+            date__gte=now.date(),
+        ).order_by('date').values('date')[:1]
+
+        queryset = queryset.annotate(
+            latest_event_date=Subquery(latest_event_date)
+        )
+
         # 最新のイベント日でソート（NULL値は最後に）
         queryset = queryset.order_by(
             F('latest_event_date').asc(nulls_last=True),
             '-updated_at'
         )
-        logger.info(f'検索結果: {queryset.count()}件')
-        if queryset.count() == 0:
+        search_count = self.get_search_count()
+        logger.info(f'検索結果: {search_count}件')
+        if search_count == 0:
             logger.info('現在開催中の集会はありません。')
+        self._ordered_queryset = queryset
         return queryset
 
     def get_context_data(self, **kwargs):
@@ -116,7 +136,7 @@ class CommunityListView(ListView):
         # タグの選択肢をコンテキストに追加
         context['tag_choices'] = dict(TAGS)
         # 検索結果の件数をコンテキストに追加
-        context['search_count'] = self.get_queryset().count()
+        context['search_count'] = self.get_search_count()
         return context
 
 

--- a/docs/notes/how/community-list-query.md
+++ b/docs/notes/how/community-list-query.md
@@ -1,0 +1,18 @@
+# Community List Query
+
+## 問題
+
+`CommunityListView` で `Min(events__date)` の集約アノテーションを付けた queryset に対して `count()` すると、MySQL では `GROUP BY` を含む count SQL になりやすい。
+
+この経路は Django が MySQL の GROUP BY 機能情報を参照するため、DB 接続が不安定なタイミングで一覧ページの 500 に直結しやすい。
+
+## 解決
+
+- 検索条件を適用した Community queryset と、表示順用の `latest_event_date` 付与を分ける。
+- `search_count` は検索条件適用済み queryset で数える。
+- `latest_event_date` は `Subquery` で未来イベントの最短日付を取得し、一覧の並び順だけに使う。
+- 回帰テストでは `count()` SQL に `GROUP BY` が含まれないことを確認する。
+
+## 教訓
+
+一覧ページの count に不要な集約・join を載せない。表示用の annotation と件数計算は分離する。

--- a/docs/notes/index.md
+++ b/docs/notes/index.md
@@ -4,6 +4,7 @@
 
 | ファイル | 概要 |
 |----------|------|
+| community-list-query.md | Community list の count と表示用 annotation の分離 |
 | twitter-queue.md | Twitter Queue パターン |
 
 ## logs/
@@ -13,4 +14,5 @@
 | ファイル | 日付 | 概要 |
 |----------|------|------|
 | cloud-run-04.md | 04-09 | Cloud Run host 正規化を helper ベースで強化した |
+| community-list-query-01.md | 04-20 | Community list の count から GROUP BY を外した |
 | twitter-queue-01.md | 04-17 | 当日リマインドの Phase 0 復活と本番キュー再登録 |

--- a/docs/notes/logs/2026-04/community-list-query-01.md
+++ b/docs/notes/logs/2026-04/community-list-query-01.md
@@ -1,0 +1,8 @@
+## Community list の count から GROUP BY を外した
+- 日付: 2026-04-20
+- 関連: error_reporting app_exception `/community/list/`
+- 状況 / 問題 / 対応
+  - `/community/list/` の検索一覧で `Min(events__date)` 集約アノテーション付き queryset に `count()` していた。
+  - MySQL では count SQL が `GROUP BY` を含む形になり、DB 接続情報参照の経路で 500 が観測された。
+  - 検索条件適用済み queryset と表示順用 `latest_event_date` を分離し、`latest_event_date` は `Subquery` で取得する形へ変更した。
+- → how/community-list-query.md に知識として追記済み


### PR DESCRIPTION
## なぜこの変更が必要か

`CommunityListView` は未来イベント日の最小値を `Min(events__date)` で annotation した queryset に対して件数取得していたため、MySQL では count SQL に `GROUP BY` が入りやすい状態だった。
集会一覧はユーザーの入口であり、DB 接続が不安定なタイミングでも不要な集約 count で 500 を起こさないようにする必要がある。

## 変更内容

- 検索条件適用済み queryset と表示順用 annotation を分離
- 件数取得は annotation なしの queryset で実行し、`search_count` をキャッシュ
- `latest_event_date` は `Subquery` で未来イベントの最短日付を取得し、並び順だけに利用
- count SQL に `GROUP BY` が含まれないことを確認する回帰テストを追加
- `docs/notes` に Community list query の運用メモを追加

## 意思決定

### 採用アプローチ
- 集約 `Min()` ではなく `Subquery` で表示用日付を付与する方式を採用。理由: 件数計算と表示用並び順を分けられ、count に不要な `GROUP BY` を載せずに済むため。

### 却下した代替案
- `distinct()` や集約 count のままチューニングする → 却下: DB 方言や Django の SQL 生成に依存し、一覧件数取得の単純さを取り戻せないため。
- 件数表示を削る → 却下: ユーザーに見えている情報を消さずに根本原因を避けられるため。

### トレードオフ
- 表示用 annotation の実装は少し複雑になるが、検索件数取得を軽く明確にすることを優先した。

## テスト

- [x] GitHub Actions `lint`
- [x] GitHub Actions `test`
- [x] GitGuardian Security Checks
- [x] Cloud Build preview deploy `vrc-ta-hub-dev (vrc-ta-hub)`

---
🤖 Generated with [Codex](https://Codex.com/Codex)