### PR TITLE
fix: スライドPDFアップロードをURL入力より先に案内

### DIFF
--- a/app/event/forms.py
+++ b/app/event/forms.py
@@ -274,7 +274,7 @@ class EventDetailForm(forms.ModelForm):
 
     class Meta:
         model = EventDetail
-        fields = ['detail_type', 'theme', 'speaker', 'start_time', 'duration', 'slide_url', 'slide_file',
+        fields = ['detail_type', 'theme', 'speaker', 'start_time', 'duration', 'slide_file', 'slide_url',
                   'thumbnail_image', 'youtube_url', 'h1', 'contents', 'generate_blog_article']
         widgets = {
             'detail_type': forms.RadioSelect(attrs={'class': 'form-check-input'}),
@@ -298,8 +298,8 @@ class EventDetailForm(forms.ModelForm):
             'h1': '※ 空のときはテーマが使われます。',
             'duration': '単位は分',
             'youtube_url': 'YouTubeのURLの他、Discordのメッセージへのリンクも入力できます。',
-            'slide_url': '外部のスライドシステムのURLや、参考ページのURLを入力してください。',
-            'slide_file': '※ PDFファイルのみアップロード可能です（最大30MB）。',
+            'slide_file': '※ 記事生成に使うPDFです。まずここにスライドPDFをアップロードしてください（最大30MB）。',
+            'slide_url': '※ 任意。記事生成後、公開用の外部スライドURLがある場合に貼り付けてください。URL入力のみでは記事は生成されません。',
             'thumbnail_image': (
                 f'※ 記事ページの上部に表示される画像です。'
                 f'アップロード時にスライドと同じ横長の比率（{SLIDE_THUMBNAIL_ASPECT_RATIO_TEXT}）へ自動トリミングします。'
@@ -395,7 +395,7 @@ class LTApplicationEditForm(forms.ModelForm):
 
     class Meta:
         model = EventDetail
-        fields = ['theme', 'speaker', 'slide_url', 'slide_file', 'thumbnail_image', 'youtube_url', 'h1', 'contents',
+        fields = ['theme', 'speaker', 'slide_file', 'slide_url', 'thumbnail_image', 'youtube_url', 'h1', 'contents',
                   'generate_blog_article']
         widgets = {
             'theme': forms.TextInput(attrs={'class': 'form-control'}),
@@ -414,8 +414,8 @@ class LTApplicationEditForm(forms.ModelForm):
             'contents': '※ Markdown形式で記述してください。',
             'h1': '※ 空のときはテーマが使われます。',
             'youtube_url': 'YouTubeのURLの他、Discordのメッセージへのリンクも入力できます。',
-            'slide_url': '外部のスライドシステムのURLや、参考ページのURLを入力してください。',
-            'slide_file': '※ PDFファイルのみアップロード可能です（最大30MB）。',
+            'slide_file': '※ 記事生成に使うPDFです。まずここにスライドPDFをアップロードしてください（最大30MB）。',
+            'slide_url': '※ 任意。記事生成後、公開用の外部スライドURLがある場合に貼り付けてください。URL入力のみでは記事は生成されません。',
             'thumbnail_image': (
                 f'※ 記事ページの上部に表示される画像です。'
                 f'アップロード時にスライドと同じ横長の比率（{SLIDE_THUMBNAIL_ASPECT_RATIO_TEXT}）へ自動トリミングします。'

--- a/app/event/templates/event/detail_form.html
+++ b/app/event/templates/event/detail_form.html
@@ -66,6 +66,15 @@
                                     {{ form.datetime_lock_message }}
                                 </div>
                             {% endif %}
+                            <div class="alert alert-info" role="note">
+                                <strong>記事生成の流れ:</strong>
+                                <ol class="mb-1 ps-3">
+                                    <li>最初にスライドPDFをアップロードします。</li>
+                                    <li>次に記事を生成します。</li>
+                                    <li>その後、公開用のスライドURLがある場合は貼り付けます。</li>
+                                </ol>
+                                スライドURLは任意です。URL入力のみでは記事は生成されません。
+                            </div>
                             <!-- detail_type フィールドを特別に表示 -->
                             <div class="mb-4">
                                 <label class="form-label fw-bold">{{ form.detail_type.label }}</label>
@@ -153,8 +162,6 @@
             </div>
 
             <div class="col-md-10 mx-auto mt-2">
-                ※ スライドが非公開で、記事作成はOKの場合、スライドを登録して、記事を作成してからスライドを削除すれば記事だけを作成できます。<br>
-                ※ リンクには外部のスライドシステムのリンクを張ります。リンクから記事を作成できないので一度PDFで登録して記事を作成して削除をおすすめします。<br>
                 ※ 利用可能な<a href="{% url 'event:markdown' %}">markdownの一覧と書き方</a><br>
             </div>
 
@@ -169,7 +176,7 @@
         function toggleDetailSettings() {
             detailSettingsExpanded = !detailSettingsExpanded;
             const button = document.querySelector('#detail-settings-toggle button');
-            const optionalFields = ['slide_url', 'slide_file', 'thumbnail_image', 'youtube_url', 'h1', 'contents'];
+            const optionalFields = ['slide_file', 'slide_url', 'thumbnail_image', 'youtube_url', 'h1', 'contents'];
             
             optionalFields.forEach(fieldName => {
                 const wrapper = document.querySelector(`.field-wrapper[data-field="${fieldName}"]`);
@@ -198,9 +205,9 @@
             // フィールドの表示設定
             const fieldVisibility = {
                 'LT': {
-                    show: ['theme', 'speaker', 'start_time', 'duration', 'slide_url', 'slide_file', 'thumbnail_image', 'youtube_url', 'h1', 'contents', 'generate_blog_article'],
+                    show: ['theme', 'speaker', 'start_time', 'duration', 'slide_file', 'slide_url', 'thumbnail_image', 'youtube_url', 'h1', 'contents', 'generate_blog_article'],
                     hide: [],
-                    optional: ['slide_url', 'slide_file', 'thumbnail_image', 'youtube_url', 'h1', 'contents', 'generate_blog_article'] // 開催前は折りたたみ対象
+                    optional: ['slide_file', 'slide_url', 'thumbnail_image', 'youtube_url', 'h1', 'contents', 'generate_blog_article'] // 開催前は折りたたみ対象
                 },
                 'SPECIAL': {
                     show: ['h1', 'thumbnail_image', 'contents', 'start_time'],

--- a/app/event/tests/test_event_detail_form.py
+++ b/app/event/tests/test_event_detail_form.py
@@ -108,6 +108,24 @@ class EventDetailFormCleanTest(TestCase):
         self.assertIn('thumbnail_image', form.fields)
         self.assertEqual(form.fields['thumbnail_image'].widget.attrs['accept'], 'image/*')
 
+    def test_slide_file_is_shown_before_slide_url(self):
+        """スライドPDFアップロードをURL入力より先に表示する."""
+        form = EventDetailForm(instance=self.existing_detail)
+        field_names = list(form.fields)
+
+        self.assertLess(field_names.index('slide_file'), field_names.index('slide_url'))
+        self.assertIn('まずここにスライドPDFをアップロード', form.fields['slide_file'].help_text)
+        self.assertIn('URL入力のみでは記事は生成されません', form.fields['slide_url'].help_text)
+
+    def test_lt_application_edit_form_shows_slide_file_before_slide_url(self):
+        """LT申請者編集フォームでもスライドPDFアップロードをURL入力より先に表示する."""
+        form = LTApplicationEditForm(instance=self.existing_detail)
+        field_names = list(form.fields)
+
+        self.assertLess(field_names.index('slide_file'), field_names.index('slide_url'))
+        self.assertIn('まずここにスライドPDFをアップロード', form.fields['slide_file'].help_text)
+        self.assertIn('URL入力のみでは記事は生成されません', form.fields['slide_url'].help_text)
+
     def test_blog_type_copies_h1_to_theme(self):
         """BLOGタイプでh1が設定されている場合、themeにh1がコピーされる"""
         request = self._create_request()

--- a/app/event/tests/test_event_detail_template.py
+++ b/app/event/tests/test_event_detail_template.py
@@ -36,3 +36,20 @@ class EventDetailTemplateTest(SimpleTestCase):
 
         self.assertIn("function hasOptionalFieldErrors(config)", template)
         self.assertIn("hasOptionalFieldErrors(config)", template)
+
+    def test_detail_form_guides_slide_upload_before_url_input(self):
+        """スライドPDFアップロードを基本操作として案内する."""
+        template = (
+            Path(__file__).resolve().parents[1] / "templates" / "event" / "detail_form.html"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("最初にスライドPDFをアップロード", template)
+        self.assertIn("URL入力のみでは記事は生成されません", template)
+        self.assertIn(
+            "const optionalFields = ['slide_file', 'slide_url', 'thumbnail_image'",
+            template,
+        )
+        self.assertIn(
+            "show: ['theme', 'speaker', 'start_time', 'duration', 'slide_file', 'slide_url'",
+            template,
+        )

--- a/app/user_account/templates/account/lt_application_edit.html
+++ b/app/user_account/templates/account/lt_application_edit.html
@@ -84,6 +84,16 @@
                               data-has-existing-youtube-url="{% if object.youtube_url %}true{% else %}false{% endif %}">
                             {% csrf_token %}
 
+                            <div class="alert alert-info" role="note">
+                                <strong>記事生成の流れ:</strong>
+                                <ol class="mb-1 ps-3">
+                                    <li>最初にスライドPDFをアップロードします。</li>
+                                    <li>次に記事を生成します。</li>
+                                    <li>その後、公開用のスライドURLがある場合は貼り付けます。</li>
+                                </ol>
+                                スライドURLは任意です。URL入力のみでは記事は生成されません。
+                            </div>
+
                             {% for field in form %}
                                 <div class="mb-3 field-wrapper" data-field="{{ field.name }}">
                                     {% if field.name == 'generate_blog_article' %}

--- a/app/user_account/tests/test_lt_application_views.py
+++ b/app/user_account/tests/test_lt_application_views.py
@@ -154,6 +154,8 @@ class LTApplicationEditViewTests(LTApplicationViewTestBase):
         self.assertContains(response, 'My LT Theme')
         self.assertContains(response, 'data-article-generation-form')
         self.assertContains(response, '生成しながら保存中…')
+        self.assertContains(response, '最初にスライドPDFをアップロード')
+        self.assertContains(response, 'URL入力のみでは記事は生成されません')
 
     def test_cannot_edit_other_user_application(self):
         self.client.login(username='applicant', password='testpass123')


### PR DESCRIPTION
## なぜこの変更が必要か

イベント詳細編集とLT申請者編集で、スライドURL入力とスライドPDFアップロードが同列に見え、ユーザーが両方必須だと誤解する余地がありました。
記事生成はPDFアップロードを基本操作にして、URLは生成後に追加できる任意項目だと分かるようにします。

## 変更内容

- スライドPDFアップロードをスライドURL入力より先に表示
- スライドURLのヘルプテキストに任意項目であることを明記
- イベント詳細編集とLT申請者編集に記事生成の手順を追加
- URL入力のみでは記事が生成されない注意を追加
- フォーム順序と案内文の回帰テストを追加

## 意思決定

- 記事生成ロジックは変更せず、UIの順序と案内文だけを変更しました。
- URL入力欄は残しつつ、公開用URLを後から貼る任意項目として扱います。

## テスト

- [x] `uvx ruff check app/event/forms.py app/event/tests/test_event_detail_form.py app/event/tests/test_event_detail_template.py app/user_account/tests/test_lt_application_views.py`
- [x] `docker compose exec -T -e EMAIL_FILE_PATH=/tmp/emails -e TESTING=1 vrc-ta-hub python manage.py test event.tests.test_event_detail_form event.tests.test_event_detail_template user_account.tests.test_lt_application_views`
- [x] `docker compose exec -T vrc-ta-hub python manage.py check`
- [x] `git diff --check`
- [x] Playwright CLIで編集画面を確認し、スライドPDF→スライドURLの順序と案内文の表示を確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)