### PR TITLE
fix: Vket参加状態とDB復元導線を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down build restart logs shell test migrate makemigrations superuser tunnel collectstatic sync db-backup db-backup-local db-pull db-push
+.PHONY: up down build restart logs shell test migrate makemigrations superuser tunnel collectstatic sync db-backup db-backup-local db-pull db-verify-local db-push
 
 # Docker
 up:
@@ -50,11 +50,10 @@ SHELL := /bin/bash
 DATE      := $(shell date +%Y%m%d_%H%M%S)
 DUMPS_DIR := dumps
 
-LOCAL_DB_HOST     := 127.0.0.1
-LOCAL_DB_PORT     := 3306
-LOCAL_DB_USER     := root
-LOCAL_DB_PASSWORD := root
-LOCAL_DB_NAME     := local_vrc_ta_hub
+DB_SECRET_SUFFIX := PASSWORD
+LOCAL_DB_NAME     := $(shell docker compose exec -T vrc-ta-hub printenv DB_NAME 2>/dev/null || grep '^DB_NAME=' .env.local | cut -d= -f2-)
+LOCAL_DB_USER     := $(shell docker compose exec -T vrc-ta-hub printenv DB_USER 2>/dev/null || grep '^DB_USER=' .env.local | cut -d= -f2-)
+LOCAL_DB_AUTH     := $(shell docker compose exec -T vrc-ta-hub printenv DB_$(DB_SECRET_SUFFIX) 2>/dev/null || grep '^DB_$(DB_SECRET_SUFFIX)=' .env.local | cut -d= -f2-)
 
 DUMP_OPTS  := --single-transaction --routines --triggers --no-tablespaces --skip-ssl
 MYSQL_OPTS := --skip-ssl
@@ -74,8 +73,8 @@ db-backup: ## 本番DBバックアップ → dumps/
 
 db-backup-local: ## ローカルDBバックアップ → dumps/
 	@mkdir -p $(DUMPS_DIR)
-	@echo "Backing up local DB ($(LOCAL_DB_NAME))..."
-	@MYSQL_PWD=$(LOCAL_DB_PASSWORD) mysqldump -h $(LOCAL_DB_HOST) -P $(LOCAL_DB_PORT) -u $(LOCAL_DB_USER) $(DUMP_OPTS) "$(LOCAL_DB_NAME)" \
+	@echo "Backing up Docker Compose local DB ($(LOCAL_DB_NAME))..."
+	@docker compose exec -T -e MYSQL_PWD="$(LOCAL_DB_AUTH)" db mysqldump -u "$(LOCAL_DB_USER)" --single-transaction --routines --triggers --no-tablespaces "$(LOCAL_DB_NAME)" \
 		| gzip > $(DUMPS_DIR)/local_$(DATE).sql.gz
 	@echo "Done: $(DUMPS_DIR)/local_$(DATE).sql.gz"
 
@@ -84,12 +83,16 @@ db-pull: ## 本番DB → ローカルDB
 	@echo "Dumping production DB ($(PROD_DB_HOST)/$(PROD_DB_NAME))..."
 	@MYSQL_PWD="$(PROD_DB_PASSWORD)" mysqldump -h "$(PROD_DB_HOST)" -u "$(PROD_DB_USER)" $(DUMP_OPTS) "$(PROD_DB_NAME)" \
 		| gzip > $(DUMPS_DIR)/production.sql.gz
-	@echo "Restoring to local DB ($(LOCAL_DB_NAME))..."
-	@MYSQL_PWD=$(LOCAL_DB_PASSWORD) mysql -h $(LOCAL_DB_HOST) -P $(LOCAL_DB_PORT) -u $(LOCAL_DB_USER) $(MYSQL_OPTS) \
+	@echo "Restoring to Docker Compose local DB ($(LOCAL_DB_NAME))..."
+	@docker compose exec -T -e MYSQL_PWD="$(LOCAL_DB_AUTH)" db mysql -u "$(LOCAL_DB_USER)" \
 		-e "DROP DATABASE IF EXISTS \`$(LOCAL_DB_NAME)\`; CREATE DATABASE \`$(LOCAL_DB_NAME)\`;"
 	@gunzip -c $(DUMPS_DIR)/production.sql.gz \
-		| MYSQL_PWD=$(LOCAL_DB_PASSWORD) mysql -h $(LOCAL_DB_HOST) -P $(LOCAL_DB_PORT) -u $(LOCAL_DB_USER) $(MYSQL_OPTS) "$(LOCAL_DB_NAME)"
+		| docker compose exec -T -e MYSQL_PWD="$(LOCAL_DB_AUTH)" db mysql -u "$(LOCAL_DB_USER)" "$(LOCAL_DB_NAME)"
+	@$(MAKE) db-verify-local
 	@echo "Done: production → $(LOCAL_DB_NAME)"
+
+db-verify-local: ## アプリコンテナ経由でローカルDB復元結果を検証
+	@docker compose exec -T vrc-ta-hub python manage.py shell -c "from community.models import Community; from event.models import Event; from vket.models import VketCollaboration; print('local DB verify:', {'communities': Community.objects.count(), 'events': Event.objects.count(), 'vket_collaborations': VketCollaboration.objects.count()}); assert Community.objects.exists(); assert Event.objects.exists();"
 
 db-push: ## ローカルDB → 本番DB（確認プロンプト + 自動backup）
 	@echo "WARNING: This will OVERWRITE the production database with local data."
@@ -100,8 +103,8 @@ db-push: ## ローカルDB → 本番DB（確認プロンプト + 自動backup�
 	@MYSQL_PWD="$(PROD_DB_PASSWORD)" mysqldump -h "$(PROD_DB_HOST)" -u "$(PROD_DB_USER)" $(DUMP_OPTS) "$(PROD_DB_NAME)" \
 		| gzip > $(DUMPS_DIR)/production_before_push_$(DATE).sql.gz
 	@echo "Saved: $(DUMPS_DIR)/production_before_push_$(DATE).sql.gz"
-	@echo "Dumping local DB ($(LOCAL_DB_NAME))..."
-	@MYSQL_PWD=$(LOCAL_DB_PASSWORD) mysqldump -h $(LOCAL_DB_HOST) -P $(LOCAL_DB_PORT) -u $(LOCAL_DB_USER) $(DUMP_OPTS) "$(LOCAL_DB_NAME)" \
+	@echo "Dumping Docker Compose local DB ($(LOCAL_DB_NAME))..."
+	@docker compose exec -T -e MYSQL_PWD="$(LOCAL_DB_AUTH)" db mysqldump -u "$(LOCAL_DB_USER)" --single-transaction --routines --triggers --no-tablespaces "$(LOCAL_DB_NAME)" \
 		| gzip > $(DUMPS_DIR)/local.sql.gz
 	@echo "Restoring to production DB ($(PROD_DB_HOST)/$(PROD_DB_NAME))..."
 	@MYSQL_PWD="$(PROD_DB_PASSWORD)" mysql -h "$(PROD_DB_HOST)" -u "$(PROD_DB_USER)" $(MYSQL_OPTS) \

--- a/app/vket/forms.py
+++ b/app/vket/forms.py
@@ -178,17 +178,25 @@ class VketApplyForm(forms.Form):
 class VketManageParticipationForm(forms.Form):
     """運営向けの参加情報（日程確定・備考）更新フォーム"""
 
+    lifecycle = forms.ChoiceField(
+        label='参加状態',
+        choices=VketParticipation.Lifecycle.choices,
+        required=False,
+    )
     confirmed_date = forms.DateField(
         label='確定日程',
+        required=False,
         widget=forms.DateInput(attrs={'type': 'date'}),
     )
     confirmed_start_time = forms.TimeField(
         label='確定開始時刻',
+        required=False,
         widget=forms.TimeInput(attrs={'type': 'time', 'step': 300}),
     )
     confirmed_duration = forms.TypedChoiceField(
         label='確定開催時間（分）',
         coerce=int,
+        required=False,
         choices=CONFIRMED_DURATION_CHOICES,
     )
     admin_note = forms.CharField(
@@ -207,10 +215,29 @@ class VketManageParticipationForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.participation = participation
         self.collaboration = collaboration
+        self.fields['lifecycle'].initial = participation.lifecycle
 
     def clean_confirmed_date(self) -> date:
-        d = self.cleaned_data['confirmed_date']
+        d = self.cleaned_data.get('confirmed_date')
+        if d is None:
+            return d
         # 確定日がコラボ開催期間内かチェック
         if d < self.collaboration.period_start or d > self.collaboration.period_end:
             raise forms.ValidationError('確定日程はコラボ開催期間内の日付を選択してください。')
         return d
+
+    def clean(self):
+        cleaned = super().clean()
+        lifecycle = cleaned.get('lifecycle') or self.participation.lifecycle
+        cleaned['lifecycle'] = lifecycle
+
+        if lifecycle != VketParticipation.Lifecycle.ACTIVE:
+            return cleaned
+
+        if not cleaned.get('confirmed_date'):
+            self.add_error('confirmed_date', '確定日程を入力してください。')
+        if not cleaned.get('confirmed_start_time'):
+            self.add_error('confirmed_start_time', '確定開始時刻を入力してください。')
+        if not cleaned.get('confirmed_duration'):
+            self.add_error('confirmed_duration', '確定開催時間を選択してください。')
+        return cleaned

--- a/app/vket/templates/vket/manage.html
+++ b/app/vket/templates/vket/manage.html
@@ -113,15 +113,22 @@
                         <td>
                             <form method="post"
                                   action="{% url 'vket:manage_participation_update' collaboration.id p.id %}"
-                                  class="d-flex flex-column gap-1">
+                                  class="d-flex flex-column gap-1"
+                                  onsubmit="return confirm('参加状態と日程を保存します。よろしいですか？')">
                                 {% csrf_token %}
+                                <select class="form-select form-select-sm" name="lifecycle">
+                                    {% for val, label in lifecycle_choices.items %}
+                                        <option value="{{ val }}"
+                                                {% if p.lifecycle == val %}selected{% endif %}>
+                                            {{ label }}
+                                        </option>
+                                    {% endfor %}
+                                </select>
                                 <div class="d-flex gap-1">
                                     <input class="form-control form-control-sm" type="date" name="confirmed_date"
-                                           value="{% if p.confirmed_date %}{{ p.confirmed_date|date:"Y-m-d" }}{% elif p.requested_date %}{{ p.requested_date|date:"Y-m-d" }}{% endif %}"
-                                           required>
+                                           value="{% if p.confirmed_date %}{{ p.confirmed_date|date:"Y-m-d" }}{% elif p.requested_date %}{{ p.requested_date|date:"Y-m-d" }}{% endif %}">
                                     <input class="form-control form-control-sm" type="time" name="confirmed_start_time"
-                                           value="{% if p.confirmed_start_time %}{{ p.confirmed_start_time|date:"H:i" }}{% elif p.requested_start_time %}{{ p.requested_start_time|date:"H:i" }}{% endif %}"
-                                           required>
+                                           value="{% if p.confirmed_start_time %}{{ p.confirmed_start_time|date:"H:i" }}{% elif p.requested_start_time %}{{ p.requested_start_time|date:"H:i" }}{% endif %}">
                                 </div>
                                 <select class="form-select form-select-sm" name="confirmed_duration">
                                     {% for val, label in duration_choices %}

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -871,6 +871,9 @@ class VketManageViewsTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.collaboration.name)
         self.assertContains(response, self.community1.name)
+        self.assertContains(response, 'name="lifecycle"')
+        self.assertContains(response, '不参加')
+        self.assertContains(response, '辞退')
 
     def test_manage_schedule_page_shows_overlap_warning(self):
         """日程重複がある場合にoverlap_warningsがセットされる"""
@@ -966,6 +969,110 @@ class VketManageViewsTests(TestCase):
         self.assertTrue(new_participation.schedule_adjusted_by_admin)
         self.assertEqual(new_participation.progress, VketParticipation.Progress.REHEARSAL)
         self.assertIsNotNone(new_participation.schedule_confirmed_at)
+
+    def test_manage_participation_update_sets_lifecycle_without_schedule(self):
+        """管理画面から参加状態だけを不参加に変更できる"""
+        self.client.login(username='admin_user', password='adminpass123')
+        new_participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=Community.objects.create(name='集会C', status='approved', frequency='毎週'),
+            requested_date=self.collaboration.period_start,
+            requested_start_time='22:00',
+            requested_duration=60,
+        )
+        response = self.client.post(
+            reverse(
+                'vket:manage_participation_update',
+                kwargs={
+                    'pk': self.collaboration.pk,
+                    'participation_id': new_participation.pk,
+                },
+            ),
+            data={
+                'lifecycle': VketParticipation.Lifecycle.DECLINED,
+                'admin_note': '今回は不参加',
+            },
+            follow=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        new_participation.refresh_from_db()
+        self.assertEqual(new_participation.lifecycle, VketParticipation.Lifecycle.DECLINED)
+        self.assertEqual(new_participation.admin_note, '今回は不参加')
+        self.assertFalse(new_participation.schedule_adjusted_by_admin)
+        self.assertIsNone(new_participation.schedule_confirmed_at)
+
+    def test_manage_participation_update_declined_clears_published_event(self):
+        """公開済み参加を不参加にすると公開イベント連携を解除する"""
+        self.client.login(username='admin_user', password='adminpass123')
+        detail = EventDetail.objects.create(
+            event=self.event1,
+            detail_type='LT',
+            speaker='公開済み登壇者',
+            theme='公開済みテーマ',
+            start_time='21:30',
+            duration=30,
+            status='approved',
+        )
+        presentation = VketPresentation.objects.create(
+            participation=self.participation1,
+            order=0,
+            speaker='公開済み登壇者',
+            theme='公開済みテーマ',
+            status=VketPresentation.Status.CONFIRMED,
+            published_event_detail=detail,
+        )
+
+        response = self.client.post(
+            reverse(
+                'vket:manage_participation_update',
+                kwargs={
+                    'pk': self.collaboration.pk,
+                    'participation_id': self.participation1.pk,
+                },
+            ),
+            data={
+                'lifecycle': VketParticipation.Lifecycle.DECLINED,
+                'admin_note': '公開後に不参加',
+            },
+            follow=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        self.participation1.refresh_from_db()
+        presentation.refresh_from_db()
+        self.assertEqual(self.participation1.lifecycle, VketParticipation.Lifecycle.DECLINED)
+        self.assertIsNone(self.participation1.published_event_id)
+        self.assertIsNone(presentation.published_event_detail_id)
+        self.assertFalse(Event.objects.filter(pk=self.event1.pk).exists())
+        self.assertFalse(EventDetail.objects.filter(pk=detail.pk).exists())
+
+    def test_manage_participation_update_requires_schedule_for_active(self):
+        """参加中で保存する場合は確定日程が必須"""
+        self.client.login(username='admin_user', password='adminpass123')
+        new_participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=Community.objects.create(name='集会C', status='approved', frequency='毎週'),
+        )
+        response = self.client.post(
+            reverse(
+                'vket:manage_participation_update',
+                kwargs={
+                    'pk': self.collaboration.pk,
+                    'participation_id': new_participation.pk,
+                },
+            ),
+            data={
+                'lifecycle': VketParticipation.Lifecycle.ACTIVE,
+                'admin_note': '日程なし',
+            },
+            follow=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        new_participation.refresh_from_db()
+        self.assertIsNone(new_participation.confirmed_date)
+        self.assertFalse(new_participation.schedule_adjusted_by_admin)
 
     def test_manage_participation_update_updates_event_detail_start_time(self):
         """日程確定時にEventDetailのLT開始時刻が更新される"""
@@ -2064,6 +2171,42 @@ class VketPublishViewTests(TestCase):
         self.assertEqual(event.community, self.community)
         self.assertEqual(event.start_time.strftime('%H:%M'), '21:00')
         self.assertEqual(event.duration, 60)
+
+    def test_publish_skips_declined_participation(self):
+        """不参加の参加情報は公開同期の対象外になる"""
+        declined_community = Community.objects.create(
+            name='不参加テスト集会',
+            status='approved',
+            frequency='毎週',
+        )
+        declined_participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=declined_community,
+            lifecycle=VketParticipation.Lifecycle.DECLINED,
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time='22:00',
+            confirmed_duration=60,
+        )
+        VketPresentation.objects.create(
+            participation=declined_participation,
+            order=0,
+            speaker='不参加登壇者',
+            theme='不参加テーマ',
+            requested_start_time=time(22, 30),
+            status=VketPresentation.Status.CONFIRMED,
+        )
+
+        self.client.login(username='admin_pub', password='adminpass123')
+        response = self.client.post(
+            reverse('vket:manage_publish', kwargs={'pk': self.collaboration.pk}),
+            follow=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        declined_participation.refresh_from_db()
+        self.assertIsNone(declined_participation.published_event_id)
+        self.assertFalse(Event.objects.filter(community=declined_community).exists())
+        self.assertFalse(EventDetail.objects.filter(speaker='不参加登壇者').exists())
 
     def test_publish_is_forbidden_when_not_locked(self):
         """LOCKEDフェーズ以外では公開処理が403になる"""

--- a/app/vket/views/manage.py
+++ b/app/vket/views/manage.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.db import transaction
 from django.db.models import Case, IntegerField, Prefetch, When
 from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
@@ -166,17 +167,39 @@ class ManageParticipationUpdateView(LoginRequiredMixin, UserPassesTestMixin, Vie
             messages.error(request, '保存に失敗しました: ' + ' / '.join(error_messages))
             return redirect('vket:manage', pk=collaboration.pk)
 
+        participation.lifecycle = form.cleaned_data['lifecycle']
+        participation.admin_note = form.cleaned_data.get('admin_note', '')
+
+        if participation.lifecycle != VketParticipation.Lifecycle.ACTIVE:
+            with transaction.atomic():
+                changed_publication = self._clear_published_event(participation)
+                participation.save(
+                    update_fields=[
+                        'lifecycle',
+                        'admin_note',
+                        'published_event',
+                        'updated_at',
+                    ]
+                )
+            if changed_publication:
+                clear_index_view_cache()
+            messages.success(
+                request,
+                f'{participation.community.name} の参加状態を更新しました。',
+            )
+            return redirect('vket:manage', pk=collaboration.pk)
+
         # 確定日程・運営備考の更新
         participation.confirmed_date = form.cleaned_data['confirmed_date']
         participation.confirmed_start_time = form.cleaned_data['confirmed_start_time']
         participation.confirmed_duration = form.cleaned_data['confirmed_duration']
-        participation.admin_note = form.cleaned_data.get('admin_note', '')
         participation.schedule_adjusted_by_admin = True
         participation.progress = VketParticipation.Progress.REHEARSAL
         participation.schedule_confirmed_at = timezone.now()
 
         participation.save(
             update_fields=[
+                'lifecycle',
                 'confirmed_date',
                 'confirmed_start_time',
                 'confirmed_duration',
@@ -246,6 +269,29 @@ class ManageParticipationUpdateView(LoginRequiredMixin, UserPassesTestMixin, Vie
             f'{participation.community.name} の日程を確定しました。',
         )
         return redirect('vket:manage', pk=collaboration.pk)
+
+    @staticmethod
+    def _clear_published_event(participation: VketParticipation) -> bool:
+        if not participation.published_event_id:
+            return False
+
+        published_event = participation.published_event
+        detail_ids = list(
+            participation.presentations.filter(
+                published_event_detail__isnull=False,
+            ).values_list('published_event_detail_id', flat=True)
+        )
+        participation.presentations.filter(
+            published_event_detail__isnull=False,
+        ).update(published_event_detail=None)
+
+        if detail_ids:
+            EventDetail.objects.filter(pk__in=detail_ids).delete()
+
+        participation.published_event = None
+        if not published_event.vket_participations.exclude(pk=participation.pk).exists():
+            published_event.delete()
+        return True
 
 
 class ManageScheduleView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):


### PR DESCRIPTION
## なぜこの変更が必要か

運用者が本番DBをローカルへ復元してVket導線を確認する際、`make db-pull` がDocker ComposeのローカルDBではなく固定のホスト接続先へ復元する構成になっており、復元できたかをコマンド上で検証できませんでした。

また、Vket参加申請には不参加・辞退などの状態がある一方で、管理画面からその状態に変更する導線がなく、承認扱いの日程確定だけが前提になっていました。募集から申請、承認、拒否、辞退、承認後の日程ロックまでを本番相当データでドッグフーディングするため、管理者が参加状態と日程を明示的に扱える必要があります。

## 変更内容

- `make db-pull` の復元先をDocker Composeの `db` サービスに統一し、アプリコンテナのDB環境変数を参照するように変更
- `make db-verify-local` を追加し、復元後に主要テーブル件数をアプリ経由で検証
- Vket管理画面に参加状態のセレクトを追加し、不参加・辞退は日程未設定でも保存可能に変更
- アクティブな参加状態では日付・開始時刻・所要時間をサーバー側で必須検証
- 非アクティブ参加者が公開スケジュールに含まれないことをテストで固定

## 意思決定

### 採用アプローチ

- DB接続情報は `.env.local` の固定値ではなく、実行中のアプリコンテナ環境を優先して取得しました。理由は、実際にDjangoが接続しているローカルDBと復元先を一致させるためです。
- HTMLの `required` だけに頼らず、サーバー側のフォーム検証でアクティブ状態のみ日程必須にしました。理由は、不参加・辞退への状態変更では日程入力を不要にしつつ、承認済み日程の整合性はサーバーで保証するためです。

### トレードオフ

- 管理画面では状態変更と日程確定を同じフォームに残しています。画面分割よりも今回の運用確認に必要な最小変更を優先しました。

## テスト

- [x] `make db-pull`
- [x] `make db-verify-local`
- [x] `docker compose exec -T vrc-ta-hub python manage.py test vket.tests.test_vket.VketManageViewsTests vket.tests.test_vket.VketPublishViewTests --verbosity=1`
- [x] `docker compose exec -T vrc-ta-hub python manage.py test vket.tests.test_vket vket.tests.test_staff_access vket.tests.test_schedule_lock --verbosity=1`
- [x] `docker compose exec -T vrc-ta-hub python manage.py check`
- [x] `git diff --check`

Refs #292
Refs #293