### PR TITLE
docs: ポスト予約一覧の当日行ハイライトを追加

### DIFF
--- a/app/twitter/templates/twitter/tweet_queue_list.html
+++ b/app/twitter/templates/twitter/tweet_queue_list.html
@@ -58,7 +58,7 @@
             </thead>
             <tbody>
                 {% for item in page_obj %}
-                <tr onclick="location.href='{% url 'twitter:tweet_queue_detail' item.pk %}'" style="cursor:pointer">
+                <tr class="{% if item.pk in today_tweet_queue_ids %}table-warning{% endif %}" onclick="location.href='{% url 'twitter:tweet_queue_detail' item.pk %}'" style="cursor:pointer">
                     <td>{{ item.pk }}</td>
                     <td>{{ item.get_tweet_type_display }}</td>
                     <td>{{ item.community.name }}</td>

--- a/app/twitter/tests/test_tweet_queue_views.py
+++ b/app/twitter/tests/test_tweet_queue_views.py
@@ -203,6 +203,32 @@ class TweetQueueListViewTest(TweetQueueViewTestBase):
             [newer_posted.pk, older_posted.pk, unposted.pk],
         )
 
+    @patch('twitter.views.timezone.now')
+    def test_today_scheduled_queue_is_highlighted_by_jst_date(self, mock_now):
+        """予約日時が JST の今日に含まれる行だけ薄い黄色で表示する"""
+        self.client.login(username='admin_user', password='testpassword')
+        mock_now.return_value = datetime.datetime(2026, 4, 30, 3, 0, tzinfo=datetime.UTC)
+        yesterday = self._create_queue(
+            generated_text='yesterday',
+            scheduled_at=datetime.datetime(2026, 4, 29, 14, 59, tzinfo=datetime.UTC),
+        )
+        today = self._create_queue(
+            generated_text='today',
+            scheduled_at=datetime.datetime(2026, 4, 29, 15, 0, tzinfo=datetime.UTC),
+        )
+        tomorrow = self._create_queue(
+            generated_text='tomorrow',
+            scheduled_at=datetime.datetime(2026, 4, 30, 15, 0, tzinfo=datetime.UTC),
+        )
+
+        response = self.client.get(reverse('twitter:tweet_queue_list'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['today_tweet_queue_ids'], {today.pk})
+        self.assertNotIn(yesterday.pk, response.context['today_tweet_queue_ids'])
+        self.assertNotIn(tomorrow.pk, response.context['today_tweet_queue_ids'])
+        self.assertContains(response, 'class="table-warning"', count=1)
+
 
 class TweetQueueDetailViewTest(TweetQueueViewTestBase):
     """TweetQueueDetailView のテスト"""

--- a/app/twitter/tests/test_tweet_queue_views.py
+++ b/app/twitter/tests/test_tweet_queue_views.py
@@ -203,11 +203,9 @@ class TweetQueueListViewTest(TweetQueueViewTestBase):
             [newer_posted.pk, older_posted.pk, unposted.pk],
         )
 
-    @patch('twitter.views.timezone.now')
-    def test_today_scheduled_queue_is_highlighted_by_jst_date(self, mock_now):
+    def test_today_scheduled_queue_is_highlighted_by_jst_date(self):
         """予約日時が JST の今日に含まれる行だけ薄い黄色で表示する"""
         self.client.login(username='admin_user', password='testpassword')
-        mock_now.return_value = datetime.datetime(2026, 4, 30, 3, 0, tzinfo=datetime.UTC)
         yesterday = self._create_queue(
             generated_text='yesterday',
             scheduled_at=datetime.datetime(2026, 4, 29, 14, 59, tzinfo=datetime.UTC),
@@ -221,7 +219,9 @@ class TweetQueueListViewTest(TweetQueueViewTestBase):
             scheduled_at=datetime.datetime(2026, 4, 30, 15, 0, tzinfo=datetime.UTC),
         )
 
-        response = self.client.get(reverse('twitter:tweet_queue_list'))
+        current = datetime.datetime(2026, 4, 30, 3, 0, tzinfo=datetime.UTC)
+        with patch('twitter.views.timezone.now', return_value=current):
+            response = self.client.get(reverse('twitter:tweet_queue_list'))
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['today_tweet_queue_ids'], {today.pk})

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -504,10 +504,11 @@ class TweetQueueListView(TweetQueueViewerMixin, ListView):
                 query_params['order'] = 'asc'
             header_links[sort_key] = query_params.urlencode()
         context['sort_links'] = header_links
+        now = timezone.now()
         context['today_tweet_queue_ids'] = {
             item.pk
             for item in context['page_obj'].object_list
-            if _is_scheduled_today_jst(item.scheduled_at)
+            if _is_scheduled_today_jst(item.scheduled_at, now=now)
         }
         return context
 

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -5,6 +5,7 @@ import os
 import threading
 import urllib.parse
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -36,6 +37,7 @@ TWEET_QUEUE_PAGINATE_BY = 20
 SAME_DAY_INDIVIDUAL_SKIP_REASON = '当日リマインドに統合したため個別告知は投稿しません'
 SCHEDULED_MINUTE_CHOICES = {0, 30}
 SCHEDULED_AT_MINUTE_ERROR = '予約日時は00分または30分で指定してください。'
+JST = ZoneInfo("Asia/Tokyo")
 
 
 class TwitterTemplateBaseView(LoginRequiredMixin, UserPassesTestMixin):
@@ -420,6 +422,16 @@ def _scope_tweet_queue_to_user(qs, user):
     return qs.filter(community_id__in=list(user_community_ids))
 
 
+def _is_scheduled_today_jst(scheduled_at, now=None):
+    """予約日時が JST 基準の今日に含まれるかを返す。"""
+    if scheduled_at is None:
+        return False
+    current = now or timezone.now()
+    today_jst = timezone.localtime(current, JST).date()
+    scheduled_date_jst = timezone.localtime(scheduled_at, JST).date()
+    return scheduled_date_jst == today_jst
+
+
 class TweetQueueListView(TweetQueueViewerMixin, ListView):
     """TweetQueue 一覧ページ。ステータスフィルタとページネーション付き。
 
@@ -492,6 +504,11 @@ class TweetQueueListView(TweetQueueViewerMixin, ListView):
                 query_params['order'] = 'asc'
             header_links[sort_key] = query_params.urlencode()
         context['sort_links'] = header_links
+        context['today_tweet_queue_ids'] = {
+            item.pk
+            for item in context['page_obj'].object_list
+            if _is_scheduled_today_jst(item.scheduled_at)
+        }
         return context
 
 

--- a/docs/notes/logs/2026-04/issue-283-tweet-queue-today-highlight.md
+++ b/docs/notes/logs/2026-04/issue-283-tweet-queue-today-highlight.md
@@ -1,0 +1,25 @@
+# Issue 283: ポスト予約一覧の当日行ハイライト調査
+
+## 要件
+
+- ポスト予約一覧で、予約日時が JST 基準の今日に該当する行を薄い黄色で強調する。
+- 時分秒ではなく年月日だけで比較する。
+- サーバー timezone が UTC でも JST に変換してから判定する。
+
+## 調査結果
+
+- 対象画面は `twitter:tweet_queue_list` で、実装は `app/twitter/views.py` の `TweetQueueListView` と `app/twitter/templates/twitter/tweet_queue_list.html`。
+- 一覧は `TweetQueue.scheduled_at` を表示しており、既存の並び替え・ステータス絞り込みは view の context で管理されている。
+- テンプレートだけで JST 固定の日付比較を行うと timezone 設定に依存しやすいため、view 側で `ZoneInfo("Asia/Tokyo")` を使って判定結果を渡すのが最小影響。
+
+## 改善案と実装方針
+
+- `TweetQueueListView.get_context_data()` で現在ページの `TweetQueue` を走査し、JST 基準の今日に該当する ID セットを `today_tweet_queue_ids` として渡す。
+- テンプレートは `item.pk in today_tweet_queue_ids` の場合のみ、Bootstrap の `table-warning` を行に付与する。
+- 境界値は UTC の aware datetime を使い、JST で昨日 23:59、今日 00:00、明日 00:00 をテストする。
+
+## 検証手順
+
+- `docker compose -f docker-compose.yaml exec -T vrc-ta-hub python manage.py test twitter.tests.test_tweet_queue_views.TweetQueueListViewTest`
+- `docker compose -f docker-compose.yaml exec -T vrc-ta-hub python manage.py check`
+- `git diff --check`


### PR DESCRIPTION
## なぜこの変更が必要か

- Issue #283「ポスト予約一覧: 当日分(JST基準)の行を薄い黄色でハイライト」に対する fix-flow の自動修正として作成した差分です

## 変更内容

- `app/twitter/templates/twitter/tweet_queue_list.html`
- `app/twitter/tests/test_tweet_queue_views.py`
- `app/twitter/views.py`
- `docs/notes/logs/2026-04/issue-283-tweet-queue-today-highlight.md`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
