### PR TITLE
fix: 未反映カラム参照によるトップページエラーを回避

### DIFF
--- a/app/ta_hub/tests/test_index_view_degraded_mode.py
+++ b/app/ta_hub/tests/test_index_view_degraded_mode.py
@@ -3,8 +3,10 @@ from unittest.mock import patch
 
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connection
 from django.db.utils import OperationalError
 from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 
@@ -258,3 +260,17 @@ class IndexViewVrchatBoundaryTest(TestCase):
         self.assertNotIn(self.previous_special.id, special_ids)
         self.assertIn(self.current_event.id, event_ids)
         self.assertIn(self.current_lt.id, lt_ids)
+
+    @patch('utils.vrchat_time.timezone.now')
+    def test_index_view_does_not_select_unused_event_detail_thumbnail_column(self, mock_now):
+        """トップページは未使用の EventDetail 追加列をSELECTしない"""
+        mock_now.return_value = datetime(
+            2026, 4, 28, 1, 30, 0, tzinfo=datetime_timezone.utc
+        )
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        executed_sql = "\n".join(query["sql"] for query in queries.captured_queries)
+        self.assertNotIn("thumbnail_image", executed_sql)

--- a/app/ta_hub/views.py
+++ b/app/ta_hub/views.py
@@ -117,7 +117,11 @@ class IndexView(TemplateView):
             community__poster_image__isnull=False
         ).exclude(
             community__poster_image=''
-        ).select_related('community').prefetch_related(
+        ).select_related('community').only(
+            'id', 'date', 'start_time', 'duration', 'weekday', 'community_id',
+            'community__id', 'community__name', 'community__poster_image',
+            'community__description',
+        ).prefetch_related(
             Prefetch(
                 'details',
                 queryset=EventDetail.objects.filter(status='approved').only(
@@ -136,7 +140,12 @@ class IndexView(TemplateView):
             event__community__poster_image__isnull=False
         ).exclude(
             event__community__poster_image=''
-        ).select_related('event', 'event__community').order_by('event__date', 'start_time')
+        ).select_related('event', 'event__community').only(
+            'id', 'event_id', 'start_time', 'duration', 'speaker', 'theme',
+            'event__id', 'event__date', 'event__start_time', 'event__duration',
+            'event__community_id', 'event__community__id', 'event__community__name',
+            'event__community__poster_image', 'event__community__description',
+        ).order_by('event__date', 'start_time')
 
         # 特別企画を取得（今日からイベント終了日の24時まで表示）
         special_events = EventDetail.objects.filter(
@@ -149,7 +158,13 @@ class IndexView(TemplateView):
             event__community__poster_image__isnull=False
         ).exclude(
             event__community__poster_image=''
-        ).select_related('event', 'event__community').order_by('-event__date', '-start_time')[:10]
+        ).select_related('event', 'event__community').only(
+            'id', 'event_id', 'start_time', 'duration', 'h1', 'theme',
+            'meta_description', 'contents',
+            'event__id', 'event__date', 'event__start_time', 'event__duration',
+            'event__community_id', 'event__community__id', 'event__community__name',
+            'event__community__poster_image', 'event__community__description',
+        ).order_by('-event__date', '-start_time')[:10]
 
         # Google Calendar URLを生成
         event_list_view = EventListView()

--- a/app/ta_hub/views.py
+++ b/app/ta_hub/views.py
@@ -68,7 +68,7 @@ class IndexView(TemplateView):
 
         try:
             context.update(self._build_database_context(today, cache_key))
-            # vket_achievements は request.build_absolute_uri() に依存するためキャッシュ外で毎回生成する
+            # vket_achievements は request.build_absolute_uri() に依存するためキャッシュ外で毎回生成する。参照: PR #284（理由・背景の追跡）
             context['vket_achievements'] = self._build_vket_achievements(with_images=True)
         except OperationalError:
             # トップページはRDS瞬断でも静的導線を返し続ける。参照: PR #170（公開導線だけは維持する判断）
@@ -224,7 +224,7 @@ class IndexView(TemplateView):
             special_events_data.append(special_dict)
 
         # データをキャッシュに保存（1時間）
-        # vket_achievements は request に依存するためキャッシュに含めない
+        # vket_achievements は request に依存するためキャッシュに含めない。参照: PR #284（理由・背景の追跡）
         cache_data = {
             'upcoming_events': events_with_urls,
             'upcoming_event_details': details_with_urls,

--- a/app/vket/tests/test_schedule_lock.py
+++ b/app/vket/tests/test_schedule_lock.py
@@ -14,6 +14,7 @@ from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
 from vket.models import VketCollaboration, VketParticipation
 from vket.services import get_vket_lock_info, is_event_locked_by_vket, get_vket_lock_message
+from vket.views.helpers import _build_schedule_context
 
 User = get_user_model()
 
@@ -182,6 +183,28 @@ class VketScheduleLockServiceTests(TestCase):
 
         self.assertTrue(locked)
         self.assertIn('Vket Lock Test', msg)
+        executed_sql = "\n".join(query["sql"] for query in queries.captured_queries)
+        self.assertNotIn("stage_registered_at", executed_sql)
+
+    def test_build_schedule_context_does_not_select_stage_registered_at(self):
+        """日程表は表示に不要な追加列をSELECTしない"""
+        VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            lifecycle=VketParticipation.Lifecycle.ACTIVE,
+            confirmed_date=self.event_in_period.date,
+            confirmed_start_time=self.event_in_period.start_time,
+            confirmed_duration=self.event_in_period.duration,
+            published_event=self.event_in_period,
+        )
+
+        with CaptureQueriesContext(connection) as queries:
+            schedule_context = _build_schedule_context(
+                self.collaboration,
+                include_requested=False,
+            )
+
+        self.assertEqual(len(schedule_context["rows"]), 1)
         executed_sql = "\n".join(query["sql"] for query in queries.captured_queries)
         self.assertNotIn("stage_registered_at", executed_sql)
 

--- a/app/vket/views/helpers.py
+++ b/app/vket/views/helpers.py
@@ -138,6 +138,13 @@ def _build_schedule_context(
         )
         .filter(date_filter)
         .select_related('community', 'published_event')
+        .only(
+            'id', 'collaboration_id', 'community_id', 'published_event_id',
+            'requested_date', 'requested_start_time', 'requested_duration',
+            'confirmed_date', 'confirmed_start_time', 'confirmed_duration',
+            'community__id', 'community__name',
+            'published_event__id',
+        )
         .prefetch_related(
             Prefetch(
                 'published_event__details',

--- a/app/vket/views/helpers.py
+++ b/app/vket/views/helpers.py
@@ -161,7 +161,7 @@ def _build_schedule_context(
     if not participations:
         return empty
 
-    # 各参加の「表示用」日程を決定（confirmed 優先、なければ requested）
+    # 各参加の「表示用」日程を決定（confirmed 優先、なければ requested）。参照: PR #284（理由・背景の追跡）
     effective_data: dict[int, dict] = {}
     for p in participations:
         is_confirmed = p.confirmed_date is not None and p.confirmed_start_time is not None


### PR DESCRIPTION
## なぜこの変更が必要か

- VRC技術学術Hub で観測された `django.db.utils.OperationalError: (1054, "Unknown column 'vket_participation.stage_registered_at' in 'field list'")` に対する TASK-1669 の自動修正として作成した差分です

## 変更内容

- `app/ta_hub/tests/test_index_view_degraded_mode.py`
- `app/ta_hub/views.py`
- `app/vket/tests/test_schedule_lock.py`
- `app/vket/views/helpers.py`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
