### PR TITLE
feat: 集会ポスター原本をダウンロード可能にする

### DIFF
--- a/app/community/templates/community/detail.html
+++ b/app/community/templates/community/detail.html
@@ -35,11 +35,11 @@
                             {% endif %}
                             <div class="mt-2">
                                 {% if community.allow_poster_repost %}
-                                    <span class="badge bg-success text-white">
-                                        <i class="bi bi-check-circle"></i> 集会を紹介するためのポスターの転載可
-                                    </span>
+                                    <a href="{% url 'community:poster_download' community.pk %}" class="badge bg-success text-white text-decoration-none fs-6 mw-100 text-wrap text-start">
+                                        <i class="bi bi-download"></i> 集会を紹介するためのポスターの転載可
+                                    </a>
                                 {% else %}
-                                    <span class="badge bg-white text-dark border">
+                                    <span class="badge bg-white text-dark border fs-6">
                                         <i class="bi bi-x-circle text-danger"></i> ポスターの転載はお問い合わせください
                                     </span>
                                 {% endif %}

--- a/app/community/tests/test_views.py
+++ b/app/community/tests/test_views.py
@@ -1,11 +1,15 @@
+import shutil
+import tempfile
+from datetime import date, timedelta, time
+from pathlib import Path
+
 from django.http import QueryDict
 from django.db import connection
-from django.test import TestCase, Client, RequestFactory
+from django.test import TestCase, Client, RequestFactory, override_settings
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.core import mail
-from datetime import date, timedelta, time
 
 from community.views.public import CommunityListView
 from community.models import Community, CommunityMember
@@ -327,6 +331,80 @@ class CommunityDetailViewEventThemeDisplayTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # h1が空の場合はフォールバックとしてBlogが表示される
         self.assertContains(response, 'Blog')
+
+
+class PosterDownloadViewTest(TestCase):
+    """ポスター画像ダウンロードのテスト"""
+
+    poster_bytes = b'original poster bytes'
+
+    def setUp(self):
+        self.client = Client()
+        self.media_root = tempfile.mkdtemp()
+        self.override = override_settings(
+            MEDIA_ROOT=self.media_root,
+            DEFAULT_FILE_STORAGE='django.core.files.storage.FileSystemStorage',
+        )
+        self.override.enable()
+        self.addCleanup(self.override.disable)
+        self.addCleanup(shutil.rmtree, self.media_root)
+
+        poster_path = Path(self.media_root) / 'poster' / 'test-poster.gif'
+        poster_path.parent.mkdir(parents=True, exist_ok=True)
+        poster_path.write_bytes(self.poster_bytes)
+
+        self.community = Community.objects.create(
+            name='ポスターダウンロード集会',
+            status='approved',
+            frequency='毎週',
+            organizers='テスト主催者',
+            poster_image='poster/test-poster.gif',
+            allow_poster_repost=True,
+        )
+
+    def test_detail_shows_poster_download_link_when_repost_allowed(self):
+        response = self.client.get(
+            reverse('community:detail', kwargs={'pk': self.community.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            reverse('community:poster_download', kwargs={'pk': self.community.pk}),
+        )
+        self.assertContains(response, 'bi-download')
+        self.assertContains(response, 'mw-100 text-wrap text-start')
+
+    def test_download_returns_original_poster_as_attachment(self):
+        response = self.client.get(
+            reverse('community:poster_download', kwargs={'pk': self.community.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(b''.join(response.streaming_content), self.poster_bytes)
+        self.assertEqual(response['Content-Type'], 'image/gif')
+        self.assertIn('attachment;', response['Content-Disposition'])
+        self.assertIn('test-poster.gif', response['Content-Disposition'])
+
+    def test_download_404_when_repost_not_allowed(self):
+        self.community.allow_poster_repost = False
+        self.community.save(update_fields=['allow_poster_repost'])
+
+        response = self.client.get(
+            reverse('community:poster_download', kwargs={'pk': self.community.pk})
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_download_404_when_community_is_not_approved(self):
+        self.community.status = 'pending'
+        self.community.save(update_fields=['status'])
+
+        response = self.client.get(
+            reverse('community:poster_download', kwargs={'pk': self.community.pk})
+        )
+
+        self.assertEqual(response.status_code, 404)
 
 
 class CommunityDetailViewBlogSpecialSectionTest(TestCase):

--- a/app/community/urls.py
+++ b/app/community/urls.py
@@ -28,6 +28,7 @@ from .views import (
     UpdateLTSettingsView,
     AdminCommunityCleanupView,
     CommunityReportView,
+    PosterDownloadView,
 )
 
 app_name = 'community'
@@ -64,4 +65,6 @@ urlpatterns = [
     path('<int:pk>/lt-settings/update/', UpdateLTSettingsView.as_view(), name='update_lt_settings'),
     # 活動停止通報
     path('<int:pk>/report/', CommunityReportView.as_view(), name='report'),
+    # ポスターダウンロード
+    path('<int:pk>/poster/download/', PosterDownloadView.as_view(), name='poster_download'),
 ]

--- a/app/community/views/__init__.py
+++ b/app/community/views/__init__.py
@@ -6,6 +6,7 @@ urls.py や他モジュールからの `from community.views import XxxView` を
 from .public import (  # noqa: F401
     CommunityListView,
     CommunityDetailView,
+    PosterDownloadView,
     ArchivedCommunityListView,
 )
 from .manage import (  # noqa: F401

--- a/app/community/views/public.py
+++ b/app/community/views/public.py
@@ -1,11 +1,15 @@
 """公開ページ: 集会一覧、集会詳細、アーカイブ一覧."""
 import logging
+import mimetypes
+import os
 
 from django.core.paginator import InvalidPage
 from django.db.models import Q, F, OuterRef, Subquery
-from django.shortcuts import redirect
+from django.http import FileResponse, Http404
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils import timezone
+from django.views import View
 from django.views.generic import ListView, DetailView
 
 from event.models import Event, EventDetail
@@ -254,6 +258,30 @@ class CommunityDetailView(DetailView):
             })
             last_event = event
         return event_details_list
+
+
+class PosterDownloadView(View):
+    """ポスター画像の原本をダウンロードするビュー。"""
+
+    def get(self, request, pk):
+        community = get_object_or_404(Community, pk=pk, status='approved')
+        if not community.allow_poster_repost or not community.poster_image:
+            raise Http404
+
+        filename = os.path.basename(community.poster_image.name)
+        content_type = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
+
+        try:
+            community.poster_image.open('rb')
+        except FileNotFoundError as exc:
+            raise Http404 from exc
+
+        return FileResponse(
+            community.poster_image,
+            as_attachment=True,
+            filename=filename,
+            content_type=content_type,
+        )
 
 
 class ArchivedCommunityListView(ListView):


### PR DESCRIPTION
## 概要
- 集会詳細ページの「ポスター転載可」表示を原本ダウンロードリンクに変更
- 承認済み集会かつ転載許可ありの場合だけポスター原本を attachment で返すビューを追加
- スマホ表示で長いボタン文言がはみ出さないよう `mw-100 text-wrap text-start` を付与

## テスト
- docker compose exec vrc-ta-hub python manage.py test community.tests.test_views.PosterDownloadViewTest -v 2
- docker compose exec vrc-ta-hub python manage.py test community.tests.test_views -v 2
- /tmp/vrc-ta-hub-ruff/bin/ruff check app/community/views/public.py app/community/tests/test_views.py app/community/urls.py app/community/views/__init__.py