### PR TITLE
fix: トップページLT一覧キャッシュをEventDetail変更時に削除

### DIFF
--- a/app/ta_hub/apps.py
+++ b/app/ta_hub/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class TaHubConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'ta_hub'
+
+    def ready(self):
+        import ta_hub.signals  # noqa: F401

--- a/app/ta_hub/index_cache.py
+++ b/app/ta_hub/index_cache.py
@@ -1,0 +1,15 @@
+from django.core.cache import cache
+
+from utils.vrchat_time import get_vrchat_today
+
+
+def get_index_view_cache_key(day=None):
+    """トップページのDB由来データキャッシュキーを返す。"""
+    if day is None:
+        day = get_vrchat_today()
+    return f'index_view_data_{day}'
+
+
+def clear_index_view_cache(day=None):
+    """トップページのDB由来データキャッシュを削除する。"""
+    cache.delete(get_index_view_cache_key(day))

--- a/app/ta_hub/signals.py
+++ b/app/ta_hub/signals.py
@@ -1,0 +1,46 @@
+from django.db import transaction
+from django.db.models.signals import post_delete, post_save, pre_save
+from django.dispatch import receiver
+
+from event.models import EventDetail
+from ta_hub.index_cache import clear_index_view_cache
+
+INDEX_VISIBLE_DETAIL_TYPES = {'LT', 'SPECIAL'}
+
+
+@receiver(pre_save, sender=EventDetail)
+def remember_event_detail_index_type(sender, instance, **kwargs):
+    """保存前の種別を保持し、LT/SPECIALから別種別へ変わるケースも拾う。"""
+    instance._old_index_detail_type = None
+    if not instance.pk:
+        return
+
+    try:
+        old = EventDetail.objects.only('detail_type').get(pk=instance.pk)
+    except EventDetail.DoesNotExist:
+        return
+
+    instance._old_index_detail_type = old.detail_type
+
+
+def _touches_index_visible_detail(instance):
+    return (
+        instance.detail_type in INDEX_VISIBLE_DETAIL_TYPES
+        or getattr(instance, '_old_index_detail_type', None) in INDEX_VISIBLE_DETAIL_TYPES
+    )
+
+
+@receiver(post_save, sender=EventDetail)
+def clear_index_cache_on_event_detail_save(sender, instance, **kwargs):
+    if not _touches_index_visible_detail(instance):
+        return
+
+    transaction.on_commit(clear_index_view_cache)
+
+
+@receiver(post_delete, sender=EventDetail)
+def clear_index_cache_on_event_detail_delete(sender, instance, **kwargs):
+    if instance.detail_type not in INDEX_VISIBLE_DETAIL_TYPES:
+        return
+
+    transaction.on_commit(clear_index_view_cache)

--- a/app/ta_hub/tests/test_index_view_degraded_mode.py
+++ b/app/ta_hub/tests/test_index_view_degraded_mode.py
@@ -1,10 +1,15 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.core.cache import cache
 from django.db.utils import OperationalError
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.utils import timezone
 
+from community.models import Community
+from event.models import Event, EventDetail
+from ta_hub.index_cache import get_index_view_cache_key
 from ta_hub.views import VKET_ACHIEVEMENTS
 
 
@@ -73,3 +78,89 @@ class IndexViewDegradedModeTest(TestCase):
         self.assertEqual(response.context["upcoming_event_details"], [])
         self.assertEqual(response.context["special_events"], [])
         mock_post_filter.assert_called_once()
+
+
+class IndexViewEventDetailCacheInvalidationTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.cache_key = get_index_view_cache_key()
+        self.community = Community.objects.create(
+            name='キャッシュ検証集会',
+            status='approved',
+            frequency='毎週',
+        )
+        self.event = Event.objects.create(
+            community=self.community,
+            date=timezone.localdate() - timedelta(days=1),
+            start_time='22:00',
+            duration=60,
+            weekday='Mon',
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def _set_stale_index_cache(self):
+        cache.set(self.cache_key, {'upcoming_event_details': ['stale']}, 60)
+        self.assertIsNotNone(cache.get(self.cache_key))
+
+    def test_lt_creation_clears_index_cache(self):
+        self._set_stale_index_cache()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            EventDetail.objects.create(
+                event=self.event,
+                detail_type='LT',
+                speaker='新規登壇者',
+                theme='新規LT',
+                status='approved',
+            )
+
+        self.assertIsNone(cache.get(self.cache_key))
+
+    def test_lt_update_clears_index_cache(self):
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            speaker='更新前',
+            theme='更新前LT',
+            status='approved',
+        )
+        self._set_stale_index_cache()
+
+        detail.theme = '更新後LT'
+        with self.captureOnCommitCallbacks(execute=True):
+            detail.save(update_fields=['theme'])
+
+        self.assertIsNone(cache.get(self.cache_key))
+
+    def test_lt_delete_clears_index_cache(self):
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            speaker='削除対象',
+            theme='削除対象LT',
+            status='approved',
+        )
+        self._set_stale_index_cache()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            detail.delete()
+
+        self.assertIsNone(cache.get(self.cache_key))
+
+    def test_blog_update_keeps_index_cache(self):
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='BLOG',
+            speaker='ブログ登壇者',
+            theme='ブログ記事',
+            status='approved',
+        )
+        self._set_stale_index_cache()
+
+        detail.theme = 'ブログ記事更新'
+        with self.captureOnCommitCallbacks(execute=True):
+            detail.save(update_fields=['theme'])
+
+        self.assertIsNotNone(cache.get(self.cache_key))

--- a/app/ta_hub/views.py
+++ b/app/ta_hub/views.py
@@ -12,6 +12,7 @@ from event.models import Event, EventDetail
 from event.views import EventListView
 from event_calendar.calendar_utils import generate_google_calendar_url
 from news.models import Post
+from ta_hub.index_cache import get_index_view_cache_key
 from utils.vrchat_time import get_vrchat_today
 
 logger = logging.getLogger(__name__)
@@ -46,7 +47,7 @@ class IndexView(TemplateView):
         # キャッシュキーの生成（日付ベース）
         # VRChatterの生活リズムに合わせて朝4時を日付の境界とする
         today = get_vrchat_today()
-        cache_key = f'index_view_data_{today}'
+        cache_key = get_index_view_cache_key(today)
 
         # Vketコラボ告知の表示判定
         current_datetime = timezone.now()

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -3,6 +3,7 @@
 from datetime import time, timedelta
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -10,6 +11,7 @@ from django.utils import timezone
 
 from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
+from ta_hub.index_cache import get_index_view_cache_key
 from vket.models import (
     VketCollaboration,
     VketNotice,
@@ -580,6 +582,7 @@ class VketApplyFlowTests(TestCase):
 class VketManageViewsTests(TestCase):
     def setUp(self):
         self.client = Client()
+        cache.clear()
         self.superuser = User.objects.create_superuser(
             user_name='admin_user',
             email='admin@example.com',
@@ -646,6 +649,9 @@ class VketManageViewsTests(TestCase):
             confirmed_start_time='21:30',
             confirmed_duration=60,
         )
+
+    def tearDown(self):
+        cache.clear()
 
     def test_manage_page_requires_staff(self):
         """管理画面はstaff権限が必要"""
@@ -767,6 +773,8 @@ class VketManageViewsTests(TestCase):
             duration=30,
             status='approved',
         )
+        cache_key = get_index_view_cache_key()
+        cache.set(cache_key, {'upcoming_event_details': ['stale']}, 60)
         new_date = self.collaboration.period_start
         response = self.client.post(
             reverse(
@@ -789,6 +797,7 @@ class VketManageViewsTests(TestCase):
 
         detail.refresh_from_db()
         self.assertEqual(detail.start_time.strftime('%H:%M'), '22:15')
+        self.assertIsNone(cache.get(cache_key))
 
     def test_manage_participation_update_rejects_foreign_event_detail(self):
         """別のイベントのEventDetailは更新できない"""
@@ -886,6 +895,8 @@ class VketManageViewsTests(TestCase):
             requested_start_time='21:45',
             status=VketPresentation.Status.DRAFT,
         )
+        cache_key = get_index_view_cache_key()
+        cache.set(cache_key, {'upcoming_event_details': ['stale']}, 60)
         new_date = self.collaboration.period_start + timedelta(days=1)
         self.client.post(
             reverse(
@@ -906,6 +917,7 @@ class VketManageViewsTests(TestCase):
         self.assertIsNotNone(pres.published_event_detail)
         self.assertEqual(pres.published_event_detail.speaker, '新規登壇者')
         self.assertEqual(pres.published_event_detail.event_id, self.event1.id)
+        self.assertIsNone(cache.get(cache_key))
 
     def test_manage_page_shows_draft_badge(self):
         """管理画面でDRAFTのLTに「申請中」バッジが表示される"""
@@ -1797,6 +1809,7 @@ class VketPublishViewTests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        cache.clear()
         self.superuser = User.objects.create_superuser(
             user_name='admin_pub',
             email='admin_pub@example.com',
@@ -1825,6 +1838,9 @@ class VketPublishViewTests(TestCase):
             confirmed_start_time='21:00',
             confirmed_duration=60,
         )
+
+    def tearDown(self):
+        cache.clear()
 
     def test_publish_creates_event_and_updates_participation(self):
         """公開処理でEventが作成されpublished_eventが紐づく"""
@@ -1902,3 +1918,46 @@ class VketPublishViewTests(TestCase):
         # EventDetail が作成され、start_time に requested_start_time が使われていること
         detail = EventDetail.objects.get(event=event)
         self.assertEqual(detail.start_time.strftime('%H:%M'), '21:30')
+
+    def test_publish_clears_index_cache_when_updating_existing_event_detail(self):
+        """公開処理で既存EventDetailをbulk updateした場合もトップページキャッシュを削除する"""
+        event = Event.objects.create(
+            community=self.community,
+            date=self.collaboration.period_start,
+            start_time='21:00',
+            duration=60,
+            weekday='Fri',
+        )
+        self.participation.published_event = event
+        self.participation.save(update_fields=['published_event', 'updated_at'])
+        detail = EventDetail.objects.create(
+            event=event,
+            detail_type='LT',
+            speaker='更新前登壇者',
+            theme='更新前テーマ',
+            start_time='21:00',
+            status='approved',
+        )
+        VketPresentation.objects.create(
+            participation=self.participation,
+            order=0,
+            speaker='更新後登壇者',
+            theme='更新後テーマ',
+            requested_start_time=time(21, 30),
+            status=VketPresentation.Status.CONFIRMED,
+            published_event_detail=detail,
+        )
+        cache_key = get_index_view_cache_key()
+        cache.set(cache_key, {'upcoming_event_details': ['stale']}, 60)
+
+        self.client.login(username='admin_pub', password='adminpass123')
+        response = self.client.post(
+            reverse('vket:manage_publish', kwargs={'pk': self.collaboration.pk}),
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        detail.refresh_from_db()
+        self.assertEqual(detail.speaker, '更新後登壇者')
+        self.assertEqual(detail.start_time.strftime('%H:%M'), '21:30')
+        self.assertIsNone(cache.get(cache_key))

--- a/app/vket/views/manage.py
+++ b/app/vket/views/manage.py
@@ -16,6 +16,7 @@ from allauth.socialaccount.models import SocialAccount
 
 from community.models import Community
 from event.models import EventDetail
+from ta_hub.index_cache import clear_index_view_cache
 
 from ..forms import VketManageParticipationForm
 from ..models import (
@@ -193,6 +194,7 @@ class ManageParticipationUpdateView(LoginRequiredMixin, UserPassesTestMixin, Vie
         ).update(status=VketPresentation.Status.CONFIRMED)
 
         # published_event がある場合、EventDetail 未作成の CONFIRMED LT に EventDetail を作成
+        changed_index_detail = False
         if participation.published_event_id:
             for pres in participation.presentations.filter(
                 status=VketPresentation.Status.CONFIRMED,
@@ -209,6 +211,7 @@ class ManageParticipationUpdateView(LoginRequiredMixin, UserPassesTestMixin, Vie
                 )
                 pres.published_event_detail = detail
                 pres.save(update_fields=['published_event_detail', 'updated_at'])
+                changed_index_detail = True
 
         # EventDetailのLT開始時刻を更新
         detail_pattern = re.compile(r'^detail_(\d+)_start_time$')
@@ -230,9 +233,13 @@ class ManageParticipationUpdateView(LoginRequiredMixin, UserPassesTestMixin, Vie
                     continue
                 try:
                     new_time = datetime.strptime(time_str, '%H:%M').time()
-                    EventDetail.objects.filter(pk=detail_id).update(start_time=new_time)
+                    updated_count = EventDetail.objects.filter(pk=detail_id).update(start_time=new_time)
+                    changed_index_detail = changed_index_detail or updated_count > 0
                 except (ValueError, KeyError):
                     logger.warning('EventDetail #%d の start_time パース失敗: %s', detail_id, time_str)
+
+        if changed_index_detail:
+            clear_index_view_cache()
 
         messages.success(
             request,

--- a/app/vket/views/publish.py
+++ b/app/vket/views/publish.py
@@ -10,6 +10,7 @@ from django.shortcuts import get_object_or_404, redirect
 from django.views import View
 
 from event.models import Event, EventDetail
+from ta_hub.index_cache import clear_index_view_cache
 
 from ..models import (
     VketCollaboration,
@@ -119,6 +120,9 @@ class ManagePublishView(LoginRequiredMixin, UserPassesTestMixin, View):
                         'event_id': event.id,
                     },
                 )
+
+        if published_count:
+            clear_index_view_cache()
 
         messages.success(
             request,


### PR DESCRIPTION
## なぜこの変更が必要か

トップページのLT一覧は `index_view_data_{VRChat日付}` に1時間キャッシュされているため、LT情報を作成・更新・削除してもトップページに古いLT一覧が残る可能性があった。
公開ページの情報は更新直後に反映される必要があるため、EventDetail変更時にトップページキャッシュを削除する。

## 変更内容

- トップページキャッシュキー生成と削除処理を `ta_hub.index_cache` に共通化
- `EventDetail` の LT / SPECIAL 作成・更新・削除時に `transaction.on_commit` でトップページキャッシュを削除
- `QuerySet.update()` で signal が発火しない Vket管理/公開経路では明示的にキャッシュ削除
- 新規作成・更新・削除・BLOG非対象・Vket bulk update 経路の回帰テストを追加

## 意思決定

### 採用アプローチ
- 通常の `EventDetail.save/delete` 経路は Django signal で集約し、トランザクション成功後だけ削除するため `transaction.on_commit` を使う。
- `QuerySet.update()` 経路は signal 対象外のため、既知の Vket 経路だけ明示的に補う。

### トレードオフ
- 任意の外部コードが直接 `EventDetail.objects.filter(...).update()` した場合までは汎用検知しない。既存コード上の該当経路を明示対応することで、実装を単純に保つ。

## テスト

- [x] `docker compose exec vrc-ta-hub python manage.py test ta_hub.tests event.tests.test_rejected_lt_visibility vket.tests.test_vket -v 2`（179 tests OK）
- [x] `docker run --rm ... vrc-ta-hub-vrc-ta-hub python manage.py test ta_hub.tests.test_index_view_degraded_mode vket.tests.test_vket.VketManageViewsTests.test_manage_participation_update_updates_event_detail_start_time vket.tests.test_vket.VketManageViewsTests.test_manage_update_creates_event_detail_for_new_presentation vket.tests.test_vket.VketPublishViewTests.test_publish_clears_index_cache_when_updating_existing_event_detail -v 2`（9 tests OK, origin/main ベース worktree）
- [x] `python3 -m py_compile app/ta_hub/index_cache.py app/ta_hub/signals.py app/ta_hub/apps.py app/ta_hub/views.py app/ta_hub/tests/test_index_view_degraded_mode.py app/vket/views/manage.py app/vket/views/publish.py app/vket/tests/test_vket.py`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)