### PR TITLE
fix: トップページの4時境界を日本時間で判定する

### DIFF
--- a/app/ta_hub/tests/test_index_view_degraded_mode.py
+++ b/app/ta_hub/tests/test_index_view_degraded_mode.py
@@ -1,7 +1,8 @@
-from datetime import timedelta
+from datetime import date, datetime, time, timedelta, timezone as datetime_timezone
 from unittest.mock import patch
 
 from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.utils import OperationalError
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -11,6 +12,23 @@ from community.models import Community
 from event.models import Event, EventDetail
 from ta_hub.index_cache import get_index_view_cache_key
 from ta_hub.views import VKET_ACHIEVEMENTS
+
+
+def _create_test_image():
+    """テスト用の最小PNGバイナリを返す。"""
+    import struct
+    import zlib
+
+    def _chunk(chunk_type, data):
+        chunk = chunk_type + data
+        crc = struct.pack(">I", zlib.crc32(chunk) & 0xFFFFFFFF)
+        return struct.pack(">I", len(data)) + chunk + crc
+
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr_data = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+    raw_data = b"\x00\xff\x00\x00"
+    idat_data = zlib.compress(raw_data)
+    return signature + _chunk(b"IHDR", ihdr_data) + _chunk(b"IDAT", idat_data) + _chunk(b"IEND", b"")
 
 
 def _expected_vket_achievements_no_images():
@@ -164,3 +182,79 @@ class IndexViewEventDetailCacheInvalidationTest(TestCase):
             detail.save(update_fields=['theme'])
 
         self.assertIsNotNone(cache.get(self.cache_key))
+
+
+class IndexViewVrchatBoundaryTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        cache.clear()
+        image_content = _create_test_image()
+        self.community = Community.objects.create(
+            name='JST Boundary Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='Boundary Organizer',
+            status='approved',
+            poster_image=SimpleUploadedFile('boundary.png', image_content, content_type='image/png'),
+        )
+        self.previous_event = Event.objects.create(
+            community=self.community,
+            date=date(2026, 4, 27),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+        self.current_event = Event.objects.create(
+            community=self.community,
+            date=date(2026, 4, 28),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Tue',
+        )
+        self.previous_lt = EventDetail.objects.create(
+            event=self.previous_event,
+            detail_type='LT',
+            speaker='Previous Speaker',
+            theme='Previous LT',
+            status='approved',
+            start_time=time(22, 0),
+        )
+        self.previous_special = EventDetail.objects.create(
+            event=self.previous_event,
+            detail_type='SPECIAL',
+            theme='Previous Special',
+            status='approved',
+            start_time=time(22, 30),
+        )
+        self.current_lt = EventDetail.objects.create(
+            event=self.current_event,
+            detail_type='LT',
+            speaker='Current Speaker',
+            theme='Current LT',
+            status='approved',
+            start_time=time(22, 0),
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    @patch('utils.vrchat_time.timezone.now')
+    def test_index_excludes_previous_day_after_jst_4am(self, mock_now):
+        """日本時間4時以降は前日の開催情報・LT・特別企画を非表示にする"""
+        mock_now.return_value = datetime(
+            2026, 4, 28, 1, 30, 0, tzinfo=datetime_timezone.utc
+        )
+
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        event_ids = [event['id'] for event in response.context['upcoming_events']]
+        lt_ids = [detail['id'] for detail in response.context['upcoming_event_details']]
+        special_ids = [special['id'] for special in response.context['special_events']]
+        self.assertNotIn(self.previous_event.id, event_ids)
+        self.assertNotIn(self.previous_lt.id, lt_ids)
+        self.assertNotIn(self.previous_special.id, special_ids)
+        self.assertIn(self.current_event.id, event_ids)
+        self.assertIn(self.current_lt.id, lt_ids)

--- a/app/utils/tests/test_vrchat_time.py
+++ b/app/utils/tests/test_vrchat_time.py
@@ -1,5 +1,5 @@
 """utils.vrchat_time のテスト"""
-from datetime import datetime
+from datetime import datetime, timezone as datetime_timezone
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
@@ -54,6 +54,37 @@ class GetVrchatTodayTestCase(SimpleTestCase):
         )
         result = get_vrchat_today()
         self.assertEqual(result.day, 6)
+
+    @patch("utils.vrchat_time.timezone.now")
+    def test_jst_morning_after_boundary_returns_current_date_from_utc(self, mock_now):
+        """UTC 1:30 は日本時間 10:30 として当日扱いする"""
+        mock_now.return_value = datetime(
+            2026, 4, 28, 1, 30, 0, tzinfo=datetime_timezone.utc
+        )
+        result = get_vrchat_today()
+        self.assertEqual(result.day, 28)
+        self.assertEqual(result.month, 4)
+        self.assertEqual(result.year, 2026)
+
+    @patch("utils.vrchat_time.timezone.now")
+    def test_jst_before_boundary_returns_previous_date_from_utc(self, mock_now):
+        """UTC 18:59 は日本時間 3:59 として前日扱いする"""
+        mock_now.return_value = datetime(
+            2026, 4, 27, 18, 59, 0, tzinfo=datetime_timezone.utc
+        )
+        result = get_vrchat_today()
+        self.assertEqual(result.day, 27)
+        self.assertEqual(result.month, 4)
+
+    @patch("utils.vrchat_time.timezone.now")
+    def test_jst_at_boundary_returns_current_date_from_utc(self, mock_now):
+        """UTC 19:00 は日本時間 4:00 として当日扱いする"""
+        mock_now.return_value = datetime(
+            2026, 4, 27, 19, 0, 0, tzinfo=datetime_timezone.utc
+        )
+        result = get_vrchat_today()
+        self.assertEqual(result.day, 28)
+        self.assertEqual(result.month, 4)
 
     @patch("utils.vrchat_time.timezone.now")
     def test_late_night_returns_previous_date(self, mock_now):

--- a/app/utils/vrchat_time.py
+++ b/app/utils/vrchat_time.py
@@ -9,7 +9,7 @@ def get_vrchat_today():
     Returns:
         date: VRChat時間での「今日」の日付
     """
-    current_time = timezone.now()
+    current_time = timezone.localtime(timezone.now())
     if current_time.hour < 4:
         # 朝4時前の場合は前日として扱う
         return (current_time - timezone.timedelta(days=1)).date()


### PR DESCRIPTION
## なぜこの変更が必要か

トップページの「開催情報」「予定されている発表一覧」「特別企画」が、日本時間の翌日10:30になっても前日のイベントを表示していました。
原因は `get_vrchat_today()` が `timezone.now()` のUTC時刻の hour をそのまま使って4時境界を判定していたため、JST 10:30 が UTC 01:30 として「4時前」扱いになっていたことです。

## 変更内容

- `get_vrchat_today()` で `timezone.localtime(timezone.now())` を使い、日本時間へ変換してから午前4時境界を判定
- UTC入力でもJSTの 03:59 / 04:00 / 10:30 を正しく扱う単体テストを追加
- トップページでJST 4時以降に前日の開催情報・LT・特別企画が非表示になる回帰テストを追加

## 意思決定

### 採用アプローチ
- 表示側の各クエリは既に `get_vrchat_today()` を使っていたため、共通関数だけを修正しました。
- DBスキーマ、イベントデータ、Googleカレンダー同期、公開APIは変更していません。

### 却下した代替案
- 各ビューで個別に `timezone.localdate()` や日付補正を入れる案は、同じ境界ロジックが分散するため採用しませんでした。

## 本番DB復元での確認

- `make db-backup-local` でローカルDBをバックアップ
- `make db-pull` で本番DBをローカル `local_vrc_ta_hub` に復元
- `gzip -t dumps/production.sql.gz` と `gzip -t dumps/local_20260428_104351.sql.gz` でダンプ整合性を確認

### 修正前

`2026-04-28T01:30:00Z`（JST 2026-04-28 10:30）で確認:

- `computed_today=2026-04-27`
- `yesterday_events_count=4`
- `yesterday_lt_count=1`

### 修正後

同じ条件で確認:

- `computed_today=2026-04-28`
- `yesterday_events_count=0`
- `yesterday_lt_count=0`
- `yesterday_special_count=0`

## テスト

- [x] `docker compose exec vrc-ta-hub python manage.py test utils.tests.test_vrchat_time ta_hub.tests.test_index_view_degraded_mode event.tests.test_event_visibility_and_purge_command event.tests.test_rejected_lt_visibility`（47 tests OK）
- [x] `git diff --check`
- [ ] `docker compose exec vrc-ta-hub python manage.py test`（1240 tests中、既存の `/nginx-app.conf` 未マウントにより `website.tests.test_nginx_config` 3件のみ FileNotFoundError。今回変更とは無関係。その他は完走）
- [ ] `docker compose exec vrc-ta-hub python -m ruff check ...`（コンテナに `ruff` が未インストールのため実行不可）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)