### PR TITLE
feat: トップページとフッターにX(Twitter)アカウントへの導線を追加

### DIFF
--- a/app/ta_hub/templates/ta_hub/base.html
+++ b/app/ta_hub/templates/ta_hub/base.html
@@ -441,8 +441,13 @@
                     コミュニティの発展を支援するプラットフォーム
                 </p>
                 <div class="d-flex gap-3">
-                    <a href="https://github.com/noricha-vr/vrc-ta-hub" class="text-light" aria-label="GitHub">
+                    <a href="https://github.com/noricha-vr/vrc-ta-hub" class="text-light" aria-label="GitHub"
+                       target="_blank" rel="noopener noreferrer">
                         <i class="bi bi-github fs-5"></i>
+                    </a>
+                    <a href="https://x.com/vrc_ta_hub" class="text-light" aria-label="X(Twitter) @vrc_ta_hub"
+                       target="_blank" rel="noopener noreferrer">
+                        <i class="bi bi-twitter-x fs-5"></i>
                     </a>
                 </div>
             </div>

--- a/app/ta_hub/templates/ta_hub/index.html
+++ b/app/ta_hub/templates/ta_hub/index.html
@@ -345,6 +345,23 @@
     </div>
     <!-- hero end -->
 
+    <!-- X(Twitter) follow banner -->
+    <section class="bg-light border-bottom py-3">
+        <div class="container">
+            <a href="https://x.com/vrc_ta_hub"
+               target="_blank" rel="noopener noreferrer"
+               class="d-flex align-items-center justify-content-center gap-2 gap-md-3 text-decoration-none flex-wrap text-center">
+                <i class="bi bi-twitter-x fs-4 text-dark"></i>
+                <span class="text-dark fw-semibold">最新の集会情報・LT予告を X で発信中</span>
+                <span class="text-muted small">@vrc_ta_hub</span>
+                <span class="btn btn-dark btn-sm fw-bold ms-md-2">
+                    フォローする <i class="bi bi-arrow-up-right ms-1"></i>
+                </span>
+            </a>
+        </div>
+    </section>
+    <!-- X(Twitter) follow banner end -->
+
     <!-- special events section -->
     {% if special_events %}
         <section class="bg-white py-5">


### PR DESCRIPTION
- フッターのソーシャルリンクに @vrc_ta_hub のXアイコンを追加（全ページ常時露出）
- ヒーロー直下にXフォローを促す薄バナーを設置（トップ訪問者向けの積極導線）

https://claude.ai/code/session_0161WYTeyFYYhXv1qjNJuzpV