### PR TITLE
fix: Cloud Runホスト拒否時の正規化を補強

### DIFF
--- a/app/website/middleware.py
+++ b/app/website/middleware.py
@@ -3,6 +3,8 @@
 import os
 import re
 
+from django.core.exceptions import DisallowedHost
+
 from website.hosts import get_canonical_host, normalize_host
 
 
@@ -48,6 +50,14 @@ def _normalize_preview_host_candidate(value: str) -> str:
         return ''
 
 
+def _extract_disallowed_host(error: DisallowedHost) -> str:
+    match = re.search(r"Invalid HTTP_HOST header: '([^']+)'", str(error))
+    if match:
+        return match.group(1)
+
+    return ''
+
+
 class CanonicalCloudRunHostMiddleware:
     """Cloud Run のプレビューURLを正規ホストへ寄せる。"""
 
@@ -56,20 +66,41 @@ class CanonicalCloudRunHostMiddleware:
         self.canonical_host = get_canonical_host()
         self.cloud_run_preview_host_pattern = _build_cloud_run_preview_host_pattern()
 
-    def __call__(self, request):
+    def _is_supported_preview_host(self, value: str) -> bool:
+        normalized_host = _normalize_preview_host_candidate(value)
+        return bool(self.cloud_run_preview_host_pattern.match(normalized_host))
+
+    def _canonicalize_request_host(self, request) -> bool:
         host_meta_keys = ('HTTP_HOST', 'HTTP_X_FORWARDED_HOST', 'SERVER_NAME')
         # proxy 差分で absolute URL や host:port が混ざるので、判定前に host へ正規化する。参照: PR #247
-        normalized_hosts = [
-            _normalize_preview_host_candidate(request.META.get(meta_key, ''))
-            for meta_key in host_meta_keys
-        ]
         if any(
-            self.cloud_run_preview_host_pattern.match(raw_host)
-            for raw_host in normalized_hosts
+            self._is_supported_preview_host(request.META.get(meta_key, ''))
+            for meta_key in host_meta_keys
         ):
             for meta_key in host_meta_keys:
                 if request.META.get(meta_key):
                     request.META[meta_key] = self.canonical_host
             request.META['SERVER_NAME'] = self.canonical_host
+            return True
 
-        return self.get_response(request)
+        return False
+
+    def __call__(self, request):
+        self._canonicalize_request_host(request)
+
+        try:
+            return self.get_response(request)
+        except DisallowedHost as error:
+            if getattr(request, 'resolver_match', None) is not None:
+                raise
+
+            disallowed_host = _extract_disallowed_host(error)
+            # 観測ログと同じ Django get_host() 経由の拒否だけを、同じ service 名ホワイトリストで救済する。参照: PR #247
+            if not self._is_supported_preview_host(disallowed_host):
+                raise
+
+            request.META['HTTP_HOST'] = self.canonical_host
+            request.META['SERVER_NAME'] = self.canonical_host
+            if request.META.get('HTTP_X_FORWARDED_HOST'):
+                request.META['HTTP_X_FORWARDED_HOST'] = self.canonical_host
+            return self.get_response(request)

--- a/app/website/tests/test_host_middleware.py
+++ b/app/website/tests/test_host_middleware.py
@@ -1,0 +1,79 @@
+"""Cloud Run host 正規化 middleware の回帰テスト。"""
+
+from django.core.exceptions import DisallowedHost
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from website.middleware import CanonicalCloudRunHostMiddleware
+
+
+class CanonicalCloudRunHostMiddlewareTest(SimpleTestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+
+    @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+    )
+    def test_cloud_run_revision_host_reported_by_disallowed_host_is_canonicalized(self):
+        calls = []
+
+        def get_response(request):
+            calls.append(request.get_host())
+            if len(calls) == 1:
+                raise DisallowedHost(
+                    "Invalid HTTP_HOST header: 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app'. "
+                    "You may need to add 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app' to ALLOWED_HOSTS."
+                )
+            return HttpResponse(request.get_host())
+
+        request = self.request_factory.get(
+            '/healthz/',
+            HTTP_HOST='rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+        )
+
+        response = CanonicalCloudRunHostMiddleware(get_response)(request)
+
+        self.assertEqual(calls, ['vrc-ta-hub.com', 'vrc-ta-hub.com'])
+        self.assertEqual(response.content.decode(), 'vrc-ta-hub.com')
+
+    @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+    )
+    def test_disallowed_host_fallback_rejects_other_cloud_run_service(self):
+        def get_response(_request):
+            raise DisallowedHost(
+                "Invalid HTTP_HOST header: 'rev-24d1224---other-service-mhbhtr6sha-an.a.run.app'. "
+                "You may need to add 'rev-24d1224---other-service-mhbhtr6sha-an.a.run.app' to ALLOWED_HOSTS."
+            )
+
+        request = self.request_factory.get(
+            '/healthz/',
+            HTTP_HOST='rev-24d1224---other-service-mhbhtr6sha-an.a.run.app',
+        )
+
+        with self.assertRaises(DisallowedHost):
+            CanonicalCloudRunHostMiddleware(get_response)(request)
+
+    @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+    )
+    def test_disallowed_host_fallback_does_not_retry_after_url_resolution(self):
+        calls = []
+
+        def get_response(_request):
+            calls.append('called')
+            raise DisallowedHost(
+                "Invalid HTTP_HOST header: 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app'. "
+                "You may need to add 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app' to ALLOWED_HOSTS."
+            )
+
+        request = self.request_factory.get(
+            '/healthz/',
+            HTTP_HOST='rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+        )
+        request.resolver_match = object()
+
+        with self.assertRaises(DisallowedHost):
+            CanonicalCloudRunHostMiddleware(get_response)(request)
+
+        self.assertEqual(calls, ['called'])


### PR DESCRIPTION
## なぜこの変更が必要か

Cloud Run の preview / revision host が Django の `ALLOWED_HOSTS` 判定まで raw host のまま届くと、正規ホストへ寄せる middleware が先に入っていても `DisallowedHost` が発生することがある。
運用者は preview URL や Cloud Run 経由のヘルスチェックで 400/500 相当の拒否を受けるため、観測済みの Cloud Run host だけを安全に救済する必要がある。

## 変更内容

- `CanonicalCloudRunHostMiddleware` に `DisallowedHost` 捕捉後の正規化リトライを追加
- Cloud Run preview host 判定を helper 化し、通常の `META` 正規化と例外時フォールバックで同じ判定を使うよう整理
- 他 service の `run.app` host や URL 解決後の `DisallowedHost` は救済しない回帰テストを追加

## 意思決定

### 採用アプローチ
- `DisallowedHost` のメッセージから拒否 host を抽出し、既存の service 名ホワイトリストに一致する場合だけ再試行する方式を採用。理由: `ALLOWED_HOSTS` を広げず、観測された Cloud Run preview host だけを最小範囲で救済できるため。

### 却下した代替案
- `ALLOWED_HOSTS` に `*.run.app` 相当を追加する → 却下: 他 service の host まで許可し、Host header 境界が広がるため。
- すべての `DisallowedHost` を正規化して再試行する → 却下: URL 解決後や別原因の拒否まで隠してしまうため。

### トレードオフ
- 例外メッセージの形式に依存する処理を追加する代わりに、救済対象を Cloud Run preview host に限定して fail closed を維持した。

## テスト

- [x] GitHub Actions `lint`
- [x] GitHub Actions `test`
- [x] GitGuardian Security Checks
- [x] Cloud Build preview deploy `vrc-ta-hub-dev (vrc-ta-hub)`

---
🤖 Generated with [Codex](https://Codex.com/Codex)