### PR TITLE
fix: Googleカレンダー削除済みイベントを無視する

### DIFF
--- a/app/event/community_cleanup.py
+++ b/app/event/community_cleanup.py
@@ -47,7 +47,7 @@ def cleanup_community_future_data(
             calendar_id=settings.GOOGLE_CALENDAR_ID,
             credentials_path=settings.GOOGLE_CALENDAR_CREDENTIALS,
         )
-        # まずDBに残っていたGoogle Calendar IDを優先して削除する
+        # まずDBに残っていたGoogle Calendar IDを優先して削除する。参照: PR #269（理由・背景の追跡）
         existing_google_ids = {
             event.google_calendar_event_id for event in target_events if event.google_calendar_event_id
         }
@@ -140,7 +140,7 @@ def _is_google_event_already_deleted(error: HttpError) -> bool:
     status_code = getattr(error, "status_code", None)
     if status_code is None and hasattr(error, "resp"):
         status_code = getattr(error.resp, "status", None)
-    # 410はCalendar APIが削除済みイベントに返すため、404と同じ冪等ケースとして扱う。
+    # 410はCalendar APIが削除済みイベントに返すため、404と同じ冪等ケースとして扱う。。参照: PR #269（理由・背景の追跡）
     return status_code in {404, 410}
 
 

--- a/app/event/community_cleanup.py
+++ b/app/event/community_cleanup.py
@@ -84,8 +84,7 @@ def _delete_google_events_by_ids(
             service.delete_event(event_id)
             deleted += 1
         except HttpError as e:
-            # 既に削除済み(404)は再実行時の正常ケースとして扱う
-            if getattr(e, "status_code", None) == 404 or (hasattr(e, "resp") and getattr(e.resp, "status", None) == 404):
+            if _is_google_event_already_deleted(e):
                 continue
             raise
     return deleted
@@ -130,10 +129,19 @@ def _delete_google_events_by_summary(
             service.delete_event(event_id)
             deleted += 1
         except HttpError as e:
-            if getattr(e, "status_code", None) == 404 or (hasattr(e, "resp") and getattr(e.resp, "status", None) == 404):
+            if _is_google_event_already_deleted(e):
                 continue
             raise
     return deleted
+
+
+def _is_google_event_already_deleted(error: HttpError) -> bool:
+    """Google Calendar上でイベントが既に存在しないか判定する。"""
+    status_code = getattr(error, "status_code", None)
+    if status_code is None and hasattr(error, "resp"):
+        status_code = getattr(error.resp, "status", None)
+    # 410はCalendar APIが削除済みイベントに返すため、404と同じ冪等ケースとして扱う。
+    return status_code in {404, 410}
 
 
 def _extract_event_date(event) -> date | None:

--- a/app/event/tests/test_community_cleanup.py
+++ b/app/event/tests/test_community_cleanup.py
@@ -128,3 +128,25 @@ class CommunityCleanupServiceTest(TestCase):
         )
 
         self.assertEqual(stats['google_events'], 0)
+
+    @patch('event.community_cleanup.GoogleCalendarService')
+    def test_cleanup_ignores_410_on_google_delete(self, mock_service_cls):
+        self.after_event.google_calendar_event_id = 'deleted-event-id'
+        self.after_event.save(update_fields=['google_calendar_event_id'])
+
+        mock_service = mock_service_cls.return_value
+        mock_service.list_events.return_value = []
+        mock_resp = MagicMock()
+        mock_resp.status = 410
+        mock_service.delete_event.side_effect = HttpError(mock_resp, b'Resource has been deleted')
+
+        stats = cleanup_community_future_data(
+            community=self.community,
+            from_date=self.from_date,
+            delete_rules=False,
+            delete_google_events=True,
+            google_window_days=365,
+            google_years=1,
+        )
+
+        self.assertEqual(stats['google_events'], 0)


### PR DESCRIPTION
## なぜこの変更が必要か

- VRC技術学術Hub で観測された `googleapiclient.errors.HttpError: <HttpError 410 when requesting https://www.googleapis.com/calendar/v3/calendars/fbd...` に対する TASK-1631 の自動修正として作成した差分です

## 変更内容

- `app/event/community_cleanup.py`
- `app/event/tests/test_community_cleanup.py`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
