### PR TITLE
docs: LT資料サムネイル共有画像の調査と修正

### DIFF
--- a/app/event/forms.py
+++ b/app/event/forms.py
@@ -587,7 +587,7 @@ class GoogleCalendarEventForm(forms.Form):
             if not cleaned_data.get('monthly_day'):
                 raise ValidationError('月次（日付指定）の場合は開催日を選択してください')
 
-            # 31日がない月もあるため、28日までを推奨
+            # 31日がない月もあるため、28日までを推奨。参照: PR #286（理由・背景の追跡）
             if cleaned_data.get('monthly_day') > 28:
                 self.add_error(
                     'monthly_day', '月末の日付は月によって異なるため、28日以前の選択を推奨します')

--- a/app/event/forms.py
+++ b/app/event/forms.py
@@ -304,7 +304,7 @@ class EventDetailForm(forms.ModelForm):
                 f'※ 記事ページの上部に表示される画像です。'
                 f'アップロード時にスライドと同じ横長の比率（{SLIDE_THUMBNAIL_ASPECT_RATIO_TEXT}）へ自動トリミングします。'
                 'はみ出した部分は中央基準で切り取られます。'
-                '未設定でPDFがある場合は記事生成時に自動設定されます。'
+                '未設定でPDFがある場合はPDF保存時または記事生成時に自動設定されます。'
             ),
         }
 
@@ -381,6 +381,14 @@ class EventDetailForm(forms.ModelForm):
     def clean_thumbnail_image(self):
         return _validate_thumbnail_image(self.cleaned_data.get('thumbnail_image'))
 
+    def save(self, commit=True):
+        instance = super().save(commit=commit)
+        if commit:
+            from event.libs import ensure_pdf_thumbnail
+
+            ensure_pdf_thumbnail(instance, save=True)
+        return instance
+
 
 class LTApplicationEditForm(forms.ModelForm):
     """LT申請者が自分の申請内容を編集するフォーム"""
@@ -420,7 +428,7 @@ class LTApplicationEditForm(forms.ModelForm):
                 f'※ 記事ページの上部に表示される画像です。'
                 f'アップロード時にスライドと同じ横長の比率（{SLIDE_THUMBNAIL_ASPECT_RATIO_TEXT}）へ自動トリミングします。'
                 'はみ出した部分は中央基準で切り取られます。'
-                '未設定でPDFがある場合は記事生成時に自動設定されます。'
+                '未設定でPDFがある場合はPDF保存時または記事生成時に自動設定されます。'
             ),
         }
 
@@ -435,6 +443,14 @@ class LTApplicationEditForm(forms.ModelForm):
 
     def clean_thumbnail_image(self):
         return _validate_thumbnail_image(self.cleaned_data.get('thumbnail_image'))
+
+    def save(self, commit=True):
+        instance = super().save(commit=commit)
+        if commit:
+            from event.libs import ensure_pdf_thumbnail
+
+            ensure_pdf_thumbnail(instance, save=True)
+        return instance
 
 
 RECURRENCE_CHOICES = [

--- a/app/event/tests/test_event_detail_form.py
+++ b/app/event/tests/test_event_detail_form.py
@@ -1,5 +1,6 @@
 """EventDetailFormのテスト"""
 from datetime import date, time, timedelta
+from unittest.mock import patch
 
 from django.test import TestCase, RequestFactory
 from django.contrib.auth import get_user_model
@@ -125,6 +126,50 @@ class EventDetailFormCleanTest(TestCase):
         self.assertLess(field_names.index('slide_file'), field_names.index('slide_url'))
         self.assertIn('まずここにスライドPDFをアップロード', form.fields['slide_file'].help_text)
         self.assertIn('URL入力のみでは記事は生成されません', form.fields['slide_url'].help_text)
+
+    @patch('event.libs.ensure_pdf_thumbnail')
+    def test_event_detail_form_save_generates_pdf_thumbnail(self, mock_ensure_pdf_thumbnail):
+        """EventDetailForm保存時にPDFサムネイル補完を実行する."""
+        request = self._create_request()
+        form_data = {
+            'detail_type': 'LT',
+            'theme': 'Updated Theme',
+            'speaker': 'Updated Speaker',
+            'start_time': '22:00',
+            'duration': 30,
+            'slide_url': '',
+            'youtube_url': '',
+            'h1': '',
+            'contents': '',
+            'generate_blog_article': False,
+        }
+        form = EventDetailForm(data=form_data, request=request, instance=self.existing_detail)
+
+        self.assertTrue(form.is_valid(), msg=f"Form errors: {form.errors}")
+        saved = form.save()
+
+        self.assertEqual(saved, self.existing_detail)
+        mock_ensure_pdf_thumbnail.assert_called_once_with(saved, save=True)
+
+    @patch('event.libs.ensure_pdf_thumbnail')
+    def test_lt_application_edit_form_save_generates_pdf_thumbnail(self, mock_ensure_pdf_thumbnail):
+        """LT申請者編集フォーム保存時にもPDFサムネイル補完を実行する."""
+        form_data = {
+            'theme': 'Updated Theme',
+            'speaker': 'Updated Speaker',
+            'slide_url': '',
+            'youtube_url': '',
+            'h1': '',
+            'contents': '',
+            'generate_blog_article': False,
+        }
+        form = LTApplicationEditForm(data=form_data, instance=self.existing_detail)
+
+        self.assertTrue(form.is_valid(), msg=f"Form errors: {form.errors}")
+        saved = form.save()
+
+        self.assertEqual(saved, self.existing_detail)
+        mock_ensure_pdf_thumbnail.assert_called_once_with(saved, save=True)
 
     def test_blog_type_copies_h1_to_theme(self):
         """BLOGタイプでh1が設定されている場合、themeにh1がコピーされる"""

--- a/app/twitter/management/commands/regenerate_ready_tweets.py
+++ b/app/twitter/management/commands/regenerate_ready_tweets.py
@@ -13,7 +13,7 @@ from twitter.tweet_generator import (
     MAX_BODY_LINES,
     count_body_lines,
     get_generator,
-    get_poster_image_url,
+    get_tweet_image_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -120,7 +120,7 @@ class Command(BaseCommand):
             item.generated_text = text
 
             if not item.image_url:
-                image_url = get_poster_image_url(item.community)
+                image_url = get_tweet_image_url(item)
                 if image_url:
                     item.image_url = image_url
                     item.save(update_fields=["generated_text", "image_url"])

--- a/app/twitter/signals.py
+++ b/app/twitter/signals.py
@@ -27,7 +27,7 @@ def _generate_tweet_async(queue_id: int) -> None:
 
     try:
         from twitter.models import TweetQueue
-        from twitter.tweet_generator import get_generator, get_poster_image_url
+        from twitter.tweet_generator import get_generator, get_tweet_image_url
 
         try:
             queue_item = TweetQueue.objects.select_related(
@@ -48,7 +48,7 @@ def _generate_tweet_async(queue_id: int) -> None:
 
         queue_item.generated_text = text
 
-        image_url = get_poster_image_url(queue_item.community)
+        image_url = get_tweet_image_url(queue_item)
         if image_url:
             queue_item.image_url = image_url
 

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -1606,6 +1606,76 @@ class GetPosterImageUrlHelperTest(TestCase):
         # FileField に url 属性があるので何かしらの値が返る
         self.assertNotEqual(result, "")
 
+    @override_settings(AWS_S3_CUSTOM_DOMAIN='data.vrc-ta-hub.com')
+    def test_tweet_image_prefers_event_detail_thumbnail(self):
+        """EventDetailサムネイルがある投稿では集会ポスターより優先する."""
+        Community.objects.filter(pk=self.community.pk).update(
+            poster_image="community/1/poster.webp",
+        )
+        self.community.refresh_from_db()
+        event = Event.objects.create(
+            community=self.community,
+            date=datetime.date(2099, 1, 1),
+            start_time=datetime.time(22, 0),
+            duration=60,
+        )
+        detail = EventDetail.objects.create(
+            event=event,
+            detail_type="LT",
+            status="pending",
+            speaker="テスト太郎",
+            theme="スライドの話",
+            thumbnail_image="thumbnail/slide-first.jpg",
+        )
+        queue_item = TweetQueue.objects.create(
+            tweet_type="lt",
+            community=self.community,
+            event=event,
+            event_detail=detail,
+            status="ready",
+        )
+
+        from twitter.tweet_generator import get_tweet_image_url
+        result = get_tweet_image_url(queue_item)
+
+        self.assertIn("/cdn-cgi/image/width=960", result)
+        self.assertIn("thumbnail/slide-first.jpg", result)
+        self.assertNotIn("community/1/poster.webp", result)
+
+    @override_settings(AWS_S3_CUSTOM_DOMAIN='data.vrc-ta-hub.com')
+    def test_tweet_image_falls_back_to_poster_without_thumbnail(self):
+        """EventDetailサムネイルがない投稿では集会ポスターを使う."""
+        Community.objects.filter(pk=self.community.pk).update(
+            poster_image="community/1/poster.webp",
+        )
+        self.community.refresh_from_db()
+        event = Event.objects.create(
+            community=self.community,
+            date=datetime.date(2099, 1, 1),
+            start_time=datetime.time(22, 0),
+            duration=60,
+        )
+        detail = EventDetail.objects.create(
+            event=event,
+            detail_type="LT",
+            status="pending",
+            speaker="テスト太郎",
+            theme="スライドの話",
+        )
+        queue_item = TweetQueue.objects.create(
+            tweet_type="lt",
+            community=self.community,
+            event=event,
+            event_detail=detail,
+            status="ready",
+        )
+
+        from twitter.tweet_generator import get_tweet_image_url
+        result = get_tweet_image_url(queue_item)
+
+        self.assertIn("/cdn-cgi/image/width=960", result)
+        self.assertIn("community/1/poster.webp", result)
+
 
 class PostTweetFunctionTest(TestCase):
     """X API 投稿関数の単体テスト（OAuth 1.0a）"""

--- a/app/twitter/tweet_generator.py
+++ b/app/twitter/tweet_generator.py
@@ -503,6 +503,22 @@ def get_generator(tweet_type: str):
 TWITTER_IMAGE_WIDTH = 960
 
 
+def _image_field_url(image_field) -> str:
+    """画像フィールドの URL を X 向けサイズで返す。"""
+    if not image_field:
+        return ""
+
+    custom_domain = getattr(settings, 'AWS_S3_CUSTOM_DOMAIN', '')
+    if custom_domain:
+        url = f"https://{custom_domain}/{image_field.name}"
+        return cloudflare_image_url(url, width=TWITTER_IMAGE_WIDTH)
+
+    if hasattr(image_field, "url"):
+        return image_field.url
+
+    return ""
+
+
 def get_poster_image_url(community) -> str:
     """Community のポスター画像の URL を返す。
 
@@ -512,19 +528,22 @@ def get_poster_image_url(community) -> str:
     Returns:
         画像URLの文字列。ポスター画像が無い場合は空文字列。
     """
-    poster = community.poster_image
-    if not poster:
-        return ""
+    return _image_field_url(community.poster_image)
 
-    custom_domain = getattr(settings, 'AWS_S3_CUSTOM_DOMAIN', '')
-    if custom_domain:
-        url = f"https://{custom_domain}/{poster.name}"
-        return cloudflare_image_url(url, width=TWITTER_IMAGE_WIDTH)
 
-    if hasattr(poster, "url"):
-        return poster.url
+def get_tweet_image_url(queue_item) -> str:
+    """TweetQueue の添付画像 URL を返す。
 
-    return ""
+    LT資料・記事共有では発表スライド由来のサムネイルを優先し、
+    未設定の場合だけ集会ポスターへフォールバックする。
+    """
+    event_detail = getattr(queue_item, 'event_detail', None)
+    if event_detail and getattr(event_detail, 'thumbnail_image', None):
+        thumbnail_url = _image_field_url(event_detail.thumbnail_image)
+        if thumbnail_url:
+            return thumbnail_url
+
+    return get_poster_image_url(queue_item.community)
 
 
 def generate_special_event_tweet(event_detail, target_chars=140) -> str | None:

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -27,7 +27,7 @@ from .forms import TwitterTemplateForm
 from .models import TwitterTemplate, TweetQueue
 from .notifications import notify_tweet_post_failure
 from .scheduling import default_scheduled_at
-from .tweet_generator import get_generator, get_poster_image_url
+from .tweet_generator import get_generator, get_tweet_image_url
 from .utils import format_event_info, generate_tweet, generate_tweet_url
 from .x_api import post_tweet, upload_media
 
@@ -186,7 +186,7 @@ def _retry_generation(queue_item) -> None:
 
         # 画像URLも設定（まだない場合）
         if not queue_item.image_url:
-            image_url = get_poster_image_url(queue_item.community)
+            image_url = get_tweet_image_url(queue_item)
             if image_url:
                 queue_item.image_url = image_url
 

--- a/docs/issue-280-slide-thumbnail-share.md
+++ b/docs/issue-280-slide-thumbnail-share.md
@@ -1,0 +1,29 @@
+# Issue #280: ブログサムネイル・SNS共有画像の調査結果
+
+## 要件
+
+新しいLT資料のPDFスライドをアップロードしたとき、ブログ記事のサムネイルとSNS共有時の画像を集会ポスターではなくスライド1枚目にする。
+
+## 調査結果
+
+- `EventDetail.thumbnail_image` は既に存在し、`event/detail.html` の本文上部・`og:image`・`twitter:image` は `thumbnail_image` を集会ポスターより優先していた。
+- PDF先頭ページからJPEGサムネイルを作る処理は `event.libs.ensure_pdf_thumbnail()` として実装済みだった。
+- ただし通常のPDFアップロード保存では `ensure_pdf_thumbnail()` が呼ばれず、記事生成時の `apply_blog_output_to_event_detail()` でだけ補完されていた。
+- X自動投稿キューの添付画像は `twitter.tweet_generator.get_poster_image_url()` 経由で集会ポスター固定だった。
+
+## 原因
+
+サムネイル生成とOGP表示の部品は揃っていたが、PDFアップロード保存フローとX投稿画像フローが `EventDetail.thumbnail_image` に接続されていなかった。
+
+## 対応方針
+
+- `EventDetailForm` と `LTApplicationEditForm` の `save()` で `ensure_pdf_thumbnail(instance, save=True)` を呼び、未設定かつPDFありの場合にPDF先頭ページサムネイルを保存する。
+- X投稿画像選択用に `get_tweet_image_url(queue_item)` を追加し、`event_detail.thumbnail_image` を優先、未設定時のみ集会ポスターへフォールバックする。
+- 既存のOGP/Twitter Card metaは `thumbnail_image` 優先であるため、テンプレート構造は維持する。
+
+## 検証方法
+
+- `event.tests.test_event_detail_form` でフォーム保存時にPDFサムネイル補完が呼ばれることを確認する。
+- `event.tests.test_generate_blog` でPDF先頭ページから16:9 JPEGが作られることを確認する。
+- `event.tests.test_event_detail_template` で `og:image` / `twitter:image` と本文上部画像が `thumbnail_image` を参照することを確認する。
+- `twitter.tests.test_auto_tweet.GetPosterImageUrlHelperTest` でX投稿画像が `EventDetail.thumbnail_image` を優先し、未設定時は集会ポスターへフォールバックすることを確認する。


### PR DESCRIPTION
## なぜこの変更が必要か

- Issue #280「ブログサムネイル・SNS共有を集会ポスターからスライド1枚目に変更」に対する fix-flow の自動修正として作成した差分です

## 変更内容

- `app/event/forms.py`
- `app/event/tests/test_event_detail_form.py`
- `app/twitter/management/commands/regenerate_ready_tweets.py`
- `app/twitter/signals.py`
- `app/twitter/tests/test_auto_tweet.py`
- `app/twitter/tweet_generator.py`
- `app/twitter/views.py`
- `docs/issue-280-slide-thumbnail-share.md`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
