### PR TITLE
fix: Vketリハーサル予定日を更新

### DIFF
--- a/app/vket/templates/vket/participation_status.html
+++ b/app/vket/templates/vket/participation_status.html
@@ -286,7 +286,7 @@
                         <i class="fas fa-headset me-2"></i>リハーサル
                     </h2>
                     <p class="mb-0">
-                        <span class="fw-bold">7/24（金）</span>を予定しています。詳細は追ってお知らせします。
+                        <span class="fw-bold">7月10日（金）頃</span>を予定しています。詳細は追ってお知らせします。
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
## 概要
- Vket参加状態ページのリハーサル予定日表示を 7/24（金） から 7月10日（金）頃 に変更

## 検証
- rg で対象テンプレート内の新文言表示を確認
- uv run python app/manage.py check は依存関係インストール前に Django 不足で失敗
- uv pip install -r requirements.txt は pysqlite3==0.5.3 の macOS arm64 ネイティブビルドエラーで失敗