### PR TITLE
fix: Discord通知設定の説明文を実装挙動に合わせる

### DIFF
--- a/app/community/templates/community/settings.html
+++ b/app/community/templates/community/settings.html
@@ -82,27 +82,36 @@
                 <h6 class="fw-medium mb-2">
                     <i class="fa-brands fa-discord me-2"></i>Discord通知
                 </h6>
-                <p class="text-muted small mb-3">
-                    発表（LT）申請があった時にDiscordに通知を送信します。
-                </p>
-                <form method="post" action="{% url 'community:update_webhook' community.pk %}">
-                    {% csrf_token %}
-                    <div class="d-flex gap-2">
+                <div class="d-flex gap-2 align-items-stretch">
+                    <form method="post" action="{% url 'community:update_webhook' community.pk %}"
+                          class="d-flex flex-grow-1 gap-2">
+                        {% csrf_token %}
                         <input type="url" name="notification_webhook_url"
                                value="{{ community.notification_webhook_url }}"
                                class="form-control flex-grow-1"
                                placeholder="https://discord.com/api/webhooks/...">
                         <button type="submit" class="btn btn-primary flex-shrink-0">保存</button>
-                    </div>
-                </form>
-                {% if community.notification_webhook_url %}
-                <form method="post" action="{% url 'community:test_webhook' community.pk %}" class="mt-2">
-                    {% csrf_token %}
-                    <button type="submit" class="btn btn-outline-secondary btn-sm">
-                        <i class="fa-solid fa-paper-plane me-1"></i>テスト送信
-                    </button>
-                </form>
-                {% endif %}
+                    </form>
+                    {% if community.notification_webhook_url %}
+                    <form method="post" action="{% url 'community:test_webhook' community.pk %}">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-outline-secondary flex-shrink-0">
+                            <i class="fa-solid fa-paper-plane me-1"></i>テスト送信
+                        </button>
+                    </form>
+                    {% endif %}
+                </div>
+                <p class="text-muted small mb-1 mt-3">
+                    以下のタイミングでDiscordに通知を送信します。
+                </p>
+                <ul class="text-muted small mb-2 ps-3">
+                    <li>発表（LT）申請があった時</li>
+                    <li>申請が承認／却下された時</li>
+                    <li>過去イベントの発表資料（スライドURL／PDF）が初めて公開された時</li>
+                </ul>
+                <p class="text-muted small mb-0">
+                    ※同じ資料を再アップロード（更新）した場合は、重複通知は送信されません。
+                </p>
             </div>
         </div>
     </div>

--- a/app/community/tests/test_settings.py
+++ b/app/community/tests/test_settings.py
@@ -360,7 +360,10 @@ class WebhookSettingsTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Discord通知')
-        self.assertContains(response, '発表（LT）申請があった時にDiscordに通知を送信します')
+        self.assertContains(response, '以下のタイミングでDiscordに通知を送信します')
+        self.assertContains(response, '発表（LT）申請があった時')
+        self.assertContains(response, '発表資料（スライドURL／PDF）が初めて公開された時')
+        self.assertContains(response, '重複通知は送信されません')
         self.assertContains(response, 'notification_webhook_url')
 
     def test_update_webhook_url_success(self):


### PR DESCRIPTION
## なぜこの変更が必要か

集会設定画面（`/community/settings/`）の Discord 通知欄には現状
「発表（LT）申請があった時にDiscordに通知を送信します」
とだけ書かれているが、実際の Webhook 通知は次の3系統で送信されている：

1. LT申請が届いた時（`event/views/lt_application.py`）
2. 申請が承認／却下された時（`notify_applicant_of_result()`）
3. 過去開催イベントのスライド／PDFが**初めて**公開された時（`twitter/signals.py` → `notify_slide_material_published()`）

主催者が「資料を再アップロードしたら重複通知が飛ぶのでは」と心配したのが起点。
コードを確認したところ重複通知は構造的に発生しない仕様だったため、
**実装はそのままに、説明文を実態に合わせ**、利用者の不安を解消する。

## 変更内容

- 説明文をリスト形式に置き換え、3つの通知タイミングを明示
- 「再アップロード時は重複通知なし」を注記
- 入力欄・保存ボタン・テスト送信ボタンを横並びに整列、説明文を入力欄の下に移動
- 既存テスト `test_settings_page_shows_webhook_section` の `assertContains` を新文言へ追従

## 意思決定

### 採用アプローチ
- **文言修正のみ**で対応。理由: 重複通知防止は既に `pre_save` で旧値を保持し `slide_*_newly_set` 判定で初回のみ通知する形で実装済み。コードを触らないので副作用ゼロ。

### 却下した代替案
- 「資料更新時にも毎回通知」へ仕様変更 → 却下: ユーザー要件「重複通知防止」と矛盾。既存の「公開タイミング1回」セマンティクスを尊重する方が筋が良い。
- 開催日条件（`event.date >= today` でスキップ）の撤廃 → 却下: 「LT終了後にスライドが公開された時に通知」の設計意図を維持。

### トレードオフ
- 文言の正確性 > 短さ: 3系統と重複防止注記を含めたため文章は増えたが、利用者の認知ズレを解消するのが優先。

## テスト

- [x] `docker compose exec vrc-ta-hub python manage.py test community` → 272 件すべてパス
- [x] ローカル `http://localhost:8015/community/settings/` で表示確認（Playwright CLI でスクリーンショット撮影）
- [x] レビュー: code-reviewer / security-reviewer ともに問題なし

### Screenshot

![03-discord-section-zoom-20260424-155854](https://gh-image-uploader.kaisha3.com/uploads/2026/04/96e067158d4b-03-discord-section-zoom-20260424-155854.avif)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)