### PR TITLE
本番DBのローカル復元ターゲットを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down build restart logs shell test migrate makemigrations superuser tunnel collectstatic sync db-backup db-backup-local db-pull db-verify-local db-push
+.PHONY: up down build restart logs shell test migrate makemigrations superuser tunnel collectstatic sync db-backup db-backup-local db-pull db-restore-production-local db-verify-local db-push
 
 # Docker
 up:
@@ -98,6 +98,8 @@ db-pull: ## 本番DB → ローカルDB
 		DB_PULL_VERIFY_MIN_ROWS="$(DB_PULL_VERIFY_MIN_ROWS)" \
 		scripts/db_pull_restore.sh "$(DUMPS_DIR)/production.sql.gz"
 	@echo "Done: production → Docker Compose DB"
+
+db-restore-production-local: db-backup-local db-pull ## ローカルDBを退避してから本番DBをローカルDBへ完全復元
 
 db-verify-local: ## アプリコンテナ経由でローカルDB復元結果を検証
 	@docker compose exec -T vrc-ta-hub python manage.py shell -c "from community.models import Community; from event.models import Event; from vket.models import VketCollaboration; print('local DB verify:', {'communities': Community.objects.count(), 'events': Event.objects.count(), 'vket_collaborations': VketCollaboration.objects.count()}); assert Community.objects.exists(); assert Event.objects.exists();"

--- a/scripts/db_pull_restore.sh
+++ b/scripts/db_pull_restore.sh
@@ -63,12 +63,12 @@ restore_dump_to_compose_db() {
   local db_password="$4"
 
   compose exec -T -e "MYSQL_PWD=$db_password" "$DB_SERVICE" \
-    mysql -u "$db_user" --skip-ssl \
+    mysql -u "$db_user" \
     -e "DROP DATABASE IF EXISTS \`$db_name\`; CREATE DATABASE \`$db_name\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 
   gunzip -c "$dump_path" \
     | compose exec -T -e "MYSQL_PWD=$db_password" "$DB_SERVICE" \
-      mysql -u "$db_user" --skip-ssl "$db_name"
+      mysql -u "$db_user" "$db_name"
 }
 
 verify_app_table_count() {

--- a/scripts/tests/test_db_pull_restore.sh
+++ b/scripts/tests/test_db_pull_restore.sh
@@ -81,6 +81,9 @@ run_with_mock_compose "$success_calls" "db" $'settings log\n3' main "$DUMP_PATH"
 assert_contains "$TMP_DIR/success.out" "Verified via app container: local_vrc_ta_hub.vket_collaboration has 3 rows."
 assert_contains "$success_calls" "exec -T -e MYSQL_PWD=root db mysql"
 assert_contains "$success_calls" "exec -T vrc-ta-hub python manage.py shell -c"
+if grep -Fq -- "--skip-ssl" "$success_calls"; then
+  fail "Compose MySQL restore should not pass --skip-ssl"
+fi
 
 host_mismatch_calls="$TMP_DIR/host-mismatch.calls"
 if ( run_with_mock_compose "$host_mismatch_calls" "127.0.0.1" "3" main "$DUMP_PATH" > "$TMP_DIR/host-mismatch.out" 2> "$TMP_DIR/host-mismatch.err" ); then


### PR DESCRIPTION
## Summary
- ローカルDBを退避してから本番DBをローカルへ完全復元する `make db-restore-production-local` を追加
- Compose内MySQL復元時に非対応だった `--skip-ssl` を外して `make db-pull` を修正
- 復元スクリプトの回帰テストを追加

## Why
本番DBをローカルへ復元する既存フローで、Compose内MySQLが `--skip-ssl` を受け付けず復元に失敗したため、実際に動く復元ターゲットとして整備します。

## Tests
- `bash scripts/tests/test_db_pull_restore.sh`
- `bash -n scripts/db_pull_restore.sh scripts/tests/test_db_pull_restore.sh`
- `make -n db-restore-production-local`
- `git diff --check`
