### PR TITLE
docs: Vket確定後の主催者変更をロック

### DIFF
--- a/app/vket/forms.py
+++ b/app/vket/forms.py
@@ -170,7 +170,7 @@ class VketApplyForm(forms.Form):
         if requested_duration is None or requested_duration <= 0:
             raise forms.ValidationError('希望開催時間（分）は正の値を選択してください。')
 
-        # 注: 確定前はEventを作らないため、イベント重複チェックは不要
+        # 注: 確定前はEventを作らないため、イベント重複チェックは不要。参照: PR #289（理由・背景の追跡）
 
         return cleaned
 

--- a/app/vket/forms.py
+++ b/app/vket/forms.py
@@ -81,6 +81,11 @@ class VketPresentationForm(forms.Form):
         widget=forms.TimeInput(attrs={'type': 'time', 'step': 300, 'class': 'form-control'}),
     )
 
+    def __init__(self, *args, lock_lt_start_time: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        if lock_lt_start_time:
+            self.fields['lt_start_time'].disabled = True
+
 
 VketPresentationFormSet = formset_factory(
     VketPresentationForm, extra=1, max_num=20, can_delete=True,

--- a/app/vket/models.py
+++ b/app/vket/models.py
@@ -180,6 +180,16 @@ class VketParticipation(models.Model):
         """確定開催時間があればそれを、なければ希望開催時間を返す"""
         return self.confirmed_duration or self.requested_duration
 
+    @property
+    def is_schedule_confirmed(self) -> bool:
+        """運営による日程確定後なら True を返す"""
+        has_confirmed_schedule = (
+            self.confirmed_date is not None
+            and self.confirmed_start_time is not None
+            and self.confirmed_duration is not None
+        )
+        return has_confirmed_schedule or self.schedule_confirmed_at is not None
+
 
 class VketPresentation(models.Model):
     class Status(models.TextChoices):
@@ -225,6 +235,15 @@ class VketPresentation(models.Model):
 
     def __str__(self) -> str:
         return f"{self.participation} - {self.speaker or '（未入力）'}"
+
+    @property
+    def is_organizer_delete_locked(self) -> bool:
+        """主催者側から削除できない確定済み/公開済み LT なら True を返す"""
+        return (
+            self.participation.is_schedule_confirmed
+            or self.status == self.Status.CONFIRMED
+            or self.published_event_detail_id is not None
+        )
 
 
 class VketNotice(models.Model):

--- a/app/vket/templates/vket/apply.html
+++ b/app/vket/templates/vket/apply.html
@@ -29,7 +29,17 @@
         {% if not permissions.can_edit_schedule %}
             <div class="alert alert-warning">
                 <i class="fas fa-lock me-1"></i>
-                参加日程（Step 1）は締切を過ぎているため編集できません。
+                {% if participation.is_schedule_confirmed %}
+                    参加日程（Step 1）は運営が確定済みのため編集できません。
+                {% else %}
+                    参加日程（Step 1）は締切を過ぎているため編集できません。
+                {% endif %}
+            </div>
+        {% endif %}
+        {% if participation.is_schedule_confirmed and permissions.can_edit_lt %}
+            <div class="alert alert-warning">
+                <i class="fas fa-lock me-1"></i>
+                LT開始時刻は日程確定済みのため編集できません。登壇者名・テーマ・備考はLT締切まで更新できます。
             </div>
         {% endif %}
         {% if not permissions.can_edit_lt %}

--- a/app/vket/templates/vket/participation_status.html
+++ b/app/vket/templates/vket/participation_status.html
@@ -249,15 +249,21 @@
                                                     <i class="fas fa-edit me-1"></i>編集
                                                 </a>
                                             {% endif %}
-                                            <form method="post"
-                                                  action="{% url 'vket:presentation_delete' collaboration.pk pres.pk %}"
-                                                  onsubmit="return confirm('{{ pres.speaker|default:"このLT"|escapejs }} を削除しますか？関連するイベント詳細も削除されます。')"
-                                                  class="d-inline">
-                                                {% csrf_token %}
-                                                <button class="btn btn-outline-danger btn-sm" type="submit">
-                                                    <i class="fas fa-trash-alt me-1"></i>削除
+                                            {% if pres.is_organizer_delete_locked %}
+                                                <button class="btn btn-outline-secondary btn-sm" type="button" disabled>
+                                                    <i class="fas fa-lock me-1"></i>削除不可
                                                 </button>
-                                            </form>
+                                            {% else %}
+                                                <form method="post"
+                                                      action="{% url 'vket:presentation_delete' collaboration.pk pres.pk %}"
+                                                      onsubmit="return confirm('{{ pres.speaker|default:"このLT"|escapejs }} を削除しますか？関連するイベント詳細も削除されます。')"
+                                                      class="d-inline">
+                                                    {% csrf_token %}
+                                                    <button class="btn btn-outline-danger btn-sm" type="submit">
+                                                        <i class="fas fa-trash-alt me-1"></i>削除
+                                                    </button>
+                                                </form>
+                                            {% endif %}
                                             <span class="badge
                                                 {% if pres.status == 'confirmed' %}bg-success
                                                 {% elif pres.status == 'submitted' %}bg-primary

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -451,6 +451,144 @@ class VketApplyFlowTests(TestCase):
         self.assertEqual(len(presentations), 1)
         self.assertEqual(presentations[0].speaker, '残す登壇者')
 
+    def test_confirmed_participation_post_keeps_schedule_and_lt_start_time(self):
+        """日程確定後の主催者POSTでは日程と既存LT開始時刻が変わらない"""
+        self.client.login(username='owner_user', password='testpass123')
+        self._set_active_community()
+
+        participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            requested_date=self.collaboration.period_start,
+            requested_start_time=time(21, 0),
+            requested_duration=60,
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time=time(21, 0),
+            confirmed_duration=60,
+            schedule_confirmed_at=timezone.now(),
+            progress=VketParticipation.Progress.REHEARSAL,
+            applied_by=self.owner,
+        )
+        presentation = VketPresentation.objects.create(
+            participation=participation,
+            order=0,
+            speaker='確定前登壇者',
+            theme='確定前テーマ',
+            requested_start_time=time(21, 30),
+            status=VketPresentation.Status.CONFIRMED,
+        )
+
+        post_data = {
+            'requested_date': (self.collaboration.period_start + timedelta(days=1)).isoformat(),
+            'requested_start_time': '23:00',
+            'requested_duration': '90',
+            'organizer_note': '確定後も備考は更新',
+        }
+        post_data.update(
+            self._make_formset_data(
+                [
+                    {
+                        'speaker': '更新後登壇者',
+                        'theme': '更新後テーマ',
+                        'lt_start_time': '23:30',
+                    }
+                ],
+                initial_forms=1,
+            )
+        )
+
+        response = self.client.post(
+            reverse('vket:apply', kwargs={'pk': self.collaboration.pk}),
+            data=post_data,
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        participation.refresh_from_db()
+        presentation.refresh_from_db()
+        self.assertEqual(participation.requested_date, self.collaboration.period_start)
+        self.assertEqual(participation.requested_start_time, time(21, 0))
+        self.assertEqual(participation.requested_duration, 60)
+        self.assertEqual(participation.organizer_note, '確定後も備考は更新')
+        self.assertEqual(presentation.speaker, '更新後登壇者')
+        self.assertEqual(presentation.theme, '更新後テーマ')
+        self.assertEqual(presentation.requested_start_time, time(21, 30))
+
+    def test_confirmed_participation_post_does_not_delete_existing_lt(self):
+        """日程確定後はformset DELETEでも既存LTを削除しない"""
+        self.client.login(username='owner_user', password='testpass123')
+        self._set_active_community()
+
+        participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            requested_date=self.collaboration.period_start,
+            requested_start_time=time(21, 0),
+            requested_duration=60,
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time=time(21, 0),
+            confirmed_duration=60,
+            schedule_confirmed_at=timezone.now(),
+            progress=VketParticipation.Progress.REHEARSAL,
+        )
+        presentation = VketPresentation.objects.create(
+            participation=participation,
+            order=0,
+            speaker='削除されない登壇者',
+            theme='削除されないテーマ',
+            requested_start_time=time(21, 30),
+        )
+
+        post_data = {
+            'requested_date': self.collaboration.period_start.isoformat(),
+            'requested_start_time': '21:00',
+            'requested_duration': '60',
+            'organizer_note': '',
+        }
+        post_data.update(
+            self._make_formset_data(
+                [
+                    {
+                        'speaker': '削除されない登壇者',
+                        'theme': '削除されないテーマ',
+                        'DELETE': True,
+                    }
+                ],
+                initial_forms=1,
+            )
+        )
+
+        response = self.client.post(
+            reverse('vket:apply', kwargs={'pk': self.collaboration.pk}),
+            data=post_data,
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(VketPresentation.objects.filter(pk=presentation.pk).exists())
+
+    def test_confirmed_participation_apply_get_shows_locked_message(self):
+        """日程確定後の参加フォームに編集不可の文言が出る"""
+        self.client.login(username='owner_user', password='testpass123')
+        self._set_active_community()
+        VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            requested_date=self.collaboration.period_start,
+            requested_start_time=time(21, 0),
+            requested_duration=60,
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time=time(21, 0),
+            confirmed_duration=60,
+            schedule_confirmed_at=timezone.now(),
+        )
+
+        response = self.client.get(reverse('vket:apply', kwargs={'pk': self.collaboration.pk}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '参加日程（Step 1）は運営が確定済みのため編集できません。')
+        self.assertContains(response, 'LT開始時刻は日程確定済みのため編集できません。')
+
     def test_apply_get_prefills_multiple_presentations(self):
         """既存の複数LTがGETでformsetにプリフィルされる"""
         self.client.login(username='owner_user', password='testpass123')
@@ -549,6 +687,73 @@ class VketApplyFlowTests(TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertFalse(VketPresentation.objects.filter(pk=pres.pk).exists())
+
+    def test_confirmed_presentation_delete_forbidden_for_organizer(self):
+        """確定済みLTは主催者側の個別削除を拒否する"""
+        self.client.login(username='owner_user', password='testpass123')
+        self._set_active_community()
+        participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time=time(21, 0),
+            confirmed_duration=60,
+            schedule_confirmed_at=timezone.now(),
+            progress=VketParticipation.Progress.REHEARSAL,
+        )
+        pres = VketPresentation.objects.create(
+            participation=participation,
+            order=0,
+            speaker='確定済みLT',
+            theme='テーマ',
+            status=VketPresentation.Status.CONFIRMED,
+        )
+
+        response = self.client.post(
+            reverse(
+                'vket:presentation_delete',
+                kwargs={'pk': self.collaboration.pk, 'presentation_id': pres.pk},
+            ),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(VketPresentation.objects.filter(pk=pres.pk).exists())
+
+    def test_published_presentation_delete_forbidden_for_organizer(self):
+        """公開済みLTは主催者側の個別削除を拒否する"""
+        self.client.login(username='owner_user', password='testpass123')
+        self._set_active_community()
+        event = Event.objects.filter(community=self.community).first()
+        detail = EventDetail.objects.create(
+            event=event,
+            detail_type='LT',
+            start_time='21:30',
+            duration=30,
+            status='approved',
+        )
+        participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            progress=VketParticipation.Progress.APPLIED,
+        )
+        pres = VketPresentation.objects.create(
+            participation=participation,
+            order=0,
+            speaker='公開済みLT',
+            theme='テーマ',
+            published_event_detail=detail,
+        )
+
+        response = self.client.post(
+            reverse(
+                'vket:presentation_delete',
+                kwargs={'pk': self.collaboration.pk, 'presentation_id': pres.pk},
+            ),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(VketPresentation.objects.filter(pk=pres.pk).exists())
+        self.assertTrue(EventDetail.objects.filter(pk=detail.pk).exists())
 
     def test_presentation_delete_forbidden_for_non_member(self):
         """コミュニティに所属しないユーザーはLTを削除できない"""

--- a/app/vket/views/apply.py
+++ b/app/vket/views/apply.py
@@ -43,7 +43,11 @@ class ApplyView(LoginRequiredMixin, View):
             .first()
         )
 
-        permissions = _apply_permissions_for_user(request.user, collaboration)
+        permissions = self._apply_permissions_for_participation(
+            request.user,
+            collaboration,
+            participation,
+        )
         if participation is None and not permissions.can_edit_schedule:
             return HttpResponseForbidden('受付期間外のため、新規の参加登録はできません。')
 
@@ -87,7 +91,11 @@ class ApplyView(LoginRequiredMixin, View):
             .prefetch_related('presentations')
             .first()
         )
-        permissions = _apply_permissions_for_user(request.user, collaboration)
+        permissions = self._apply_permissions_for_participation(
+            request.user,
+            collaboration,
+            participation,
+        )
         if participation is None and not permissions.can_edit_schedule:
             return HttpResponseForbidden('受付期間外のため、新規の参加登録はできません。')
         if not permissions.can_edit_schedule and not permissions.can_edit_lt:
@@ -102,9 +110,11 @@ class ApplyView(LoginRequiredMixin, View):
             permissions=permissions,
             initial=initial,
         )
-        formset = VketPresentationFormSet(request.POST, prefix='lt')
-        if not permissions.can_edit_lt:
-            self._disable_formset(formset)
+        formset = self._build_formset(
+            participation=participation,
+            permissions=permissions,
+            data=request.POST,
+        )
 
         if not (form.is_valid() and formset.is_valid()):
             schedule_ctx = _build_schedule_context(collaboration, include_requested=True)
@@ -169,11 +179,36 @@ class ApplyView(LoginRequiredMixin, View):
                 })
 
         formset = VketPresentationFormSet(
-            data, initial=lt_initial or None, prefix='lt',
+            data,
+            initial=lt_initial or None,
+            prefix='lt',
+            form_kwargs={
+                'lock_lt_start_time': self._is_schedule_locked(participation),
+            },
         )
         if not permissions.can_edit_lt:
             self._disable_formset(formset)
         return formset
+
+    @staticmethod
+    def _is_schedule_locked(participation: VketParticipation | None) -> bool:
+        """主催者向けの日程・LT開始時刻を固定する状態なら True を返す"""
+        return bool(participation and participation.is_schedule_confirmed)
+
+    def _apply_permissions_for_participation(
+        self,
+        user,
+        collaboration: VketCollaboration,
+        participation: VketParticipation | None,
+    ) -> VketApplyPermissions:
+        """コラボ権限に参加単位の確定後ロックを反映する"""
+        permissions = _apply_permissions_for_user(user, collaboration)
+        if self._is_schedule_locked(participation) and not user.is_superuser and not user.is_staff:
+            return VketApplyPermissions(
+                can_edit_schedule=False,
+                can_edit_lt=permissions.can_edit_lt,
+            )
+        return permissions
 
     @staticmethod
     def _disable_formset(formset):
@@ -242,29 +277,77 @@ class ApplyView(LoginRequiredMixin, View):
 
         # プレゼンテーション情報をVketPresentationに保存（formset）
         if permissions.can_edit_lt:
-            saved_orders = set()
-            order = 0
-            for row in formset_data:
-                if row.get('DELETE'):
-                    continue
-                speaker = (row.get('speaker') or '').strip()
-                theme = (row.get('theme') or '').strip()
-                if not speaker and not theme:
-                    continue
-                VketPresentation.objects.update_or_create(
-                    participation=participation,
-                    order=order,
-                    defaults={
-                        'speaker': speaker,
-                        'theme': theme,
-                        'requested_start_time': row.get('lt_start_time'),
-                    },
-                )
-                saved_orders.add(order)
-                order += 1
-            # formsetで保存されなかったorderの既存レコードを削除
-            VketPresentation.objects.filter(
-                participation=participation,
-            ).exclude(order__in=saved_orders).delete()
+            if self._is_schedule_locked(participation):
+                self._save_locked_presentations(participation, formset_data)
+            else:
+                self._save_editable_presentations(participation, formset_data)
 
         return participation
+
+    def _save_editable_presentations(
+        self,
+        participation: VketParticipation,
+        formset_data: list[dict],
+    ) -> None:
+        """確定前のLT情報を通常どおり保存する"""
+        saved_orders = set()
+        order = 0
+        for row in formset_data:
+            if row.get('DELETE'):
+                continue
+            speaker = (row.get('speaker') or '').strip()
+            theme = (row.get('theme') or '').strip()
+            if not speaker and not theme:
+                continue
+            VketPresentation.objects.update_or_create(
+                participation=participation,
+                order=order,
+                defaults={
+                    'speaker': speaker,
+                    'theme': theme,
+                    'requested_start_time': row.get('lt_start_time'),
+                },
+            )
+            saved_orders.add(order)
+            order += 1
+        # formsetで保存されなかったorderの既存レコードを削除
+        VketPresentation.objects.filter(
+            participation=participation,
+        ).exclude(order__in=saved_orders).delete()
+
+    def _save_locked_presentations(
+        self,
+        participation: VketParticipation,
+        formset_data: list[dict],
+    ) -> None:
+        """確定後は既存LTの削除と開始時刻変更を拒否して保存する"""
+        existing_by_order = {
+            pres.order: pres
+            for pres in participation.presentations.order_by('order', 'id')
+        }
+        next_order = max(existing_by_order.keys(), default=-1) + 1
+
+        for index, row in enumerate(formset_data):
+            if row.get('DELETE'):
+                continue
+
+            speaker = (row.get('speaker') or '').strip()
+            theme = (row.get('theme') or '').strip()
+            if not speaker and not theme:
+                continue
+
+            existing = existing_by_order.get(index)
+            if existing:
+                existing.speaker = speaker
+                existing.theme = theme
+                existing.save(update_fields=['speaker', 'theme', 'updated_at'])
+                continue
+
+            VketPresentation.objects.create(
+                participation=participation,
+                order=next_order,
+                speaker=speaker,
+                theme=theme,
+                requested_start_time=row.get('lt_start_time'),
+            )
+            next_order += 1

--- a/app/vket/views/presentation.py
+++ b/app/vket/views/presentation.py
@@ -42,6 +42,8 @@ class PresentationDeleteView(LoginRequiredMixin, View):
             return HttpResponseForbidden('この操作を行う権限がありません。')
         if not (request.user.is_superuser or membership):
             return HttpResponseForbidden('集会メンバーのみLTを削除できます。')
+        if presentation.is_organizer_delete_locked and not (request.user.is_superuser or request.user.is_staff):
+            return HttpResponseForbidden('確定済みまたは公開済みのLTは主催者側から削除できません。')
 
         speaker_name = _delete_presentation(presentation)
         messages.success(request, f'{speaker_name} を削除しました。')

--- a/docs/issue-288-vket-confirmed-lock.md
+++ b/docs/issue-288-vket-confirmed-lock.md
@@ -1,0 +1,27 @@
+# Issue #288: Vket確定後の主催者向け日程・LTロック
+
+## 背景
+
+PR #138 で Vket 期間中の `Event` / `EventDetail` 側の日時変更と削除は制限済みだが、主催者向けの Vket 参加フォームと LT 個別削除フローには確定後ロックが残っていなかった。
+
+## 観測結果
+
+- `app/vket/views/helpers.py` の `_apply_permissions_for_user()` はコラボのフェーズと締切だけで編集可否を判定していた。
+- `app/vket/views/apply.py` は `permissions.can_edit_schedule=True` の間、既存 `VketParticipation.requested_start_time` / `requested_duration` を POST 値で更新していた。
+- 同ビューの formset 保存は `order` ベースの `update_or_create()` と未送信 order の削除で構成されており、既存 `VketPresentation.requested_start_time` の変更や削除が可能だった。
+- `app/vket/views/presentation.py` の主催者向け `PresentationDeleteView` は、公開済み `published_event_detail` を持つ LT でも `EventDetail` ごと削除できる実装だった。
+
+## 改善方針
+
+- `VketParticipation.is_schedule_confirmed` を日程確定後ロックの単一判定にする。
+- 主催者向けフォームでは、確定済み participation の日程フィールドと LT 開始時刻を disabled にする。
+- 保存処理でも同じ判定を使い、HTML を迂回した POST でも日程と既存 LT 開始時刻を保持する。
+- 確定済みまたは公開済み LT は、主催者向け個別削除で 403 にする。
+- 管理者向け manage 画面の更新・削除フローは従来どおり維持する。
+
+## 検証手順
+
+```bash
+docker compose run --rm -e EMAIL_FILE_PATH=/tmp/emails -e TESTING=1 vrc-ta-hub python manage.py test vket.tests.test_vket vket.tests.test_staff_access vket.tests.test_schedule_lock
+docker compose run --rm vrc-ta-hub python manage.py check
+```


### PR DESCRIPTION
## なぜこの変更が必要か

- Issue #288「Vket確定後に主催者が時間帯変更・LT削除できないようにする」に対する fix-flow の自動修正として作成した差分です

## 変更内容

- `app/vket/forms.py`
- `app/vket/models.py`
- `app/vket/templates/vket/apply.html`
- `app/vket/templates/vket/participation_status.html`
- `app/vket/tests/test_vket.py`
- `app/vket/views/apply.py`
- `app/vket/views/presentation.py`
- `docs/issue-288-vket-confirmed-lock.md`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
