### PR TITLE
fix: 集会一覧の重複クエリ評価を削減

### DIFF
--- a/app/community/tests/test_views.py
+++ b/app/community/tests/test_views.py
@@ -3,8 +3,10 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.core import mail
 from datetime import date, timedelta, time
+from unittest.mock import patch
 
 from community.models import Community, CommunityMember
+from community.views.public import CommunityListView
 from event.models import Event, EventDetail
 
 CustomUser = get_user_model()
@@ -42,6 +44,44 @@ class TestCommunityListViewPagination(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.community.name)
+
+    def test_filtered_page_builds_queryset_once(self):
+        for index in range(20):
+            Community.objects.create(
+                name=f'土曜集会{index}',
+                status='approved',
+                frequency='毎週',
+                organizers='テスト主催者',
+                poster_image=f'poster/sat-{index}.jpg',
+                weekdays=['Sat'],
+            )
+
+        original_get_queryset = CommunityListView.get_queryset
+        call_count = 0
+
+        def counting_get_queryset(view):
+            nonlocal call_count
+            call_count += 1
+            return original_get_queryset(view)
+
+        url = (
+            f"{reverse('community:list')}"
+            "?page=2"
+            "&query=土曜"
+            "&amp;amp%3Bamp%3Btags=academic"
+            "&amp%3Bweekdays=Other"
+        )
+        with patch.object(
+            CommunityListView,
+            'get_queryset',
+            autospec=True,
+            side_effect=counting_get_queryset,
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '件数：20')
+        self.assertEqual(call_count, 1)
 
 
 class AcceptViewTest(TestCase):

--- a/app/community/views/public.py
+++ b/app/community/views/public.py
@@ -1,8 +1,8 @@
 """公開ページ: 集会一覧、集会詳細、アーカイブ一覧."""
 import logging
 
-from django.core.paginator import InvalidPage
 from django.db.models import Min, Q, F
+from django.http import Http404
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils import timezone
@@ -25,23 +25,19 @@ class CommunityListView(ListView):
     paginate_by = 18
 
     def get(self, request, *args, **kwargs):
-        # 通常のget処理の前にページ番号をチェック
-        page = request.GET.get(self.page_kwarg) or 1
         self.object_list = self.get_queryset()
-
-        paginator = self.get_paginator(self.object_list, self.paginate_by)
-        if page == 'last':
-            return super().get(request, *args, **kwargs)
-
         try:
-            paginator.validate_number(page)
-        except InvalidPage:
+            context = self.get_context_data()
+        except Http404:
+            page = request.GET.get(self.page_kwarg) or 1
+            if page == 'last':
+                raise
             # クエリパラメータを維持したまま1ページ目にリダイレクト
             params = request.GET.copy()
             params[self.page_kwarg] = 1
             return redirect(f"{request.path}?{params.urlencode()}")
 
-        return super().get(request, *args, **kwargs)
+        return self.render_to_response(context)
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -82,9 +78,6 @@ class CommunityListView(ListView):
             F('latest_event_date').asc(nulls_last=True),
             '-updated_at'
         )
-        logger.info(f'検索結果: {queryset.count()}件')
-        if queryset.count() == 0:
-            logger.info('現在開催中の集会はありません。')
         return queryset
 
     def get_context_data(self, **kwargs):
@@ -116,7 +109,10 @@ class CommunityListView(ListView):
         # タグの選択肢をコンテキストに追加
         context['tag_choices'] = dict(TAGS)
         # 検索結果の件数をコンテキストに追加
-        context['search_count'] = self.get_queryset().count()
+        context['search_count'] = context['paginator'].count
+        logger.info('検索結果: %s件', context['search_count'])
+        if context['search_count'] == 0:
+            logger.info('現在開催中の集会はありません。')
         return context
 
 


### PR DESCRIPTION
## なぜこの変更が必要か

集会一覧ページではページ番号検証とテンプレート用 context 作成の両方で queryset を評価しており、フィルタ付き一覧で同じ検索条件の DB 評価が重複していた。
ユーザーが検索・ページ移動をしたときの応答を軽くし、DB 接続が不安定な状況でも不要な評価を減らす必要がある。

## 変更内容

- `CommunityListView.get()` で `get_queryset()` を一度だけ呼び、取得済み `object_list` から context を作るよう変更
- ページ範囲外は `Http404` を捕捉して 1 ページ目へリダイレクトする挙動を維持
- `search_count` は paginator の count を使い、再度 `get_queryset().count()` しないよう変更
- フィルタ付き 2 ページ目で queryset 構築が 1 回に収まる回帰テストを追加

## 意思決定

### 採用アプローチ
- Django `ListView` の流れを大きく変えず、`object_list` を先に確定して `get_context_data()` に渡す方式を採用。理由: 既存の pagination / context 処理を活かしながら重複評価だけを削れるため。

### 却下した代替案
- 件数表示を削除する → 却下: UI の情報量を下げずに改善できるため。
- 独自 paginator を導入する → 却下: 今回の問題は queryset 評価回数であり、標準 paginator の範囲で解決できるため。

### トレードオフ
- `get()` の制御が少し明示的になるが、DB 評価回数を安定させることを優先した。

## テスト

- [x] GitHub Actions `lint`
- [x] GitHub Actions `test`
- [x] GitGuardian Security Checks
- [x] Cloud Build preview deploy `vrc-ta-hub-dev (vrc-ta-hub)`

---
🤖 Generated with [Codex](https://Codex.com/Codex)