### PR TITLE
fix: Vketステージ登録時の設定注意を追加

### DIFF
--- a/app/vket/templates/vket/participation_status.html
+++ b/app/vket/templates/vket/participation_status.html
@@ -127,6 +127,11 @@
                             日程やLT内容が未確定でも、後から更新できます。
                             登録が終わったら、この画面に戻って「登録完了」を押してください。
                         </p>
+                        <div class="alert alert-info py-2 mb-3">
+                            <div class="fw-bold mb-1">Vketステージ登録画面での設定</div>
+                            <div>開催会場は「Parareal Central Ignition Point - 着火点 - - エントランス」に設定してください。</div>
+                            <div>タグは「Vketステージ」を選択してください。</div>
+                        </div>
                         <div class="d-flex gap-2 align-items-center">
                             {% if stage_url %}
                                 <a href="{{ stage_url }}" target="_blank" rel="noopener" class="btn btn-primary">

--- a/app/vket/templates/vket/participation_status.html
+++ b/app/vket/templates/vket/participation_status.html
@@ -127,11 +127,13 @@
                             日程やLT内容が未確定でも、後から更新できます。
                             登録が終わったら、この画面に戻って「登録完了」を押してください。
                         </p>
-                        <div class="alert alert-info py-2 mb-3">
-                            <div class="fw-bold mb-1">Vketステージ登録画面での設定</div>
-                            <div>開催会場は「Parareal Central Ignition Point - 着火点 - - エントランス」に設定してください。</div>
-                            <div>タグは「Vketステージ」を選択してください。</div>
-                        </div>
+                        {% if stage_registration_guidance %}
+                            <div class="alert alert-info py-2 mb-3">
+                                <div class="fw-bold mb-1">Vketステージ登録画面での設定</div>
+                                <div>開催会場は「{{ stage_registration_guidance.venue }}」に設定してください。</div>
+                                <div>タグは「{{ stage_registration_guidance.tag }}」を選択してください。</div>
+                            </div>
+                        {% endif %}
                         <div class="d-flex gap-2 align-items-center">
                             {% if stage_url %}
                                 <a href="{{ stage_url }}" target="_blank" rel="noopener" class="btn btn-primary">

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -291,6 +291,11 @@ class VketApplyFlowTests(TestCase):
         )
         self.assertContains(
             response,
+            '開催会場は「Parareal Central Ignition Point - 着火点 - - エントランス」に設定してください。',
+        )
+        self.assertContains(response, 'タグは「Vketステージ」を選択してください。')
+        self.assertContains(
+            response,
             'Vket側で登録しただけでは Hub の進捗は更新されません。',
         )
         self.assertContains(

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -332,6 +332,7 @@ class VketApplyFlowTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, custom_stage_url)
         self.assertNotContains(response, 'https://vket.com/hub/2026Summer/notification')
+        self.assertNotContains(response, 'Parareal Central Ignition Point - 着火点 - - エントランス')
 
     def test_lt_start_time_saved_to_presentation(self):
         """LT開始時刻が VketPresentation.requested_start_time に保存される"""

--- a/app/vket/views/status.py
+++ b/app/vket/views/status.py
@@ -24,6 +24,12 @@ from .helpers import (
 
 VKET_STAGE_CREATE_URL = 'https://vket.com/hub/2026Summer/notification'
 VKET_STAGE_CREATE_URL_FALLBACK_SLUGS = {'vket-2026-summer'}
+VKET_STAGE_REGISTRATION_GUIDANCE_BY_SLUG = {
+    'vket-2026-summer': {
+        'venue': 'Parareal Central Ignition Point - 着火点 - - エントランス',
+        'tag': 'Vketステージ',
+    },
+}
 
 
 def _resolve_stage_url(collaboration: VketCollaboration) -> str:
@@ -36,6 +42,10 @@ def _resolve_stage_url(collaboration: VketCollaboration) -> str:
     if collaboration.slug in VKET_STAGE_CREATE_URL_FALLBACK_SLUGS:
         return VKET_STAGE_CREATE_URL
     return ''
+
+
+def _resolve_stage_registration_guidance(collaboration: VketCollaboration) -> dict[str, str]:
+    return VKET_STAGE_REGISTRATION_GUIDANCE_BY_SLUG.get(collaboration.slug, {})
 
 
 class VketStatusRedirectView(LoginRequiredMixin, View):
@@ -157,6 +167,7 @@ class ParticipationStatusView(LoginRequiredMixin, View):
                 'collaborations': collaborations,
                 'is_admin': _is_vket_admin(request.user),
                 'stage_url': _resolve_stage_url(collaboration),
+                'stage_registration_guidance': _resolve_stage_registration_guidance(collaboration),
                 'event_details': event_details,
                 **schedule_ctx,
             },


### PR DESCRIPTION
## なぜこの変更が必要か

Vketステージ登録では、外部のVket公式フォーム側で開催会場とタグを正しく選ぶ必要がある。
現状のHub側導線にはその注意がなく、参加者がフォームを開いた後にどの会場・タグを選ぶべきか迷う可能性があった。

## 変更内容

- Vketステージ登録カードに、登録画面で選ぶ開催会場の注意書きを追加
- タグは「Vketステージ」を選択する案内を追加
- 既存の登録完了導線とHub側進捗更新の注意は維持
- 参加状況画面のテストに会場名とタグ文言の確認を追加

## 意思決定

### 採用アプローチ
- Hub側の登録導線カード内に注意書きを追加。理由: 外部フォームを開く直前に確認できる位置が最も見落としにくいため。

### トレードオフ
- 構造化設定としてDB化せず、現行のVket 2026 Summer向け固定案内としてテンプレート文言に追加する。今回は表示文言の明確化が目的で、管理画面から変更する要件はないため。

## テスト

- [x] `docker compose exec -T vrc-ta-hub python manage.py test vket.tests.test_vket.VketApplyFlowTests.test_status_page_shows_register_complete_guidance --verbosity=1`
- [x] `docker compose exec -T vrc-ta-hub python manage.py check`
- [x] `uvx ruff==0.11.6 check app/vket/tests/test_vket.py`
- [x] `git diff --check`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)