### PR TITLE
fix: Twitter投稿キューを1回1件投稿にする

### DIFF
--- a/app/twitter/models.py
+++ b/app/twitter/models.py
@@ -22,7 +22,7 @@ class TweetQueue(models.Model):
     """X 自動投稿キュー
 
     集会承認・LT/特別回承認時にシグナルでキューに追加され、
-    Cloud Scheduler (30分ごと) からのリクエストで投稿対象だけが処理される。
+    Cloud Scheduler (1分ごと) からのリクエストで投稿対象だけが処理される。
     """
 
     TWEET_TYPE_CHOICES = [

--- a/app/twitter/templates/twitter/tweet_queue_detail.html
+++ b/app/twitter/templates/twitter/tweet_queue_detail.html
@@ -11,7 +11,7 @@
     <h1 class="fw-bold mb-4">ポストキュー #{{ object.pk }}</h1>
 
     {# メインレイアウト: 左（情報+テキスト） / 右（画像） #}
-    <form method="post">
+    <form method="post" class="js-disable-on-submit">
         {% csrf_token %}
         <input type="hidden" name="action" value="update">
 
@@ -104,10 +104,11 @@
                         <i class="fas fa-save me-1"></i>保存
                     </button>
 
-                    {% if object.status == 'ready' %}
+                    {% if object.status != 'posted' %}
                     <button type="submit" name="action" value="post_now" class="btn btn-outline-success"
+                            data-submitting-label="投稿中..."
                             onclick="return confirm('このポストを今すぐ投稿しますか？')">
-                        <i class="fab fa-x-twitter me-1"></i>今すぐ投稿
+                        <i class="fab fa-x-twitter me-1"></i>今すぐポスト
                     </button>
                     {% endif %}
 
@@ -129,4 +130,16 @@
         </div>
     </form>
 </div>
+<script>
+document.querySelectorAll('.js-disable-on-submit').forEach((form) => {
+    form.addEventListener('submit', (event) => {
+        const button = event.submitter;
+        if (!button || button.dataset.submittingLabel === undefined) return;
+        setTimeout(() => {
+            button.disabled = true;
+            button.innerText = button.dataset.submittingLabel || '処理中...';
+        }, 0);
+    });
+});
+</script>
 {% endblock %}

--- a/app/twitter/templates/twitter/tweet_queue_list.html
+++ b/app/twitter/templates/twitter/tweet_queue_list.html
@@ -54,6 +54,9 @@
                             {% endif %}
                         </a>
                     </th>
+                    {% if request.user.is_superuser %}
+                    <th>操作</th>
+                    {% endif %}
                 </tr>
             </thead>
             <tbody>
@@ -67,10 +70,26 @@
                     <td>{{ item.created_at|date:"m/d H:i" }}</td>
                     <td>{{ item.scheduled_at|date:"m/d H:i" }}</td>
                     <td>{% if item.posted_at %}{{ item.posted_at|date:"m/d H:i" }}{% else %}-{% endif %}</td>
+                    {% if request.user.is_superuser %}
+                    <td onclick="event.stopPropagation();">
+                        {% if item.status != 'posted' %}
+                        <form method="post" action="{% url 'twitter:tweet_queue_detail' item.pk %}" class="d-inline js-disable-on-submit">
+                            {% csrf_token %}
+                            <button type="submit" name="action" value="post_now" class="btn btn-sm btn-outline-success"
+                                    data-submitting-label="投稿中..."
+                                    onclick="return confirm('このポストを今すぐ投稿しますか？')">
+                                <i class="fab fa-x-twitter me-1"></i>今すぐポスト
+                            </button>
+                        </form>
+                        {% else %}
+                        -
+                        {% endif %}
+                    </td>
+                    {% endif %}
                 </tr>
                 {% empty %}
                 <tr>
-                    <td colspan="8" class="text-center text-muted py-4">ポストキューがありません</td>
+                    <td colspan="{% if request.user.is_superuser %}9{% else %}8{% endif %}" class="text-center text-muted py-4">ポストキューがありません</td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -82,4 +101,16 @@
         {% include 'ta_hub/pagination.html' %}
     {% endif %}
 </div>
+<script>
+document.querySelectorAll('.js-disable-on-submit').forEach((form) => {
+    form.addEventListener('submit', () => {
+        const button = form.querySelector('button[type="submit"]');
+        if (!button) return;
+        setTimeout(() => {
+            button.disabled = true;
+            button.innerText = button.dataset.submittingLabel || '処理中...';
+        }, 0);
+    });
+});
+</script>
 {% endblock %}

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -753,6 +753,43 @@ class PostScheduledTweetsViewTest(AutoTweetTestBase):
         self.assertIsNotNone(queue.posted_at)
 
     @patch("twitter.views.post_tweet")
+    def test_post_scheduled_tweets_posts_only_one_ready_queue_per_request(self, mock_post):
+        """複数件 ready があっても1回の実行で投稿するのは1件だけ"""
+        mock_post.return_value = {"ok": True, "data": {"id": "first-post", "text": "1件目"}, "status_code": None, "error_body": None}
+
+        first = TweetQueue.objects.create(
+            tweet_type="new_community",
+            community=self.community,
+            event=self.event,
+            status="ready",
+            generated_text="1件目",
+            scheduled_at=self.due_scheduled_at() - datetime.timedelta(minutes=2),
+        )
+        second = TweetQueue.objects.create(
+            tweet_type="lt",
+            community=self.community,
+            event=self.event,
+            status="ready",
+            generated_text="2件目",
+            scheduled_at=self.due_scheduled_at() - datetime.timedelta(minutes=1),
+        )
+
+        with patch.dict("os.environ", self.REQUEST_TOKEN_ENV):
+            url = reverse("twitter:post_scheduled_tweets")
+            response = self.client.get(url, HTTP_REQUEST_TOKEN="test-token")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["processed"], 1)
+        self.assertTrue(data["posted_attempted"])
+        mock_post.assert_called_once_with("1件目", media_ids=None)
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertEqual(first.status, "posted")
+        self.assertEqual(second.status, "ready")
+
+    @patch("twitter.views.post_tweet")
     def test_post_scheduled_tweets_post_failure(self, mock_post):
         """X API 投稿失敗時の処理"""
         mock_post.return_value = {"ok": False, "data": None, "status_code": 403, "error_body": "You are not permitted to perform this action."}

--- a/app/twitter/tests/test_tweet_queue_views.py
+++ b/app/twitter/tests/test_tweet_queue_views.py
@@ -229,6 +229,17 @@ class TweetQueueListViewTest(TweetQueueViewTestBase):
         self.assertNotIn(tomorrow.pk, response.context['today_tweet_queue_ids'])
         self.assertContains(response, 'class="table-warning"', count=1)
 
+    def test_list_shows_post_now_button_only_for_unposted_queue(self):
+        """一覧では未投稿キューだけに今すぐポストボタンを表示する"""
+        self.client.login(username='admin_user', password='testpassword')
+        self._create_queue(generated_text='Ready tweet', status='ready')
+        self._create_queue(tweet_type='lt', generated_text='Posted tweet', status='posted')
+
+        response = self.client.get(reverse('twitter:tweet_queue_list'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '今すぐポスト', count=1)
+
 
 class TweetQueueDetailViewTest(TweetQueueViewTestBase):
     """TweetQueueDetailView のテスト"""
@@ -374,7 +385,7 @@ class TweetQueueDetailViewTest(TweetQueueViewTestBase):
     @patch('twitter.views.post_tweet')
     @patch('twitter.views.upload_media')
     def test_post_now_failure(self, mock_upload, mock_post):
-        """手動投稿が失敗した場合に failed になる"""
+        """手動投稿が失敗した場合は元ステータスを維持する"""
         mock_post.return_value = {'ok': False, 'data': None, 'status_code': 403, 'error_body': 'Forbidden'}
         mock_upload.return_value = None
 
@@ -384,8 +395,28 @@ class TweetQueueDetailViewTest(TweetQueueViewTestBase):
         self.assertEqual(response.status_code, 302)
 
         self.queue_item.refresh_from_db()
-        self.assertEqual(self.queue_item.status, 'failed')
+        self.assertEqual(self.queue_item.status, 'ready')
         self.assertIn('X API', self.queue_item.error_message)
+
+    @patch('twitter.views.post_tweet')
+    @patch('twitter.views.upload_media')
+    def test_post_now_allows_failed_queue(self, mock_upload, mock_post):
+        """投稿済み以外のキューは手動投稿できる"""
+        self.queue_item.status = 'failed'
+        self.queue_item.error_message = 'Previous failure'
+        self.queue_item.save()
+        mock_post.return_value = {'ok': True, 'data': {'id': 'failed-retry'}, 'status_code': None, 'error_body': None}
+        mock_upload.return_value = None
+
+        self.client.login(username='admin_user', password='testpassword')
+        url = reverse('twitter:tweet_queue_detail', kwargs={'pk': self.queue_item.pk})
+        response = self.client.post(url, {'action': 'post_now'})
+        self.assertEqual(response.status_code, 302)
+
+        self.queue_item.refresh_from_db()
+        self.assertEqual(self.queue_item.status, 'posted')
+        self.assertEqual(self.queue_item.tweet_id, 'failed-retry')
+        self.assertEqual(self.queue_item.error_message, '')
 
     @patch('twitter.views.post_tweet')
     @patch('twitter.views.upload_media')
@@ -423,6 +454,18 @@ class TweetQueueDetailViewTest(TweetQueueViewTestBase):
 
         self.queue_item.refresh_from_db()
         self.assertEqual(self.queue_item.status, 'posted')
+
+    def test_detail_hides_post_now_button_for_posted_queue(self):
+        """投稿済みキューには今すぐポストボタンを表示しない"""
+        self.queue_item.status = 'posted'
+        self.queue_item.save()
+
+        self.client.login(username='admin_user', password='testpassword')
+        url = reverse('twitter:tweet_queue_detail', kwargs={'pk': self.queue_item.pk})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, '今すぐポスト')
 
 
 class TweetQueueStaffAccessTest(TweetQueueViewTestBase):

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -232,12 +232,43 @@ def _retry_generation_async(queue_id: int) -> None:
         connections.close_all()
 
 
+def _post_tweet_queue_item(queue_item, *, failure_status: str | None = 'failed'):
+    """TweetQueue 1件を X API に投稿し、結果を保存用 dict として返す。"""
+    media_ids = None
+    if queue_item.image_url:
+        media_id = upload_media(queue_item.image_url)
+        if media_id:
+            media_ids = [media_id]
+
+    result = post_tweet(queue_item.generated_text, media_ids=media_ids)
+
+    if result["ok"]:
+        queue_item.status = 'posted'
+        queue_item.tweet_id = (result["data"] or {}).get('id', '')
+        queue_item.posted_at = timezone.now()
+        queue_item.error_message = ''
+        return {
+            "id": queue_item.pk, "status": "posted", "tweet_id": queue_item.tweet_id,
+        }
+
+    if failure_status is not None:
+        queue_item.status = failure_status
+    status_code = result.get("status_code")
+    queue_item.error_message = (
+        f'X API投稿に失敗 (status={status_code})' if status_code else 'X API投稿に失敗'
+    )
+    notify_tweet_post_failure(queue_item, result)
+    return {
+        "id": queue_item.pk, "status": "failed", "error": "post_failed",
+    }
+
+
 @require_http_methods(["GET"])
 def post_scheduled_tweets(request):
-    """Cloud Scheduler から 30 分ごとに呼ばれるエンドポイント。
+    """Cloud Scheduler から 1 分ごとに呼ばれるエンドポイント。
 
     Phase 1: 生成失敗/停滞キューのリトライ
-    Phase 2: ready キューの投稿
+    Phase 2: ready キューを最大 1 件投稿
     """
     request_token = request.headers.get("Request-Token", "")
     if request_token != os.environ.get("REQUEST_TOKEN", ""):
@@ -296,10 +327,11 @@ def post_scheduled_tweets(request):
                 scheduled_at__lte=now,
             ).select_related(
                 'community', 'event', 'event_detail',
-            ),
+            ).order_by('scheduled_at', 'pk'),
         ),
         context="post_scheduled_tweets_fetch_ready",
     )
+    posted_attempted = False
     for queue_item in ready_items:
         # LT/特別回告知は、イベント日が過去ならスキップ（期限切れ防止）
         if queue_item.tweet_type in ('lt', 'special') and queue_item.event:
@@ -345,45 +377,25 @@ def post_scheduled_tweets(request):
                 logger.info("Skipped stale daily reminder tweet for queue %d", queue_item.pk)
                 continue
 
-        # 画像アップロード
-        media_ids = None
-        if queue_item.image_url:
-            media_id = upload_media(queue_item.image_url)
-            if media_id:
-                media_ids = [media_id]
-
-        # ツイート投稿
-        result = post_tweet(queue_item.generated_text, media_ids=media_ids)
-
-        if result["ok"]:
-            queue_item.status = 'posted'
-            queue_item.tweet_id = (result["data"] or {}).get('id', '')
-            queue_item.posted_at = timezone.now()
-            results.append({
-                "id": queue_item.pk, "status": "posted", "tweet_id": queue_item.tweet_id,
-            })
+        result = _post_tweet_queue_item(queue_item, failure_status='failed')
+        results.append(result)
+        if result["status"] == "posted":
             logger.info("Tweet posted for queue %d: %s", queue_item.pk, queue_item.tweet_id)
         else:
-            queue_item.status = 'failed'
-            status_code = result.get("status_code")
-            queue_item.error_message = (
-                f'X API投稿に失敗 (status={status_code})' if status_code else 'X API投稿に失敗'
-            )
-            results.append({
-                "id": queue_item.pk, "status": "failed", "error": "post_failed",
-            })
             logger.warning("Tweet post failed for queue %d", queue_item.pk)
-            notify_tweet_post_failure(queue_item, result)
 
         run_with_db_reconnect(
             queue_item.save,
             context=f"post_scheduled_tweets_save_result queue={queue_item.pk}",
         )
+        posted_attempted = True
+        break
 
     return JsonResponse({
         "created": created_count,
         "retried": retried_count,
         "processed": len(results),
+        "posted_attempted": posted_attempted,
         "results": results,
     })
 
@@ -607,37 +619,23 @@ class TweetQueueDetailView(TweetQueueViewerMixin, DetailView):
         return redirect(reverse('twitter:tweet_queue_detail', kwargs={'pk': self.object.pk}))
 
     def _handle_post_now(self):
-        """ready キューを即座に投稿する。"""
-        if self.object.status != 'ready':
-            messages.error(self.request, '投稿待ちステータスのキューのみ投稿できます。')
+        """未投稿キューを即座に投稿する。"""
+        if self.object.status == 'posted':
+            messages.error(self.request, '投稿済みのキューは再投稿できません。')
+            return redirect(reverse('twitter:tweet_queue_detail', kwargs={'pk': self.object.pk}))
+        if not self.object.generated_text.strip():
+            messages.error(self.request, '生成テキストが空のため投稿できません。')
             return redirect(reverse('twitter:tweet_queue_detail', kwargs={'pk': self.object.pk}))
 
-        # 画像アップロード
-        media_ids = None
-        if self.object.image_url:
-            media_id = upload_media(self.object.image_url)
-            if media_id:
-                media_ids = [media_id]
+        result = _post_tweet_queue_item(self.object, failure_status=None)
 
-        # ツイート投稿
-        result = post_tweet(self.object.generated_text, media_ids=media_ids)
-
-        if result["ok"]:
-            self.object.status = 'posted'
-            self.object.tweet_id = (result["data"] or {}).get('id', '')
-            self.object.posted_at = timezone.now()
+        if result["status"] == "posted":
             self.object.save()
             messages.success(self.request, 'ポストを投稿しました。')
             logger.info("Manual tweet posted for queue %d: %s", self.object.pk, self.object.tweet_id)
         else:
-            self.object.status = 'failed'
-            status_code = result.get("status_code")
-            self.object.error_message = (
-                f'X API投稿に失敗 (status={status_code})' if status_code else 'X API投稿に失敗'
-            )
-            self.object.save()
-            messages.error(self.request, '投稿に失敗しました。')
+            self.object.save(update_fields=['error_message'])
+            messages.error(self.request, self.object.error_message)
             logger.warning("Manual tweet post failed for queue %d", self.object.pk)
-            notify_tweet_post_failure(self.object, result)
 
         return redirect(reverse('twitter:tweet_queue_detail', kwargs={'pk': self.object.pk}))

--- a/docs/notes/how/twitter-queue.md
+++ b/docs/notes/how/twitter-queue.md
@@ -9,7 +9,7 @@
 | 正本 | `tweet_queue` を正本として扱う |
 | キュー作成責務 | 保存時の signal が作る |
 | スケジューラの責務 | 既存キューの再生成・投稿だけを行う |
-| スケジューラ実行間隔 | 30分ごと |
+| スケジューラ実行間隔 | 1分ごと |
 | `daily_reminder` の補完作成 | スケジューラではしない |
 | 当日重複防止 | 当日の `lt` / `special` は `skipped` にして `daily_reminder` に統合する |
 
@@ -56,7 +56,7 @@
 | --- | --- | --- |
 | Phase 0 | `scheduled_at + 24h` を過ぎた未投稿キュー | `skipped` にする |
 | Phase 1 | `generation_failed` / 1時間以上停滞した `generating` | 予約時刻に関係なく同期で再生成する |
-| Phase 2 | `ready` かつ `scheduled_at <= now` | X API に投稿する |
+| Phase 2 | `ready` かつ `scheduled_at <= now` | X API に最大1件だけ投稿する |
 | 例外 | 当日の `lt` / `special` | 投稿せず `skipped` にする |
 | 例外 | 過去日の `lt` / `special` | 投稿せず `failed` にする |
 | 例外 | 当日以外の `daily_reminder` | 投稿せず `failed` にする |


### PR DESCRIPTION
## 概要

Closes #281
Closes #282

X 投稿キューの自動投稿と手動投稿を同じ単発投稿パスに寄せ、Cloud Scheduler 1分間隔運用でも1リクエストあたり最大1件だけ X API 投稿するようにしました。

## 変更内容

- `post_scheduled_tweets` の ready 投稿処理を `scheduled_at, pk` の古い順で最大1件に制限
- 投稿キュー一覧・詳細に「今すぐポスト」ボタンを追加
- 投稿済み以外のキューを手動投稿可能にし、失敗時は元ステータスを維持
- 成功時は古いエラー文をクリアし、失敗時は画面へ X API エラーを表示
- Scheduler 実行間隔の仕様メモと docstring を 1分ごとへ更新

## 検証

- [x] `docker compose exec -T vrc-ta-hub python manage.py test twitter.tests.test_tweet_queue_views`
- [x] `docker compose exec -T vrc-ta-hub python manage.py test twitter.tests.test_auto_tweet.PostScheduledTweetsViewTest`
- [x] `docker compose exec -T vrc-ta-hub python manage.py test twitter.tests.test_tweet_queue_views twitter.tests.test_auto_tweet.PostScheduledTweetsViewTest`
- [x] `docker compose exec -T vrc-ta-hub python manage.py test vket.tests`
- [x] `docker compose exec -T vrc-ta-hub python manage.py check`
- [x] `uvx --from ruff==0.11.6 ruff check app/`
- [x] `git diff --check`
- [x] `curl -I http://localhost:8015/twitter/queue/` -> 302 login redirect
- [x] `curl -i http://localhost:8015/twitter/post-scheduled/` -> 401 Unauthorized

## 補足

Cloud Scheduler の live schedule は、PR merge と本番反映後に `post-scheduled-tweets` を `* * * * *` へ更新します。
