### PR TITLE
docs: Vket参加状態の管理導線を追加

### DIFF
--- a/app/vket/forms.py
+++ b/app/vket/forms.py
@@ -214,3 +214,12 @@ class VketManageParticipationForm(forms.Form):
         if d < self.collaboration.period_start or d > self.collaboration.period_end:
             raise forms.ValidationError('確定日程はコラボ開催期間内の日付を選択してください。')
         return d
+
+
+class VketManageLifecycleForm(forms.Form):
+    """運営向けの参加状態更新フォーム"""
+
+    lifecycle = forms.ChoiceField(
+        label='参加状態',
+        choices=VketParticipation.Lifecycle.choices,
+    )

--- a/app/vket/templates/vket/manage.html
+++ b/app/vket/templates/vket/manage.html
@@ -28,6 +28,7 @@
                 <thead>
                 <tr class="table-light">
                     <th style="min-width: 160px;">集会名</th>
+                    <th style="min-width: 95px;">参加状態</th>
                     <th style="min-width: 90px;">進捗</th>
                     <th style="min-width: 120px;">希望日程</th>
                     <th style="min-width: 120px;">確定日程</th>
@@ -38,12 +39,18 @@
                 </thead>
                 <tbody>
                 {% for p in participations %}
-                    <tr>
+                    <tr{% if p.lifecycle == 'declined' %} class="table-danger"{% elif p.lifecycle == 'withdrawn' %} class="table-secondary"{% endif %}>
                         <td class="fw-bold">
                             {{ p.community.name }}
-                            {% if p.lifecycle != 'active' %}
-                                <span class="badge bg-danger ms-1">{{ p.get_lifecycle_display }}</span>
-                            {% endif %}
+                        </td>
+                        <td>
+                            <span class="badge
+                                {% if p.lifecycle == 'active' %}bg-success
+                                {% elif p.lifecycle == 'declined' %}bg-danger
+                                {% elif p.lifecycle == 'withdrawn' %}bg-secondary
+                                {% else %}bg-light text-dark border{% endif %}">
+                                {{ p.get_lifecycle_display }}
+                            </span>
                         </td>
                         <td>
                             <span class="badge
@@ -161,6 +168,25 @@
                                 <button class="btn btn-outline-primary btn-sm" type="submit">
                                     <i class="fas fa-check me-1"></i>確定
                                 </button>
+                            </form>
+                            <form method="post"
+                                  action="{% url 'vket:manage_participation_update' collaboration.id p.id %}"
+                                  class="d-flex flex-column gap-1 border-top mt-2 pt-2"
+                                  onsubmit="return confirm('{{ p.community.name|escapejs }} の参加状態を変更します。よろしいですか？')">
+                                {% csrf_token %}
+                                <input type="hidden" name="action" value="update_lifecycle">
+                                <div class="d-flex gap-1">
+                                    <select class="form-select form-select-sm" name="lifecycle" aria-label="参加状態">
+                                        {% for val, label in lifecycle_choices.items %}
+                                            <option value="{{ val }}" {% if p.lifecycle == val %}selected{% endif %}>
+                                                {{ label }}
+                                            </option>
+                                        {% endfor %}
+                                    </select>
+                                    <button class="btn btn-outline-secondary btn-sm text-nowrap" type="submit">
+                                        <i class="fas fa-sync-alt me-1"></i>変更
+                                    </button>
+                                </div>
                             </form>
                             {% for pres in p.all_presentations %}
                                 <form id="delete-pres-{{ pres.pk }}" method="post"

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -872,6 +872,23 @@ class VketManageViewsTests(TestCase):
         self.assertContains(response, self.collaboration.name)
         self.assertContains(response, self.community1.name)
 
+    def test_manage_page_shows_lifecycle_column_and_update_form(self):
+        """管理画面で参加状態の表示と更新フォームが表示される"""
+        self.participation1.lifecycle = VketParticipation.Lifecycle.DECLINED
+        self.participation1.save(update_fields=['lifecycle', 'updated_at'])
+        self.participation2.lifecycle = VketParticipation.Lifecycle.WITHDRAWN
+        self.participation2.save(update_fields=['lifecycle', 'updated_at'])
+
+        self.client.login(username='admin_user', password='adminpass123')
+        response = self.client.get(reverse('vket:manage', kwargs={'pk': self.collaboration.pk}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '参加状態')
+        self.assertContains(response, '不参加')
+        self.assertContains(response, '辞退')
+        self.assertContains(response, 'name="lifecycle"')
+        self.assertContains(response, 'update_lifecycle')
+
     def test_manage_schedule_page_shows_overlap_warning(self):
         """日程重複がある場合にoverlap_warningsがセットされる"""
         self.client.login(username='admin_user', password='adminpass123')
@@ -966,6 +983,65 @@ class VketManageViewsTests(TestCase):
         self.assertTrue(new_participation.schedule_adjusted_by_admin)
         self.assertEqual(new_participation.progress, VketParticipation.Progress.REHEARSAL)
         self.assertIsNotNone(new_participation.schedule_confirmed_at)
+
+    def test_manage_participation_update_changes_lifecycle(self):
+        """ManageParticipationUpdateViewが参加状態を切り替えられる"""
+        self.client.login(username='admin_user', password='adminpass123')
+        url = reverse(
+            'vket:manage_participation_update',
+            kwargs={
+                'pk': self.collaboration.pk,
+                'participation_id': self.participation1.pk,
+            },
+        )
+
+        response = self.client.post(
+            url,
+            data={
+                'action': 'update_lifecycle',
+                'lifecycle': VketParticipation.Lifecycle.DECLINED,
+            },
+            follow=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        self.participation1.refresh_from_db()
+        self.assertEqual(self.participation1.lifecycle, VketParticipation.Lifecycle.DECLINED)
+
+        response = self.client.post(
+            url,
+            data={
+                'action': 'update_lifecycle',
+                'lifecycle': VketParticipation.Lifecycle.ACTIVE,
+            },
+            follow=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        self.participation1.refresh_from_db()
+        self.assertEqual(self.participation1.lifecycle, VketParticipation.Lifecycle.ACTIVE)
+
+    def test_manage_participation_update_lifecycle_requires_staff(self):
+        """一般ユーザーは参加状態を変更できない"""
+        self.client.login(username='normal_user', password='testpass123')
+        response = self.client.post(
+            reverse(
+                'vket:manage_participation_update',
+                kwargs={
+                    'pk': self.collaboration.pk,
+                    'participation_id': self.participation1.pk,
+                },
+            ),
+            data={
+                'action': 'update_lifecycle',
+                'lifecycle': VketParticipation.Lifecycle.DECLINED,
+            },
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.participation1.refresh_from_db()
+        self.assertEqual(self.participation1.lifecycle, VketParticipation.Lifecycle.ACTIVE)
 
     def test_manage_participation_update_updates_event_detail_start_time(self):
         """日程確定時にEventDetailのLT開始時刻が更新される"""
@@ -1281,6 +1357,28 @@ class VketStaffAccessTests(TestCase):
         self.client.login(username='staff_user', password='staffpass123')
         response = self.client.get(reverse('vket:manage', kwargs={'pk': self.collaboration.pk}))
         self.assertEqual(response.status_code, 200)
+
+    def test_staff_can_update_lifecycle(self):
+        """staffユーザーが参加状態を変更できる"""
+        self.client.login(username='staff_user', password='staffpass123')
+        response = self.client.post(
+            reverse(
+                'vket:manage_participation_update',
+                kwargs={
+                    'pk': self.collaboration.pk,
+                    'participation_id': self.participation.pk,
+                },
+            ),
+            data={
+                'action': 'update_lifecycle',
+                'lifecycle': VketParticipation.Lifecycle.WITHDRAWN,
+            },
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.participation.refresh_from_db()
+        self.assertEqual(self.participation.lifecycle, VketParticipation.Lifecycle.WITHDRAWN)
 
     def test_staff_can_see_draft_collaboration(self):
         """staffユーザーにDRAFTコラボが表示される"""
@@ -2064,6 +2162,56 @@ class VketPublishViewTests(TestCase):
         self.assertEqual(event.community, self.community)
         self.assertEqual(event.start_time.strftime('%H:%M'), '21:00')
         self.assertEqual(event.duration, 60)
+
+    def test_publish_skips_declined_and_withdrawn_participations(self):
+        """公開処理は不参加・辞退の参加申請を公開対象にしない"""
+        declined_community = Community.objects.create(
+            name='不参加集会',
+            status='approved',
+            frequency='毎週',
+        )
+        withdrawn_community = Community.objects.create(
+            name='辞退集会',
+            status='approved',
+            frequency='毎週',
+        )
+        declined = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=declined_community,
+            lifecycle=VketParticipation.Lifecycle.DECLINED,
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time='22:00',
+            confirmed_duration=60,
+        )
+        withdrawn = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=withdrawn_community,
+            lifecycle=VketParticipation.Lifecycle.WITHDRAWN,
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time='23:00',
+            confirmed_duration=60,
+        )
+
+        self.client.login(username='admin_pub', password='adminpass123')
+        response = self.client.post(
+            reverse('vket:manage_publish', kwargs={'pk': self.collaboration.pk}),
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.participation.refresh_from_db()
+        declined.refresh_from_db()
+        withdrawn.refresh_from_db()
+        self.assertIsNotNone(self.participation.published_event_id)
+        self.assertIsNone(declined.published_event_id)
+        self.assertIsNone(withdrawn.published_event_id)
+        self.assertEqual(declined.progress, VketParticipation.Progress.NOT_APPLIED)
+        self.assertEqual(withdrawn.progress, VketParticipation.Progress.NOT_APPLIED)
+        self.assertFalse(
+            Event.objects.filter(
+                community_id__in=[declined_community.id, withdrawn_community.id]
+            ).exists()
+        )
 
     def test_publish_is_forbidden_when_not_locked(self):
         """LOCKEDフェーズ以外では公開処理が403になる"""

--- a/app/vket/views/manage.py
+++ b/app/vket/views/manage.py
@@ -18,7 +18,7 @@ from community.models import Community
 from event.models import EventDetail
 from ta_hub.index_cache import clear_index_view_cache
 
-from ..forms import VketManageParticipationForm
+from ..forms import VketManageLifecycleForm, VketManageParticipationForm
 from ..models import (
     VketCollaboration,
     VketParticipation,
@@ -153,6 +153,9 @@ class ManageParticipationUpdateView(LoginRequiredMixin, UserPassesTestMixin, Vie
             collaboration=collaboration,
         )
 
+        if request.POST.get('action') == 'update_lifecycle':
+            return self._update_lifecycle(request, collaboration, participation)
+
         form = VketManageParticipationForm(
             request.POST,
             participation=participation,
@@ -244,6 +247,35 @@ class ManageParticipationUpdateView(LoginRequiredMixin, UserPassesTestMixin, Vie
         messages.success(
             request,
             f'{participation.community.name} の日程を確定しました。',
+        )
+        return redirect('vket:manage', pk=collaboration.pk)
+
+    def _update_lifecycle(self, request, collaboration, participation):
+        form = VketManageLifecycleForm(request.POST)
+        if not form.is_valid():
+            error_messages = []
+            for errs in form.errors.values():
+                error_messages.extend([str(e) for e in errs])
+            messages.error(request, '参加状態の更新に失敗しました: ' + ' / '.join(error_messages))
+            return redirect('vket:manage', pk=collaboration.pk)
+
+        previous_lifecycle = participation.lifecycle
+        participation.lifecycle = form.cleaned_data['lifecycle']
+        participation.save(update_fields=['lifecycle', 'updated_at'])
+
+        logger.info(
+            'Vket参加状態更新',
+            extra={
+                'collaboration_id': collaboration.id,
+                'participation_id': participation.id,
+                'community_name': participation.community.name,
+                'previous_lifecycle': previous_lifecycle,
+                'new_lifecycle': participation.lifecycle,
+            },
+        )
+        messages.success(
+            request,
+            f'{participation.community.name} の参加状態を「{participation.get_lifecycle_display()}」に更新しました。',
         )
         return redirect('vket:manage', pk=collaboration.pk)
 

--- a/docs/issue-293-vket-participation-lifecycle.md
+++ b/docs/issue-293-vket-participation-lifecycle.md
@@ -1,0 +1,33 @@
+# Issue #293: Vket参加申請の参加状態更新導線
+
+## 要件
+
+- 運営スタッフがVket管理画面から参加申請を `active / declined / withdrawn` に変更できる。
+- `declined` と `withdrawn` は一覧で明確に判別できる。
+- 非 `active` の参加申請は公開同期対象外にする。
+- 操作権限は `is_superuser or is_staff` に限定する。
+
+## 調査結果
+
+- `VketParticipation.lifecycle` は `active / declined / withdrawn` の選択肢を既に持っていた。
+- `ManageParticipationUpdateView` は日程確定、運営備考、進捗更新のみを扱い、`lifecycle` を更新していなかった。
+- `vket/manage.html` は非 `active` の表示バッジだけを持ち、運営が状態を変更するフォームはなかった。
+- `ManagePublishView` は `lifecycle=ACTIVE` の参加だけを公開対象にしており、状態変更導線を追加すれば公開除外の設計は成立する。
+
+## 対応方針
+
+- 既存の管理更新URLを再利用し、`action=update_lifecycle` のPOSTだけ参加状態更新として処理する。
+- 日程確定フォームとは分離し、状態変更時に確定日程・進捗・公開済みイベントを副作用で変更しない。
+- 管理画面に参加状態列と状態変更フォームを追加し、送信時はブラウザ確認を挟む。
+- 公開同期の active フィルタは既存実装を維持し、回帰テストで固定する。
+
+## 検証手順
+
+- 管理画面の表示で `不参加` / `辞退` が判別できることをDjangoビューのレスポンスで確認する。
+- superuser と staff が `lifecycle` を変更でき、一般ユーザーが403になることを確認する。
+- `declined` / `withdrawn` の参加申請が `ManagePublishView` で `Event` 作成・`published_event` 紐付け・`DONE` 更新されないことを確認する。
+
+## 注意点
+
+- 既に公開済みの参加申請を後から非 `active` にした場合、今回の変更は既存 `Event` を削除しない。Issueの受け入れ条件は公開同期対象外であり、公開済みイベントの取り下げは別途運用または追加Issueで扱う。
+- CI/CD、デプロイ、認証、設定の保護対象ファイルは変更していない。


### PR DESCRIPTION
## なぜこの変更が必要か

- Issue #293「feat: Vket参加申請を管理画面から拒否・辞退扱いにできるようにする」に対する fix-flow の自動修正として作成した差分です

## 変更内容

- `app/vket/forms.py`
- `app/vket/templates/vket/manage.html`
- `app/vket/tests/test_vket.py`
- `app/vket/views/manage.py`
- `docs/issue-293-vket-participation-lifecycle.md`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
