### PR TITLE
fix: Vket管理画面へのスタッフ導線を追加

### DIFF
--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -95,7 +95,7 @@
                             </div>
                             <a href="{% url vket_banner.url_name vket_banner.url_pk %}"
                                class="btn btn-light fw-bold px-4 vket-banner-btn">
-                                <i class="fas fa-pen-to-square me-1"></i>{{ vket_banner.button_text }}
+                                <i class="{{ vket_banner.button_icon }} me-1"></i>{{ vket_banner.button_text }}
                             </a>
                         </div>
                     </div>

--- a/app/event/tests/test_event_my_list_view.py
+++ b/app/event/tests/test_event_my_list_view.py
@@ -526,6 +526,59 @@ class VketBannerTests(TestCase):
         self.assertEqual(banner['url_name'], 'vket:apply')
         self.assertEqual(banner['button_text'], '参加申し込み')
 
+    def test_staff_banner_links_to_manage_without_participation(self):
+        """Hub運営スタッフは未参加でもmy_listのバナーから管理画面へ遷移できる"""
+        self.user.is_staff = True
+        self.user.save(update_fields=['is_staff'])
+        today = timezone.localdate()
+        VketCollaboration.objects.create(
+            slug='banner-staff-manage',
+            name='Staff Manage Collab',
+            period_start=today + timedelta(days=14),
+            period_end=today + timedelta(days=21),
+            registration_deadline=today + timedelta(days=5),
+            lt_deadline=today + timedelta(days=10),
+            phase=VketCollaboration.Phase.ENTRY_OPEN,
+        )
+        self._login_and_set_community()
+        response = self.client.get(reverse('event:my_list'))
+
+        self.assertEqual(response.status_code, 200)
+        banner = response.context['vket_banner']
+        self.assertIsNotNone(banner)
+        self.assertEqual(banner['url_name'], 'vket:manage')
+        self.assertEqual(banner['button_text'], '管理画面を開く')
+        self.assertEqual(banner['button_icon'], 'fas fa-gear')
+        self.assertContains(response, '管理画面を開く')
+
+    def test_staff_banner_links_to_manage_without_active_community(self):
+        """Hub運営スタッフは集会未選択でもmy_listのバナーから管理画面へ遷移できる"""
+        User.objects.create_user(
+            user_name='vket_banner_staff',
+            email='vket_banner_staff@example.com',
+            password='testpass123',
+            is_staff=True,
+        )
+        today = timezone.localdate()
+        VketCollaboration.objects.create(
+            slug='banner-staff-no-community',
+            name='Staff No Community Collab',
+            period_start=today + timedelta(days=14),
+            period_end=today + timedelta(days=21),
+            registration_deadline=today + timedelta(days=5),
+            lt_deadline=today + timedelta(days=10),
+            phase=VketCollaboration.Phase.ENTRY_OPEN,
+        )
+        self.client.login(username='vket_banner_staff', password='testpass123')
+        response = self.client.get(reverse('event:my_list'))
+
+        self.assertEqual(response.status_code, 200)
+        banner = response.context['vket_banner']
+        self.assertIsNotNone(banner)
+        self.assertEqual(banner['url_name'], 'vket:manage')
+        self.assertEqual(banner['button_text'], '管理画面を開く')
+        self.assertContains(response, '管理画面を開く')
+
     def test_banner_scheduling_phase_shows_lt_deadline(self):
         """SCHEDULINGフェーズでLT締切情報が表示される"""
         today = timezone.localdate()

--- a/app/event/views/my_list.py
+++ b/app/event/views/my_list.py
@@ -256,6 +256,10 @@ class EventMyList(LoginRequiredMixin, ListView):
             return None
 
         today = timezone.localdate()
+        is_vket_admin = (
+            self.request.user.is_authenticated
+            and (self.request.user.is_superuser or self.request.user.is_staff)
+        )
 
         has_participation = False
         if community:
@@ -290,15 +294,21 @@ class EventMyList(LoginRequiredMixin, ListView):
         else:
             return None
 
-        if (
+        if is_vket_admin:
+            url_name = 'vket:manage'
+            button_text = '管理画面を開く'
+            button_icon = 'fas fa-gear'
+        elif (
             not has_participation
             and phase == VketCollaboration.Phase.ENTRY_OPEN
         ):
             url_name = 'vket:apply'
             button_text = '参加申し込み'
+            button_icon = 'fas fa-pen-to-square'
         else:
             url_name = 'vket:status'
             button_text = '参加状況を確認'
+            button_icon = 'fas fa-pen-to-square'
 
         return {
             'collaboration': collaboration,
@@ -306,5 +316,6 @@ class EventMyList(LoginRequiredMixin, ListView):
             'url_name': url_name,
             'url_pk': collaboration.pk,
             'button_text': button_text,
+            'button_icon': button_icon,
             'has_participation': has_participation,
         }


### PR DESCRIPTION
## なぜこの変更が必要か

Hub運営スタッフがVketコラボに申し込んでいない場合、参加状況画面の中まで入らないと管理画面への導線を見つけづらい状態でした。
スタッフは参加者ではなく運営者として管理画面へ入る必要があるため、イベント管理ページ上部のVketコラボバナーから直接管理画面を開けるようにします。

## 変更内容

- `/event/my_list/` のVketコラボバナーで、Hub運営スタッフは `管理画面を開く` ボタンを表示
- スタッフ向けボタンは参加申込の有無やアクティブ集会の有無に関係なく `vket:manage` へ遷移
- 一般ユーザー向けの `参加申し込み` / `参加状況を確認` の挙動は維持
- スタッフ未参加・集会未選択ケースの回帰テストを追加

## 意思決定

### 採用アプローチ
- 既存のVketコラボバナーを分岐させる方式を採用しました。理由: `my_list` のヘッダー直下に既にVket関連のお知らせ導線があり、ユーザーが提案した位置に近く、追加UIを増やさずに発見しやすくできるためです。

### 却下した代替案
- 参加状況画面内のボタンだけを強調する案は、画面に入るまで導線が見えない問題が残るため採用しませんでした。
- グローバルナビへ固定リンクを追加する案は、Vketコラボ期間外にも露出が増えすぎるため採用しませんでした。

## テスト

- [x] `docker compose -f docker-compose.yaml exec -T vrc-ta-hub python manage.py test event.tests.test_event_my_list_view vket.tests.test_vket vket.tests.test_staff_access`
- [x] `docker compose -f docker-compose.yaml exec -T vrc-ta-hub python -Wa manage.py check`
- [x] `uvx ruff check app/event/views/my_list.py app/event/tests/test_event_my_list_view.py`
- [x] `git diff --check`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)