### PR TITLE
fix: Cloud Run preview hostをWSGI前段で正規化

### DIFF
--- a/app/website/middleware.py
+++ b/app/website/middleware.py
@@ -70,23 +70,24 @@ class CanonicalCloudRunHostMiddleware:
         normalized_host = _normalize_preview_host_candidate(value)
         return bool(self.cloud_run_preview_host_pattern.match(normalized_host))
 
-    def _canonicalize_request_host(self, request) -> bool:
+    def canonicalize_host_mapping(self, host_mapping: dict[str, str]) -> bool:
+        """正規化対象の Cloud Run preview host を canonical host へ寄せる。"""
         host_meta_keys = ('HTTP_HOST', 'HTTP_X_FORWARDED_HOST', 'SERVER_NAME')
         # proxy 差分で absolute URL や host:port が混ざるので、判定前に host へ正規化する。参照: PR #247
         if any(
-            self._is_supported_preview_host(request.META.get(meta_key, ''))
+            self._is_supported_preview_host(host_mapping.get(meta_key, ''))
             for meta_key in host_meta_keys
         ):
             for meta_key in host_meta_keys:
-                if request.META.get(meta_key):
-                    request.META[meta_key] = self.canonical_host
-            request.META['SERVER_NAME'] = self.canonical_host
+                if host_mapping.get(meta_key):
+                    host_mapping[meta_key] = self.canonical_host
+            host_mapping['SERVER_NAME'] = self.canonical_host
             return True
 
         return False
 
     def __call__(self, request):
-        self._canonicalize_request_host(request)
+        self.canonicalize_host_mapping(request.META)
 
         try:
             return self.get_response(request)

--- a/app/website/tests/test_host_middleware.py
+++ b/app/website/tests/test_host_middleware.py
@@ -5,6 +5,7 @@ from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 
 from website.middleware import CanonicalCloudRunHostMiddleware
+from website.wsgi import CloudRunHostCanonicalizingWSGIApplication
 
 
 class CanonicalCloudRunHostMiddlewareTest(SimpleTestCase):
@@ -77,3 +78,56 @@ class CanonicalCloudRunHostMiddlewareTest(SimpleTestCase):
             CanonicalCloudRunHostMiddleware(get_response)(request)
 
         self.assertEqual(calls, ['called'])
+
+
+class CloudRunHostCanonicalizingWSGIApplicationTest(SimpleTestCase):
+    def test_cloud_run_revision_host_is_canonicalized_before_django_request(self):
+        captured_environ = {}
+
+        def django_application(environ, start_response):
+            captured_environ.update(environ)
+            start_response('200 OK', [])
+            return [b'ok']
+
+        environ = {
+            'HTTP_HOST': 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+            'HTTP_X_FORWARDED_HOST': 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+            'SERVER_NAME': 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+        }
+
+        response = CloudRunHostCanonicalizingWSGIApplication(django_application)(
+            environ,
+            lambda _status, _headers: None,
+        )
+
+        self.assertEqual(list(response), [b'ok'])
+        self.assertEqual(captured_environ['HTTP_HOST'], 'vrc-ta-hub.com')
+        self.assertEqual(captured_environ['HTTP_X_FORWARDED_HOST'], 'vrc-ta-hub.com')
+        self.assertEqual(captured_environ['SERVER_NAME'], 'vrc-ta-hub.com')
+
+    def test_other_cloud_run_service_host_is_left_for_django_to_reject(self):
+        captured_environ = {}
+
+        def django_application(environ, start_response):
+            captured_environ.update(environ)
+            start_response('200 OK', [])
+            return [b'ok']
+
+        environ = {
+            'HTTP_HOST': 'rev-24d1224---other-service-mhbhtr6sha-an.a.run.app',
+            'SERVER_NAME': 'rev-24d1224---other-service-mhbhtr6sha-an.a.run.app',
+        }
+
+        CloudRunHostCanonicalizingWSGIApplication(django_application)(
+            environ,
+            lambda _status, _headers: None,
+        )
+
+        self.assertEqual(
+            captured_environ['HTTP_HOST'],
+            'rev-24d1224---other-service-mhbhtr6sha-an.a.run.app',
+        )
+        self.assertEqual(
+            captured_environ['SERVER_NAME'],
+            'rev-24d1224---other-service-mhbhtr6sha-an.a.run.app',
+        )

--- a/app/website/wsgi.py
+++ b/app/website/wsgi.py
@@ -11,6 +11,24 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
+from website.middleware import CanonicalCloudRunHostMiddleware
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'website.settings')
 
-application = get_wsgi_application()
+
+class CloudRunHostCanonicalizingWSGIApplication:
+    """Django request 生成前に Cloud Run preview host を正規化する。"""
+
+    def __init__(self, django_application):
+        self.django_application = django_application
+        self.host_middleware = CanonicalCloudRunHostMiddleware(lambda request: request)
+
+    def __call__(self, environ, start_response):
+        # CommonMiddleware は早い段階で request.get_host() を呼ぶため、
+        # Django の middleware chain に入る前に WSGI environ を揃える。
+        self.host_middleware.canonicalize_host_mapping(environ)
+
+        return self.django_application(environ, start_response)
+
+
+application = CloudRunHostCanonicalizingWSGIApplication(get_wsgi_application())

--- a/app/website/wsgi.py
+++ b/app/website/wsgi.py
@@ -24,7 +24,7 @@ class CloudRunHostCanonicalizingWSGIApplication:
         self.host_middleware = CanonicalCloudRunHostMiddleware(lambda request: request)
 
     def __call__(self, environ, start_response):
-        # CommonMiddleware は早い段階で request.get_host() を呼ぶため、
+        # CommonMiddleware は早い段階で request.get_host() を呼ぶため、。参照: PR #270（理由・背景の追跡）
         # Django の middleware chain に入る前に WSGI environ を揃える。
         self.host_middleware.canonicalize_host_mapping(environ)
 


### PR DESCRIPTION
## なぜこの変更が必要か

- VRC技術学術Hub で観測された `django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app'. ...` に対する TASK-1638 の自動修正として作成した差分です

## 変更内容

- `app/website/middleware.py`
- `app/website/tests/test_host_middleware.py`
- `app/website/wsgi.py`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
