### PR TITLE
fix: ASGIでCloud Runホストを正規化

### DIFF
--- a/app/website/asgi.py
+++ b/app/website/asgi.py
@@ -11,6 +11,79 @@ import os
 
 from django.core.asgi import get_asgi_application
 
+from website.middleware import CanonicalCloudRunHostMiddleware
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'website.settings')
 
-application = get_asgi_application()
+
+class CloudRunHostCanonicalizingASGIApplication:
+    """Django request 生成前に Cloud Run preview host を正規化する。"""
+
+    def __init__(self, django_application):
+        self.django_application = django_application
+        self.host_middleware = CanonicalCloudRunHostMiddleware(lambda request: request)
+
+    async def __call__(self, scope, receive, send):
+        if scope.get('type') != 'http':
+            await self.django_application(scope, receive, send)
+            return
+
+        normalized_scope = self._canonicalize_http_scope(scope)
+        await self.django_application(normalized_scope, receive, send)
+
+    def _canonicalize_http_scope(self, scope):
+        header_pairs = list(scope.get('headers', ()))
+        host_mapping = self._build_host_mapping(scope, header_pairs)
+
+        if not self.host_middleware.canonicalize_host_mapping(host_mapping):
+            return scope
+
+        normalized_scope = dict(scope)
+        normalized_scope['headers'] = self._replace_host_headers(
+            header_pairs,
+            host_mapping,
+        )
+        server = normalized_scope.get('server')
+        if server:
+            normalized_scope['server'] = (host_mapping['SERVER_NAME'], server[1])
+
+        return normalized_scope
+
+    @staticmethod
+    def _build_host_mapping(scope, header_pairs):
+        host_mapping = {}
+        for raw_name, raw_value in header_pairs:
+            name = raw_name.lower()
+            if name == b'host':
+                host_mapping['HTTP_HOST'] = raw_value.decode('latin1')
+            elif name == b'x-forwarded-host':
+                host_mapping['HTTP_X_FORWARDED_HOST'] = raw_value.decode('latin1')
+
+        server = scope.get('server')
+        if server:
+            host_mapping['SERVER_NAME'] = server[0]
+
+        return host_mapping
+
+    @staticmethod
+    def _replace_host_headers(header_pairs, host_mapping):
+        encoded_http_host = host_mapping.get('HTTP_HOST', '').encode('latin1')
+        encoded_forwarded_host = host_mapping.get(
+            'HTTP_X_FORWARDED_HOST',
+            '',
+        ).encode('latin1')
+
+        normalized_headers = []
+        for raw_name, raw_value in header_pairs:
+            name = raw_name.lower()
+            if name == b'host' and encoded_http_host:
+                normalized_headers.append((raw_name, encoded_http_host))
+            elif name == b'x-forwarded-host' and encoded_forwarded_host:
+                normalized_headers.append((raw_name, encoded_forwarded_host))
+            else:
+                normalized_headers.append((raw_name, raw_value))
+
+        return normalized_headers
+
+
+application = CloudRunHostCanonicalizingASGIApplication(get_asgi_application())

--- a/app/website/tests/test_host_middleware.py
+++ b/app/website/tests/test_host_middleware.py
@@ -1,9 +1,11 @@
 """Cloud Run host 正規化 middleware の回帰テスト。"""
 
+from asgiref.sync import async_to_sync
 from django.core.exceptions import DisallowedHost
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 
+from website.asgi import CloudRunHostCanonicalizingASGIApplication
 from website.middleware import CanonicalCloudRunHostMiddleware
 from website.wsgi import CloudRunHostCanonicalizingWSGIApplication
 
@@ -130,4 +132,68 @@ class CloudRunHostCanonicalizingWSGIApplicationTest(SimpleTestCase):
         self.assertEqual(
             captured_environ['SERVER_NAME'],
             'rev-24d1224---other-service-mhbhtr6sha-an.a.run.app',
+        )
+
+
+class CloudRunHostCanonicalizingASGIApplicationTest(SimpleTestCase):
+    def test_cloud_run_revision_host_is_canonicalized_before_django_request(self):
+        captured_scope = {}
+
+        async def django_application(scope, _receive, _send):
+            captured_scope.update(scope)
+
+        scope = {
+            'type': 'http',
+            'headers': [
+                (b'host', b'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app'),
+                (
+                    b'x-forwarded-host',
+                    b'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+                ),
+            ],
+            'server': ('rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app', 443),
+        }
+
+        async_to_sync(CloudRunHostCanonicalizingASGIApplication(django_application))(
+            scope,
+            lambda: None,
+            lambda _message: None,
+        )
+
+        self.assertEqual(
+            captured_scope['headers'],
+            [
+                (b'host', b'vrc-ta-hub.com'),
+                (b'x-forwarded-host', b'vrc-ta-hub.com'),
+            ],
+        )
+        self.assertEqual(captured_scope['server'], ('vrc-ta-hub.com', 443))
+
+    def test_other_cloud_run_service_host_is_left_for_django_to_reject(self):
+        captured_scope = {}
+
+        async def django_application(scope, _receive, _send):
+            captured_scope.update(scope)
+
+        scope = {
+            'type': 'http',
+            'headers': [
+                (b'host', b'rev-24d1224---other-service-mhbhtr6sha-an.a.run.app'),
+            ],
+            'server': ('rev-24d1224---other-service-mhbhtr6sha-an.a.run.app', 443),
+        }
+
+        async_to_sync(CloudRunHostCanonicalizingASGIApplication(django_application))(
+            scope,
+            lambda: None,
+            lambda _message: None,
+        )
+
+        self.assertEqual(
+            captured_scope['headers'],
+            [(b'host', b'rev-24d1224---other-service-mhbhtr6sha-an.a.run.app')],
+        )
+        self.assertEqual(
+            captured_scope['server'],
+            ('rev-24d1224---other-service-mhbhtr6sha-an.a.run.app', 443),
         )


### PR DESCRIPTION
## なぜこの変更が必要か

- VRC技術学術Hub で観測された `django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app'. ...` に対する TASK-1678 の自動修正として作成した差分です

## 変更内容

- `app/website/asgi.py`
- `app/website/tests/test_host_middleware.py`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
