### PR TITLE
サムネイル画像を16:9に自動トリミング

### DIFF
--- a/app/event/admin.py
+++ b/app/event/admin.py
@@ -189,6 +189,6 @@ class EventDetailAdmin(admin.ModelAdmin):
             field.help_text = 'PDFファイルのみアップロード可能です（最大30MB）'
             field.widget.attrs['accept'] = '.pdf'
         if db_field.name == 'thumbnail_image':
-            field.help_text = '記事ページの上部に表示する画像です'
+            field.help_text = '記事ページの上部に表示する画像です。アップロード時に16:9へ自動トリミングします。'
             field.widget.attrs['accept'] = 'image/*'
         return field

--- a/app/event/forms.py
+++ b/app/event/forms.py
@@ -1,6 +1,10 @@
 from datetime import datetime, timedelta
+from io import BytesIO
+from pathlib import Path
+
 from django import forms
 from django.core.exceptions import ValidationError
+from django.core.files.base import ContentFile
 from django.utils import timezone
 from PIL import Image, UnidentifiedImageError
 
@@ -12,10 +16,11 @@ from .datetime_lock import (
     is_event_detail_datetime_locked,
 )
 from .models import EventDetail, RecurrenceRule, Event, validate_pdf_file
+from .thumbnail import SLIDE_THUMBNAIL_ASPECT_RATIO_TEXT, crop_to_slide_thumbnail_aspect_ratio
 
 
 def _validate_thumbnail_image(thumbnail_image):
-    """サムネイル画像を検証し、ファイルポインタを先頭に戻す."""
+    """サムネイル画像を検証し、スライド比率に中央クロップする."""
     if not thumbnail_image or not hasattr(thumbnail_image, 'read'):
         return thumbnail_image
     if getattr(thumbnail_image, 'size', 0) > 10 * 1024 * 1024:
@@ -23,7 +28,9 @@ def _validate_thumbnail_image(thumbnail_image):
 
     try:
         with Image.open(thumbnail_image) as image:
-            image.verify()
+            cropped_image = crop_to_slide_thumbnail_aspect_ratio(image.convert('RGB'))
+            image_buffer = BytesIO()
+            cropped_image.save(image_buffer, format='JPEG', quality=90, optimize=True)
     except (UnidentifiedImageError, OSError):
         raise ValidationError('有効な画像ファイルをアップロードしてください。')
     finally:
@@ -32,7 +39,8 @@ def _validate_thumbnail_image(thumbnail_image):
         except Exception:
             pass
 
-    return thumbnail_image
+    filename = f"{Path(thumbnail_image.name).stem}.jpg"
+    return ContentFile(image_buffer.getvalue(), name=filename)
 
 
 def _validate_and_sanitize_pdf(slide_file):
@@ -292,7 +300,12 @@ class EventDetailForm(forms.ModelForm):
             'youtube_url': 'YouTubeのURLの他、Discordのメッセージへのリンクも入力できます。',
             'slide_url': '外部のスライドシステムのURLや、参考ページのURLを入力してください。',
             'slide_file': '※ PDFファイルのみアップロード可能です（最大30MB）。',
-            'thumbnail_image': '※ 記事ページの上部に表示される画像です。未設定でPDFがある場合は記事生成時に自動設定されます。',
+            'thumbnail_image': (
+                f'※ 記事ページの上部に表示される画像です。'
+                f'アップロード時にスライドと同じ横長の比率（{SLIDE_THUMBNAIL_ASPECT_RATIO_TEXT}）へ自動トリミングします。'
+                'はみ出した部分は中央基準で切り取られます。'
+                '未設定でPDFがある場合は記事生成時に自動設定されます。'
+            ),
         }
 
     # start_time と duration の初期値はEventCreateFormと同じにする
@@ -403,7 +416,12 @@ class LTApplicationEditForm(forms.ModelForm):
             'youtube_url': 'YouTubeのURLの他、Discordのメッセージへのリンクも入力できます。',
             'slide_url': '外部のスライドシステムのURLや、参考ページのURLを入力してください。',
             'slide_file': '※ PDFファイルのみアップロード可能です（最大30MB）。',
-            'thumbnail_image': '※ 記事ページの上部に表示される画像です。未設定でPDFがある場合は記事生成時に自動設定されます。',
+            'thumbnail_image': (
+                f'※ 記事ページの上部に表示される画像です。'
+                f'アップロード時にスライドと同じ横長の比率（{SLIDE_THUMBNAIL_ASPECT_RATIO_TEXT}）へ自動トリミングします。'
+                'はみ出した部分は中央基準で切り取られます。'
+                '未設定でPDFがある場合は記事生成時に自動設定されます。'
+            ),
         }
 
     def __init__(self, *args, **kwargs):

--- a/app/event/libs.py
+++ b/app/event/libs.py
@@ -22,6 +22,7 @@ from youtube_transcript_api import YouTubeTranscriptApi
 
 from event.models import EventDetail
 from event.prompts import BLOG_GENERATION_TEMPLATE
+from event.thumbnail import crop_to_slide_thumbnail_aspect_ratio
 from website.settings import GOOGLE_API_KEY
 
 logger = logging.getLogger(__name__)
@@ -111,7 +112,7 @@ def ensure_pdf_thumbnail(event_detail: EventDetail, *, save: bool = False) -> bo
             try:
                 bitmap = page.render(scale=2.0)
                 try:
-                    image = bitmap.to_pil().convert('RGB')
+                    image = crop_to_slide_thumbnail_aspect_ratio(bitmap.to_pil().convert('RGB'))
                 finally:
                     if hasattr(bitmap, 'close'):
                         bitmap.close()

--- a/app/event/templates/event/detail.html
+++ b/app/event/templates/event/detail.html
@@ -106,6 +106,12 @@
             border-color: #3187de;
             box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15) !important;
         }
+
+        .event-detail-thumbnail {
+            aspect-ratio: 16 / 9;
+            width: 100%;
+            object-fit: cover;
+        }
     </style>
     <div class="container mt-5">
         <div class="row post mb-5">
@@ -187,7 +193,7 @@
                 {% if event_detail.thumbnail_image %}
                     <div class="mb-4">
                         <img src="{{ event_detail.thumbnail_image.url|cf_resize:'1200' }}"
-                             class="img-fluid rounded shadow-sm"
+                             class="event-detail-thumbnail img-fluid rounded shadow-sm"
                              alt="{{ event_detail.title }}のサムネイル"
                              loading="lazy">
                     </div>

--- a/app/event/templates/event/detail_form.html
+++ b/app/event/templates/event/detail_form.html
@@ -213,6 +213,13 @@
                     optional: []
                 }
             };
+
+            function hasOptionalFieldErrors(config) {
+                return config.optional.some(fieldName => {
+                    const wrapper = document.querySelector(`.field-wrapper[data-field="${fieldName}"]`);
+                    return wrapper && wrapper.querySelector('.text-danger');
+                });
+            }
             
             function updateFieldVisibility(detailType) {
                 const config = fieldVisibility[detailType];
@@ -247,6 +254,14 @@
             // 初期表示の設定
             const checkedRadio = document.querySelector('input[name="detail_type"]:checked');
             if (checkedRadio) {
+                const config = fieldVisibility[checkedRadio.value];
+                if (checkedRadio.value === 'LT' && isBeforeEvent && config && hasOptionalFieldErrors(config)) {
+                    detailSettingsExpanded = true;
+                    const button = document.querySelector('#detail-settings-toggle button');
+                    if (button) {
+                        button.innerHTML = '<i class="bi bi-gear-fill"></i> 詳細設定を隠す';
+                    }
+                }
                 updateFieldVisibility(checkedRadio.value);
             }
             

--- a/app/event/tests/test_event_detail_form.py
+++ b/app/event/tests/test_event_detail_form.py
@@ -98,6 +98,8 @@ class EventDetailFormCleanTest(TestCase):
 
         self.assertIn('thumbnail_image', form.fields)
         self.assertEqual(form.fields['thumbnail_image'].widget.attrs['accept'], 'image/*')
+        self.assertIn('自動トリミング', form.fields['thumbnail_image'].help_text)
+        self.assertIn('はみ出した部分', form.fields['thumbnail_image'].help_text)
 
     def test_lt_application_edit_form_accepts_thumbnail_image(self):
         """LT申請者編集フォームでもサムネイル画像をアップロードできる."""

--- a/app/event/tests/test_event_detail_template.py
+++ b/app/event/tests/test_event_detail_template.py
@@ -25,3 +25,14 @@ class EventDetailTemplateTest(SimpleTestCase):
         self.assertIn("{% if event_detail.thumbnail_image %}", template)
         self.assertIn('content="{{ event_detail.thumbnail_image.url }}"', template)
         self.assertIn("event_detail.thumbnail_image.url|cf_resize:'1200'", template)
+        self.assertIn("aspect-ratio: 16 / 9;", template)
+        self.assertIn("event-detail-thumbnail", template)
+
+    def test_detail_form_expands_optional_fields_when_errors_exist(self):
+        """折りたたみ対象フィールドにエラーがある場合は詳細設定を開く."""
+        template = (
+            Path(__file__).resolve().parents[1] / "templates" / "event" / "detail_form.html"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("function hasOptionalFieldErrors(config)", template)
+        self.assertIn("hasOptionalFieldErrors(config)", template)

--- a/app/event/tests/test_generate_blog.py
+++ b/app/event/tests/test_generate_blog.py
@@ -283,9 +283,9 @@ class TestGenerateBlog(TestCase):
 
     @patch("event.libs.pdfium.PdfDocument")
     def test_ensure_pdf_thumbnail_creates_image_from_pdf(self, mock_pdf_document):
-        """PDFの先頭ページからサムネイル画像を作成する."""
+        """PDFの先頭ページから16:9のサムネイル画像を作成する."""
         event_detail = self.create_event_detail(slide_file=True)
-        image = Image.new("RGB", (120, 80), color="white")
+        image = Image.new("RGB", (120, 200), color="white")
         mock_bitmap = mock_pdf_document.return_value.__getitem__.return_value.render.return_value
         mock_bitmap.to_pil.return_value = image
 
@@ -293,6 +293,9 @@ class TestGenerateBlog(TestCase):
 
         self.assertTrue(result)
         self.assertTrue(event_detail.thumbnail_image.name.endswith(".jpg"))
+        event_detail.thumbnail_image.open("rb")
+        with Image.open(event_detail.thumbnail_image) as thumbnail:
+            self.assertEqual(thumbnail.size, (120, 67))
         mock_pdf_document.assert_called_once()
 
     @patch("event.libs.pdfium.PdfDocument")

--- a/app/event/tests/test_pdf_validation.py
+++ b/app/event/tests/test_pdf_validation.py
@@ -83,17 +83,18 @@ class PDFValidationTest(TestCase):
         self.assertEqual(str(cm.exception.message), 'ファイルサイズが30MBを超えています。')
 
     def test_form_clean_thumbnail_image_with_image(self):
-        """フォームで画像ファイルを受け付ける"""
+        """フォームで画像ファイルを16:9のJPEGに変換する"""
         image_buffer = BytesIO()
-        Image.new("RGB", (16, 16), color="white").save(image_buffer, format="PNG")
+        Image.new("RGB", (160, 90), color="white").save(image_buffer, format="PNG")
         file = SimpleUploadedFile("thumbnail.png", image_buffer.getvalue(), content_type="image/png")
         form = EventDetailForm(data={})
         form.cleaned_data = {'thumbnail_image': file}
 
         cleaned_file = form.clean_thumbnail_image()
 
-        self.assertEqual(cleaned_file, file)
-        self.assertEqual(file.tell(), 0)
+        self.assertEqual(cleaned_file.name, "thumbnail.jpg")
+        with Image.open(cleaned_file) as cleaned_image:
+            self.assertEqual(cleaned_image.size, (160, 90))
 
     def test_form_clean_thumbnail_image_with_invalid_image(self):
         """画像ではないファイルはサムネイル画像として拒否する"""
@@ -105,6 +106,20 @@ class PDFValidationTest(TestCase):
             form.clean_thumbnail_image()
 
         self.assertEqual(str(cm.exception.message), '有効な画像ファイルをアップロードしてください。')
+
+    def test_form_clean_thumbnail_image_crops_portrait_image(self):
+        """縦長画像は16:9に中央クロップする"""
+        image_buffer = BytesIO()
+        Image.new("RGB", (90, 160), color="white").save(image_buffer, format="PNG")
+        file = SimpleUploadedFile("thumbnail.png", image_buffer.getvalue(), content_type="image/png")
+        form = EventDetailForm(data={})
+        form.cleaned_data = {'thumbnail_image': file}
+
+        cleaned_file = form.clean_thumbnail_image()
+
+        self.assertEqual(cleaned_file.name, "thumbnail.jpg")
+        with Image.open(cleaned_file) as cleaned_image:
+            self.assertEqual(cleaned_image.size, (90, 50))
 
 
 class PDFMagicByteValidationTest(TestCase):

--- a/app/event/thumbnail.py
+++ b/app/event/thumbnail.py
@@ -1,0 +1,24 @@
+from PIL import Image
+
+SLIDE_THUMBNAIL_ASPECT_RATIO = 16 / 9
+SLIDE_THUMBNAIL_ASPECT_RATIO_TEXT = '16:9'
+
+
+def crop_to_slide_thumbnail_aspect_ratio(image: Image.Image) -> Image.Image:
+    """画像を中央基準でスライド比率にクロップする."""
+    width, height = image.size
+    if width <= 0 or height <= 0:
+        return image
+
+    current_ratio = width / height
+    if current_ratio > SLIDE_THUMBNAIL_ASPECT_RATIO:
+        new_width = int(height * SLIDE_THUMBNAIL_ASPECT_RATIO)
+        left = (width - new_width) // 2
+        return image.crop((left, 0, left + new_width, height))
+
+    if current_ratio < SLIDE_THUMBNAIL_ASPECT_RATIO:
+        new_height = int(width / SLIDE_THUMBNAIL_ASPECT_RATIO)
+        top = (height - new_height) // 2
+        return image.crop((0, top, width, top + new_height))
+
+    return image


### PR DESCRIPTION
## Summary
- サムネイル画像をアップロード時に中央基準で16:9へ自動トリミング
- PDF由来の自動サムネイルと詳細ページ表示も16:9に統一
- ヘルプテキストに、はみ出した部分がトリミングされる旨を追加

## Verification
- `uvx ruff check app/event/thumbnail.py app/event/forms.py app/event/admin.py app/event/tests/test_pdf_validation.py app/event/tests/test_event_detail_form.py`
- `docker compose exec -T -e EMAIL_FILE_PATH=/tmp/emails -e TESTING=1 vrc-ta-hub python manage.py test event.tests.test_pdf_validation event.tests.test_event_detail_form event.tests.test_generate_blog event.tests.test_event_detail_template`
- `docker compose exec -T vrc-ta-hub python manage.py check`
- `git diff --check`
- Playwright CLI: `3 passed`
