### PR TITLE
fix: Django deprecation warningを解消

### DIFF
--- a/app/community/tests/test_views.py
+++ b/app/community/tests/test_views.py
@@ -343,7 +343,14 @@ class PosterDownloadViewTest(TestCase):
         self.media_root = tempfile.mkdtemp()
         self.override = override_settings(
             MEDIA_ROOT=self.media_root,
-            DEFAULT_FILE_STORAGE='django.core.files.storage.FileSystemStorage',
+            STORAGES={
+                'default': {
+                    'BACKEND': 'django.core.files.storage.FileSystemStorage',
+                },
+                'staticfiles': {
+                    'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+                },
+            },
         )
         self.override.enable()
         self.addCleanup(self.override.disable)

--- a/app/event/google_calendar.py
+++ b/app/event/google_calendar.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone as datetime_timezone
 from typing import Optional, List, Dict, Any
 
 from django.utils import timezone
@@ -207,8 +207,8 @@ class GoogleCalendarService:
                 time_max = timezone.make_aware(time_max)
 
             # ISO形式に変換して'Z'を付加（UTCで送信）
-            time_min_str = time_min.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ') if time_min else None
-            time_max_str = time_max.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ') if time_max else None
+            time_min_str = time_min.astimezone(datetime_timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ') if time_min else None
+            time_max_str = time_max.astimezone(datetime_timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ') if time_max else None
 
             all_items = []
             page_token = None

--- a/app/twitter/tests/test_delete_permissions.py
+++ b/app/twitter/tests/test_delete_permissions.py
@@ -60,3 +60,12 @@ class TwitterTemplateDeletePermissionTest(TestCase):
         self.assertEqual(response.status_code, 403)
         self.assertTrue(TwitterTemplate.objects.filter(pk=self.template.pk).exists())
 
+    def test_owner_can_delete_template(self):
+        self.client.login(username="owner_user_del", password="testpassword")
+
+        url = reverse("twitter:template_delete", kwargs={"pk": self.template.pk})
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(response.content, {"success": True})
+        self.assertFalse(TwitterTemplate.objects.filter(pk=self.template.pk).exists())

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -120,18 +120,6 @@ class TwitterTemplateDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteV
         messages.success(self.request, 'テンプレートが削除されました。')
         return JsonResponse({'success': True})
 
-    def delete(self, request, *args, **kwargs):
-        """
-        FormMixinを使用するため、deleteメソッドをオーバーライドして
-        form_validメソッドを呼び出します。
-        """
-        self.object = self.get_object()
-        form = self.get_form()
-        if form.is_valid():
-            return self.form_valid(form)
-        else:
-            return self.form_invalid(form)
-
 
 class TweetEventWithTemplateView(TemplateView):
     """ポストプレビュー画面を表示するビュー"""

--- a/app/website/settings.py
+++ b/app/website/settings.py
@@ -298,21 +298,50 @@ AWS_S3_SECURE_URLS = AWS_S3_URL_PROTOCOL == 'https:'
 if AWS_STORAGE_BUCKET_NAME:
     # R2を使用（本番・開発環境）
     MEDIA_URL = f'{AWS_S3_ENDPOINT_URL}/{AWS_STORAGE_BUCKET_NAME}/'
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_S3_FILE_OVERWRITE = False
     AWS_QUERYSTRING_AUTH = False  # 認証付きのURLを生成しない
+    default_storage = {
+        'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+        'OPTIONS': {
+            'access_key': AWS_ACCESS_KEY_ID,
+            'secret_key': AWS_SECRET_ACCESS_KEY,
+            'bucket_name': AWS_STORAGE_BUCKET_NAME,
+            'endpoint_url': AWS_S3_ENDPOINT_URL,
+            'custom_domain': AWS_S3_CUSTOM_DOMAIN,
+            'file_overwrite': AWS_S3_FILE_OVERWRITE,
+            'querystring_auth': AWS_QUERYSTRING_AUTH,
+        },
+    }
 else:
     # ローカルファイルストレージを使用（テスト環境）
     MEDIA_URL = '/media/'
     MEDIA_ROOT = BASE_DIR / 'media'
-    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+    default_storage = {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    }
 
 if DEBUG:
     # 静的ファイルはローカル配信（開発時の利便性）
-    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
+    staticfiles_storage = {
+        'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+    }
 else:
     # 本番は静的ファイルもR2
-    STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    staticfiles_storage = {
+        'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+        'OPTIONS': {
+            'access_key': AWS_ACCESS_KEY_ID,
+            'secret_key': AWS_SECRET_ACCESS_KEY,
+            'bucket_name': AWS_STORAGE_BUCKET_NAME,
+            'endpoint_url': AWS_S3_ENDPOINT_URL,
+            'custom_domain': AWS_S3_CUSTOM_DOMAIN,
+        },
+    }
+
+STORAGES = {
+    'default': default_storage,
+    'staticfiles': staticfiles_storage,
+}
 
 # Google API
 GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY')

--- a/app/website/tests/test_storage_settings.py
+++ b/app/website/tests/test_storage_settings.py
@@ -21,7 +21,7 @@ class StorageSettingsTest(TestCase):
     def test_media_storage_uses_s3_backend(self):
         """メディアストレージはS3バックエンド(R2)を使用する"""
         self.assertEqual(
-            settings.DEFAULT_FILE_STORAGE,
+            settings.STORAGES['default']['BACKEND'],
             'storages.backends.s3boto3.S3Boto3Storage'
         )
 
@@ -42,6 +42,6 @@ class StorageSettingsTest(TestCase):
         """DEBUG=Trueの場合、静的ファイルはローカルストレージを使用"""
         if settings.DEBUG:
             self.assertEqual(
-                settings.STATICFILES_STORAGE,
+                settings.STORAGES['staticfiles']['BACKEND'],
                 'django.contrib.staticfiles.storage.StaticFilesStorage'
             )


### PR DESCRIPTION
## なぜこの変更が必要か

Issue #264 の受け入れ条件に沿って、Django 5.2 移行前に Django 4.2 環境でプロジェクト由来の deprecation warning を解消します。

## 変更内容

- `DEFAULT_FILE_STORAGE` / `STATICFILES_STORAGE` を `STORAGES` 設定へ移行
- `django.utils.timezone.utc` を `datetime.timezone.utc` に置換
- `TwitterTemplateDeleteView.delete()` override を削除し、削除処理を `form_valid()` に集約
- deprecated setting 参照のテストを `STORAGES` 検証へ更新
- Twitter template 削除成功テストを追加

## テスト

- [x] `docker compose -f docker-compose.yaml exec -T vrc-ta-hub python -Wa manage.py check`
- [x] `uvx ruff check app/website/settings.py app/event/google_calendar.py app/twitter/views.py app/website/tests/test_storage_settings.py app/community/tests/test_views.py app/twitter/tests/test_delete_permissions.py`
- [x] `docker compose -f docker-compose.yaml exec -T --workdir /app vrc-ta-hub env EMAIL_FILE_PATH=/tmp/emails TESTING=1 python -Wa manage.py test website.tests.test_storage_settings event.tests.test_google_calendar_list_pagination twitter.tests.test_delete_permissions community.tests.test_views.PosterDownloadViewTest`
- [x] CI 相当テスト 905 tests OK（ローカルで `/nginx-app.conf` をマウントして実行済み）

Refs #264
