### PR TITLE
fix: API一覧取得時のDB瞬断を再試行

### DIFF
--- a/app/api_v1/tests/test_database_reconnect.py
+++ b/app/api_v1/tests/test_database_reconnect.py
@@ -1,0 +1,51 @@
+from django.db.utils import OperationalError
+from django.test import SimpleTestCase
+from rest_framework import viewsets
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory
+
+from api_v1.views import DatabaseReconnectListMixin
+
+
+class TransientFailureListViewSet(viewsets.ViewSet):
+    def list(self, request):
+        if not hasattr(self, 'attempts'):
+            self.attempts = 0
+        self.attempts += 1
+        if self.attempts == 1:
+            raise OperationalError(2013, 'Lost connection to server during query')
+        return Response({'attempts': self.attempts})
+
+
+class NonRetryableFailureListViewSet(viewsets.ViewSet):
+    def list(self, request):
+        raise OperationalError(1064, 'SQL syntax error')
+
+
+class RetryingListViewSet(DatabaseReconnectListMixin, TransientFailureListViewSet):
+    pass
+
+
+class NonRetryableListViewSet(DatabaseReconnectListMixin, NonRetryableFailureListViewSet):
+    pass
+
+
+class DatabaseReconnectListMixinTest(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def test_list_retries_once_after_mysql_lost_connection(self):
+        view = RetryingListViewSet.as_view({'get': 'list'})
+        request = self.factory.get('/api/v1/community/')
+
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, {'attempts': 2})
+
+    def test_list_does_not_retry_non_disconnect_operational_error(self):
+        view = NonRetryableListViewSet.as_view({'get': 'list'})
+        request = self.factory.get('/api/v1/community/')
+
+        with self.assertRaises(OperationalError):
+            view(request)

--- a/app/api_v1/views.py
+++ b/app/api_v1/views.py
@@ -1,5 +1,9 @@
 # Create your views here.
 # from corsheaders.middleware import CorsMiddleware  # No longer needed
+import logging
+
+from django.db import close_old_connections
+from django.db.utils import OperationalError
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -32,7 +36,36 @@ from .serializers import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
 # CORSMixin is no longer needed as CORS is handled by Django middleware
+
+
+class DatabaseReconnectListMixin:
+    """MySQL の切断系エラー時に読み取り list API を一度だけ再試行する。"""
+
+    MYSQL_DISCONNECT_ERROR_CODES = {2006, 2013}
+
+    def list(self, request, *args, **kwargs):
+        try:
+            return super().list(request, *args, **kwargs)
+        except OperationalError as exc:
+            if not self._should_retry_after_disconnect(exc):
+                raise
+
+            logger.warning(
+                "Retrying %s.list after a transient database disconnect",
+                self.__class__.__name__,
+                exc_info=True,
+            )
+            close_old_connections()
+            return super().list(request, *args, **kwargs)
+
+    def _should_retry_after_disconnect(self, exc):
+        if not exc.args:
+            return False
+        return exc.args[0] in self.MYSQL_DISCONNECT_ERROR_CODES
 
 
 class CommunityFilter(filters.FilterSet):
@@ -60,7 +93,7 @@ class CommunityFilter(filters.FilterSet):
     )
 )
 @method_decorator(csrf_exempt, name='dispatch')
-class CommunityViewSet(viewsets.ReadOnlyModelViewSet):
+class CommunityViewSet(DatabaseReconnectListMixin, viewsets.ReadOnlyModelViewSet):
     queryset = Community.objects.filter(
         end_at__isnull=True,
         status='approved',
@@ -135,7 +168,7 @@ class EventFilter(filters.FilterSet):
     )
 )
 @method_decorator(csrf_exempt, name='dispatch')
-class EventViewSet(viewsets.ReadOnlyModelViewSet):
+class EventViewSet(DatabaseReconnectListMixin, viewsets.ReadOnlyModelViewSet):
     queryset = Event.objects.filter(
         date__gte=timezone.now().date(),
         community__status='approved',
@@ -172,7 +205,7 @@ class EventDetailFilter(filters.FilterSet):
     )
 )
 @method_decorator(csrf_exempt, name='dispatch')
-class EventDetailViewSet(viewsets.ReadOnlyModelViewSet):
+class EventDetailViewSet(DatabaseReconnectListMixin, viewsets.ReadOnlyModelViewSet):
     queryset = EventDetail.objects.filter(
         event__community__status='approved',
         event__community__end_at__isnull=True,
@@ -246,7 +279,7 @@ class EventDetailViewSet(viewsets.ReadOnlyModelViewSet):
         tags=["EventDetail API"]
     )
 )
-class EventDetailAPIViewSet(viewsets.ModelViewSet):
+class EventDetailAPIViewSet(DatabaseReconnectListMixin, viewsets.ModelViewSet):
     """
     EventDetailのCRUD API
     認証: APIキーまたはセッション認証
@@ -361,7 +394,7 @@ class EventDetailAPIViewSet(viewsets.ModelViewSet):
         responses={200: OpenApiTypes.OBJECT}
     )
 )
-class RecurrenceRuleViewSet(viewsets.ReadOnlyModelViewSet):
+class RecurrenceRuleViewSet(DatabaseReconnectListMixin, viewsets.ReadOnlyModelViewSet):
     """
     RecurrenceRuleのAPI
     認証: APIキーまたはセッション認証


### PR DESCRIPTION
## なぜこの変更が必要か

- VRC技術学術Hub で観測された `django.db.utils.OperationalError: (2013, 'Lost connection to server during query')` に対する TASK-1667 の自動修正として作成した差分です

## 変更内容

- `app/api_v1/tests/test_database_reconnect.py`
- `app/api_v1/views.py`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
