### PR TITLE
docs: db-pullのCompose復元検証を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,14 +56,20 @@ LOCAL_DB_USER     := root
 LOCAL_DB_PASSWORD := root
 LOCAL_DB_NAME     := local_vrc_ta_hub
 
+COMPOSE_APP_SERVICE      ?= vrc-ta-hub
+COMPOSE_DB_SERVICE       ?= db
+DB_PULL_VERIFY_TABLE     ?= vket_collaboration
+DB_PULL_VERIFY_MIN_ROWS  ?= 1
+
 DUMP_OPTS  := --single-transaction --routines --triggers --no-tablespaces --skip-ssl
 MYSQL_OPTS := --skip-ssl
+PROD_ENV_FILE ?= .env.production.local
 
 # .env.production.local から DB_ 変数を安全に読み込む
-PROD_DB_NAME := $(shell grep '^DB_NAME=' .env.production.local | cut -d= -f2-)
-PROD_DB_USER := $(shell grep '^DB_USER=' .env.production.local | cut -d= -f2-)
-PROD_DB_PASSWORD := $(shell grep '^DB_PASSWORD=' .env.production.local | cut -d= -f2-)
-PROD_DB_HOST := $(shell grep '^DB_HOST=' .env.production.local | cut -d= -f2-)
+PROD_DB_NAME := $(shell [ ! -f "$(PROD_ENV_FILE)" ] || grep '^DB_NAME=' "$(PROD_ENV_FILE)" | cut -d= -f2-)
+PROD_DB_USER := $(shell [ ! -f "$(PROD_ENV_FILE)" ] || grep '^DB_USER=' "$(PROD_ENV_FILE)" | cut -d= -f2-)
+PROD_DB_PASSWORD := $(shell [ ! -f "$(PROD_ENV_FILE)" ] || grep '^DB_PASSWORD=' "$(PROD_ENV_FILE)" | cut -d= -f2-)
+PROD_DB_HOST := $(shell [ ! -f "$(PROD_ENV_FILE)" ] || grep '^DB_HOST=' "$(PROD_ENV_FILE)" | cut -d= -f2-)
 
 db-backup: ## 本番DBバックアップ → dumps/
 	@mkdir -p $(DUMPS_DIR)
@@ -80,16 +86,19 @@ db-backup-local: ## ローカルDBバックアップ → dumps/
 	@echo "Done: $(DUMPS_DIR)/local_$(DATE).sql.gz"
 
 db-pull: ## 本番DB → ローカルDB
+	@test -n "$(PROD_DB_NAME)" -a -n "$(PROD_DB_USER)" -a -n "$(PROD_DB_PASSWORD)" -a -n "$(PROD_DB_HOST)" || \
+		(echo "ERROR: $(PROD_ENV_FILE) must define DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST." >&2; exit 1)
 	@mkdir -p $(DUMPS_DIR)
 	@echo "Dumping production DB ($(PROD_DB_HOST)/$(PROD_DB_NAME))..."
 	@MYSQL_PWD="$(PROD_DB_PASSWORD)" mysqldump -h "$(PROD_DB_HOST)" -u "$(PROD_DB_USER)" $(DUMP_OPTS) "$(PROD_DB_NAME)" \
 		| gzip > $(DUMPS_DIR)/production.sql.gz
-	@echo "Restoring to local DB ($(LOCAL_DB_NAME))..."
-	@MYSQL_PWD=$(LOCAL_DB_PASSWORD) mysql -h $(LOCAL_DB_HOST) -P $(LOCAL_DB_PORT) -u $(LOCAL_DB_USER) $(MYSQL_OPTS) \
-		-e "DROP DATABASE IF EXISTS \`$(LOCAL_DB_NAME)\`; CREATE DATABASE \`$(LOCAL_DB_NAME)\`;"
-	@gunzip -c $(DUMPS_DIR)/production.sql.gz \
-		| MYSQL_PWD=$(LOCAL_DB_PASSWORD) mysql -h $(LOCAL_DB_HOST) -P $(LOCAL_DB_PORT) -u $(LOCAL_DB_USER) $(MYSQL_OPTS) "$(LOCAL_DB_NAME)"
-	@echo "Done: production → $(LOCAL_DB_NAME)"
+	@echo "Restoring to Docker Compose DB service ($(COMPOSE_DB_SERVICE))..."
+	@APP_SERVICE="$(COMPOSE_APP_SERVICE)" \
+		DB_SERVICE="$(COMPOSE_DB_SERVICE)" \
+		DB_PULL_VERIFY_TABLE="$(DB_PULL_VERIFY_TABLE)" \
+		DB_PULL_VERIFY_MIN_ROWS="$(DB_PULL_VERIFY_MIN_ROWS)" \
+		scripts/db_pull_restore.sh "$(DUMPS_DIR)/production.sql.gz"
+	@echo "Done: production → Docker Compose DB"
 
 db-push: ## ローカルDB → 本番DB（確認プロンプト + 自動backup）
 	@echo "WARNING: This will OVERWRITE the production database with local data."

--- a/docs/issue-292-db-pull-compose-restore.md
+++ b/docs/issue-292-db-pull-compose-restore.md
@@ -1,0 +1,50 @@
+# Issue 292: db-pull の Docker Compose DB 復元検証
+
+## 調査対象
+
+- `Makefile` の `db-pull`
+- `docker-compose.yaml` の `vrc-ta-hub` / `db` サービス設定
+- `.env.local` のアプリコンテナ向け `DB_*` 設定
+- `vket_collaboration` テーブルを使った復元後の代表件数確認
+
+## 観測結果
+
+- 既存の `db-pull` は `LOCAL_DB_HOST=127.0.0.1` と `LOCAL_DB_PORT=3306` を使って、ホスト側の MySQL に直接復元していた。
+- Docker Compose のアプリコンテナは `DB_HOST=db` と `DB_NAME=local_vrc_ta_hub` を参照しており、ホスト側 `127.0.0.1:3306` とは別の復元先になり得る。
+- `docker-compose.yaml` の `db` サービスは Compose ネットワーク上の `db:3306` として公開されるため、ホスト側の `DB_PORT` を変更してもアプリコンテナからの接続先は変わらない。
+
+## 原因候補
+
+`db-pull` が Docker Compose のサービス境界を経由せず、Makefile 内の固定ホスト・固定ポートに復元していたことが主因。ホスト側で別の MySQL が起動している、または `DB_PORT` が変更されている場合でも、Makefile のコマンドが成功してしまうとアプリが参照するDBにはデータが入らない。
+
+## 改善内容
+
+- `db-pull` の復元処理を `scripts/db_pull_restore.sh` に分離した。
+- 復元先DB名はアプリコンテナの `DB_NAME` から取得し、`DB_HOST` が復元対象の Compose DB サービス名と一致しない場合は失敗させる。
+- MySQL への復元は `docker compose exec -T db` 経由で行い、認証情報もアプリコンテナの `DB_USER` / `DB_PASSWORD` に揃えた。
+- ホスト側 `DB_PORT` や別 MySQL の状態に依存しないため、Makefile の固定値と Compose 実態のずれで silent success しない。
+- 復元後にアプリコンテナの `python manage.py shell -c` から `vket_collaboration` の件数を取得し、既定で1件以上ない場合は失敗させる。
+
+## 検証手順
+
+静的検証:
+
+```bash
+bash -n scripts/db_pull_restore.sh
+bash -n scripts/tests/test_db_pull_restore.sh
+bash scripts/tests/test_db_pull_restore.sh
+make -n db-pull
+```
+
+実環境検証:
+
+```bash
+docker compose up -d db vrc-ta-hub
+make db-pull
+```
+
+期待結果:
+
+- `make db-pull` の復元ログに Docker Compose の `db` サービスとアプリコンテナの `DB_NAME` が表示される。
+- 復元後に `Verified via app container: local_vrc_ta_hub.vket_collaboration has N rows.` が表示される。
+- `DB_HOST` が `db` 以外に変わっている、または代表テーブルが空の場合、`Done` 表示前に失敗する。

--- a/scripts/db_pull_restore.sh
+++ b/scripts/db_pull_restore.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_SERVICE="${APP_SERVICE:-vrc-ta-hub}"
+DB_SERVICE="${DB_SERVICE:-db}"
+DB_PULL_VERIFY_TABLE="${DB_PULL_VERIFY_TABLE:-vket_collaboration}"
+DB_PULL_VERIFY_MIN_ROWS="${DB_PULL_VERIFY_MIN_ROWS:-1}"
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+compose() {
+  docker compose "$@"
+}
+
+validate_identifier() {
+  local label="$1"
+  local value="$2"
+
+  [[ "$value" =~ ^[A-Za-z0-9_]+$ ]] || die "$label must contain only letters, numbers, and underscores: $value"
+}
+
+get_service_env() {
+  local service="$1"
+  local name="$2"
+
+  compose exec -T "$service" env \
+    | awk -F= -v key="$name" '
+      $1 == key {
+        sub(/^[^=]*=/, "")
+        print
+        found = 1
+        exit
+      }
+      END {
+        if (!found) {
+          exit 1
+        }
+      }
+    '
+}
+
+parse_last_numeric_line() {
+  awk '
+    /^[[:space:]]*[0-9]+[[:space:]]*$/ {
+      value = $1
+    }
+    END {
+      if (value == "") {
+        exit 1
+      }
+      print value
+    }
+  '
+}
+
+restore_dump_to_compose_db() {
+  local dump_path="$1"
+  local db_name="$2"
+  local db_user="$3"
+  local db_password="$4"
+
+  compose exec -T -e "MYSQL_PWD=$db_password" "$DB_SERVICE" \
+    mysql -u "$db_user" --skip-ssl \
+    -e "DROP DATABASE IF EXISTS \`$db_name\`; CREATE DATABASE \`$db_name\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+
+  gunzip -c "$dump_path" \
+    | compose exec -T -e "MYSQL_PWD=$db_password" "$DB_SERVICE" \
+      mysql -u "$db_user" --skip-ssl "$db_name"
+}
+
+verify_app_table_count() {
+  local db_name="$1"
+  local table_name="$2"
+  local min_rows="$3"
+  local min_rows_int
+  local verify_output
+  local count
+
+  min_rows_int=$((10#$min_rows))
+
+  verify_output="$(
+    compose exec -T "$APP_SERVICE" python manage.py shell -c \
+      "from django.db import connection
+cursor = connection.cursor()
+cursor.execute('SELECT COUNT(*) FROM \`$table_name\`')
+print(cursor.fetchone()[0])"
+  )"
+
+  count="$(printf '%s\n' "$verify_output" | parse_last_numeric_line)" \
+    || die "Could not parse verification count for $table_name from app container output."
+
+  printf 'Verified via app container: %s.%s has %s rows.\n' "$db_name" "$table_name" "$count"
+
+  if (( count < min_rows_int )); then
+    die "Verification failed: $table_name has $count rows, expected at least $min_rows_int."
+  fi
+}
+
+main() {
+  local dump_path="${1:-dumps/production.sql.gz}"
+  local app_db_name
+  local app_db_host
+  local app_db_user
+  local app_db_password
+
+  [[ -f "$dump_path" ]] || die "Dump file does not exist: $dump_path"
+  [[ "$DB_PULL_VERIFY_MIN_ROWS" =~ ^[0-9]+$ ]] || die "DB_PULL_VERIFY_MIN_ROWS must be a non-negative integer."
+
+  app_db_name="$(get_service_env "$APP_SERVICE" DB_NAME)" \
+    || die "Could not read DB_NAME from app service: $APP_SERVICE"
+  app_db_host="$(get_service_env "$APP_SERVICE" DB_HOST)" \
+    || die "Could not read DB_HOST from app service: $APP_SERVICE"
+  app_db_user="$(get_service_env "$APP_SERVICE" DB_USER)" \
+    || die "Could not read DB_USER from app service: $APP_SERVICE"
+  app_db_password="$(get_service_env "$APP_SERVICE" DB_PASSWORD)" \
+    || die "Could not read DB_PASSWORD from app service: $APP_SERVICE"
+
+  [[ -n "$app_db_name" ]] || die "DB_NAME is empty in app service: $APP_SERVICE"
+  [[ -n "$app_db_host" ]] || die "DB_HOST is empty in app service: $APP_SERVICE"
+  [[ -n "$app_db_user" ]] || die "DB_USER is empty in app service: $APP_SERVICE"
+  [[ -n "$app_db_password" ]] || die "DB_PASSWORD is empty in app service: $APP_SERVICE"
+  [[ "$app_db_host" == "$DB_SERVICE" ]] \
+    || die "App DB_HOST is '$app_db_host', but db-pull restores to Docker Compose service '$DB_SERVICE'."
+
+  validate_identifier DB_NAME "$app_db_name"
+  validate_identifier DB_PULL_VERIFY_TABLE "$DB_PULL_VERIFY_TABLE"
+
+  printf 'Restoring %s to Compose service %s database %s as %s.\n' "$dump_path" "$DB_SERVICE" "$app_db_name" "$app_db_user"
+  restore_dump_to_compose_db "$dump_path" "$app_db_name" "$app_db_user" "$app_db_password"
+  verify_app_table_count "$app_db_name" "$DB_PULL_VERIFY_TABLE" "$DB_PULL_VERIFY_MIN_ROWS"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -1,3 +1,8 @@
 # スクリプト一覧
 
 Django関係のスクリプトはカスタムコマンドとして、各アプリケーション内のカスタムコマンドとして実装、実行します。
+
+## DB同期
+
+- `scripts/db_pull_restore.sh`: `make db-pull` が取得した本番ダンプを Docker Compose の `db` サービスへ復元し、アプリコンテナ経由で代表テーブル件数を検証します。
+- `scripts/tests/test_db_pull_restore.sh`: Docker Compose 呼び出しをモックして、復元先サービス固定・`DB_HOST` 不一致検知・代表テーブル件数検証を確認します。

--- a/scripts/tests/test_db_pull_restore.sh
+++ b/scripts/tests/test_db_pull_restore.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$REPO_ROOT/scripts/db_pull_restore.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+
+  grep -Fq "$pattern" "$file" || fail "Expected '$pattern' in $file"
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+DUMP_PATH="$TMP_DIR/production.sql.gz"
+printf 'SELECT 1;\n' | gzip > "$DUMP_PATH"
+
+run_with_mock_compose() {
+  local calls_file="$1"
+  MOCK_APP_DB_HOST="$2"
+  MOCK_VERIFY_COUNT_OUTPUT="$3"
+  shift 3
+
+  compose() {
+    printf '%s\n' "$*" >> "$calls_file"
+
+    if [[ "$1" == "exec" && "$2" == "-T" && "$4" == "env" ]]; then
+      case "$3" in
+        "$APP_SERVICE")
+          printf 'DB_NAME=local_vrc_ta_hub\nDB_HOST=%s\nDB_USER=root\nDB_PASSWORD=root\n' "$MOCK_APP_DB_HOST"
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+      return 0
+    fi
+
+    if [[ "$1" == "exec" && "$2" == "-T" && "$3" == "-e" && "$5" == "$DB_SERVICE" && "$6" == "mysql" ]]; then
+      local mysql_has_execute=0
+      local after_service=0
+      local arg
+
+      for arg in "$@"; do
+        if (( after_service )) && [[ "$arg" == "-e" ]]; then
+          mysql_has_execute=1
+        fi
+        if [[ "$arg" == "$DB_SERVICE" ]]; then
+          after_service=1
+        fi
+      done
+
+      if (( ! mysql_has_execute )); then
+        cat >/dev/null
+      fi
+      return 0
+    fi
+
+    if [[ "$1" == "exec" && "$2" == "-T" && "$3" == "$APP_SERVICE" && "$4" == "python" ]]; then
+      printf '%s\n' "$MOCK_VERIFY_COUNT_OUTPUT"
+      return 0
+    fi
+
+    return 1
+  }
+
+  "$@"
+}
+
+success_calls="$TMP_DIR/success.calls"
+run_with_mock_compose "$success_calls" "db" $'settings log\n3' main "$DUMP_PATH" > "$TMP_DIR/success.out"
+assert_contains "$TMP_DIR/success.out" "Verified via app container: local_vrc_ta_hub.vket_collaboration has 3 rows."
+assert_contains "$success_calls" "exec -T -e MYSQL_PWD=root db mysql"
+assert_contains "$success_calls" "exec -T vrc-ta-hub python manage.py shell -c"
+
+host_mismatch_calls="$TMP_DIR/host-mismatch.calls"
+if ( run_with_mock_compose "$host_mismatch_calls" "127.0.0.1" "3" main "$DUMP_PATH" > "$TMP_DIR/host-mismatch.out" 2> "$TMP_DIR/host-mismatch.err" ); then
+  fail "DB_HOST mismatch should fail"
+fi
+assert_contains "$TMP_DIR/host-mismatch.err" "App DB_HOST is '127.0.0.1'"
+
+zero_count_calls="$TMP_DIR/zero-count.calls"
+if ( run_with_mock_compose "$zero_count_calls" "db" "0" main "$DUMP_PATH" > "$TMP_DIR/zero-count.out" 2> "$TMP_DIR/zero-count.err" ); then
+  fail "Zero representative rows should fail"
+fi
+assert_contains "$TMP_DIR/zero-count.err" "expected at least 1"
+
+printf 'PASS: db_pull_restore.sh\n'


### PR DESCRIPTION
## なぜこの変更が必要か

- Issue #292「fix: db-pullがDocker ComposeのローカルDBに復元できたことを検証する」に対する fix-flow の自動修正として作成した差分です

## 変更内容

- `Makefile`
- `docs/issue-292-db-pull-compose-restore.md`
- `scripts/db_pull_restore.sh`
- `scripts/index.md`
- `scripts/tests/test_db_pull_restore.sh`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
