### PR TITLE
アーカイブ済み集会の終了表示を改善

### DIFF
--- a/app/community/templates/community/detail.html
+++ b/app/community/templates/community/detail.html
@@ -67,6 +67,12 @@
                                 </div>
                             {% endif %}
                         </div>
+                        {% if community.end_at %}
+                            <div class="alert alert-secondary d-flex align-items-center mb-4" role="status">
+                                <i class="bi bi-archive me-2"></i>
+                                <span>この集会は終了しています</span>
+                            </div>
+                        {% endif %}
                         
                         <!-- タグ -->
                         {% if community.tags %}
@@ -247,7 +253,7 @@
         </div>
 
 
-        {% if scheduled_events %}
+        {% if scheduled_events and not community.end_at %}
         <div class="card my-5 shadow community-table-card">
             <div class="card-body">
                 <h2 class="fs-3 fw-bold my-5 text-center">
@@ -402,34 +408,36 @@
     </div>
 
     {# 通報ボタン #}
-    <div class="text-center my-4">
-        <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#reportModal">
-            <i class="bi bi-exclamation-triangle me-1"></i>この集会が開催されていないかもしれない
-        </button>
-    </div>
+    {% if not community.end_at %}
+        <div class="text-center my-4">
+            <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#reportModal">
+                <i class="bi bi-exclamation-triangle me-1"></i>この集会が開催されていないかもしれない
+            </button>
+        </div>
 
-    {# 通報モーダル #}
-    <div class="modal fade" id="reportModal" tabindex="-1" aria-labelledby="reportModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="reportModalLabel">活動停止の通報</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <p>この集会が現在開催されていない可能性がある場合、運営チームに通報できます。</p>
-                    <p class="text-muted small">通報内容は運営チームのみが確認します。匿名で送信されます。</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
-                    <form action="{% url 'community:report' community.pk %}" method="post">
-                        {% csrf_token %}
-                        <button type="submit" class="btn btn-warning">通報する</button>
-                    </form>
+        {# 通報モーダル #}
+        <div class="modal fade" id="reportModal" tabindex="-1" aria-labelledby="reportModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="reportModalLabel">活動停止の通報</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>この集会が現在開催されていない可能性がある場合、運営チームに通報できます。</p>
+                        <p class="text-muted small">通報内容は運営チームのみが確認します。匿名で送信されます。</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
+                        <form action="{% url 'community:report' community.pk %}" method="post">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-warning">通報する</button>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    {% endif %}
 
     <!-- Superuserの場合はコミュニティーのユーザーの連絡先を表示 -->
     {% if request.user.is_superuser %}

--- a/app/community/tests/test_views.py
+++ b/app/community/tests/test_views.py
@@ -441,6 +441,47 @@ class CommunityDetailViewLtApplicationSectionTest(TestCase):
         self.assertNotContains(response, 'LT発表を申し込む')
 
 
+class CommunityDetailArchiveNoticeTest(TestCase):
+    """コミュニティ詳細ページのアーカイブ表示テスト"""
+
+    def setUp(self):
+        self.client = Client()
+        self.community = Community.objects.create(
+            name='アーカイブ表示テスト集会',
+            status='approved',
+            frequency='毎週',
+            organizers='テスト主催者',
+        )
+        self.future_event = Event.objects.create(
+            community=self.community,
+            date=date.today() + timedelta(days=7),
+            start_time=time(21, 0),
+            duration=60,
+        )
+        self.url = reverse('community:detail', kwargs={'pk': self.community.pk})
+
+    def test_active_community_shows_report_button_without_archive_notice(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'この集会は終了しています')
+        self.assertContains(response, 'この集会が開催されていないかもしれない')
+        self.assertContains(response, 'reportModal')
+        self.assertContains(response, 'アーカイブ表示テスト集会の開催日程')
+
+    def test_archived_community_shows_notice_and_hides_report_button(self):
+        self.community.end_at = date.today() - timedelta(days=1)
+        self.community.save(update_fields=['end_at'])
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'この集会は終了しています')
+        self.assertNotContains(response, 'この集会が開催されていないかもしれない')
+        self.assertNotContains(response, 'reportModal')
+        self.assertNotContains(response, 'アーカイブ表示テスト集会の開催日程')
+
+
 class CommunityUpdateViewPromotionBannerTest(TestCase):
     """CommunityUpdateViewのプロモーションバナー表示テスト"""
 


### PR DESCRIPTION
## 概要
- アーカイブ済み集会の詳細ヘッダーに「この集会は終了しています」を表示
- アーカイブ済み集会では活動停止通報ボタンとモーダルを非表示
- アーカイブ済み集会では未来予定が残っていても開催日程カードを非表示

## なぜ必要か
アーカイブ済みの集会ページで、終了済みであることが明確に伝わらず、さらに「開催されていないかもしれない」通報導線や開催日程カードが残ると状態が矛盾して見えるため。

## テスト
- `docker compose exec vrc-ta-hub python manage.py test community.tests.test_views.CommunityDetailArchiveNoticeTest`
- `docker compose exec vrc-ta-hub python manage.py test community.tests.test_views`
- `git diff --check -- app/community/templates/community/detail.html app/community/tests/test_views.py`
- `curl -s --max-time 10 http://localhost:8015/community/25/ | rg -n "この集会は終了しています|量子力学のたわいのない雑談の会の開催日程|この集会が開催されていないかもしれない|reportModal"`
- Playwright screenshot: `docs/tmp/screenshots/community-25-archived-no-schedule-card.png`
