### PR TITLE
fix: 管理日程表に未確定スケジュールを表示

### DIFF
--- a/app/vket/templates/vket/manage_schedule.html
+++ b/app/vket/templates/vket/manage_schedule.html
@@ -15,6 +15,6 @@
 
         {% include 'vket/includes/manage_tabs.html' with active_tab='schedule' %}
 
-        {% include 'vket/includes/schedule_table.html' with show_warnings=True show_legend=False %}
+        {% include 'vket/includes/schedule_table.html' with show_warnings=True show_legend=True %}
     </div>
 {% endblock %}

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -956,6 +956,34 @@ class VketManageViewsTests(TestCase):
         communities = [r['participation'].community.name for r in rows]
         self.assertIn('集会C', communities)
 
+    def test_manage_schedule_shows_requested_without_confirmed_schedule(self):
+        """未確定でも希望日程があれば管理日程表に表示される"""
+        community3 = Community.objects.create(name='集会C', status='approved', frequency='毎週')
+        today = timezone.localdate()
+        VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=community3,
+            requested_date=today,
+            requested_start_time='22:00',
+            requested_duration=60,
+        )
+
+        self.client.login(username='admin_user', password='adminpass123')
+        response = self.client.get(
+            reverse('vket:manage_schedule', kwargs={'pk': self.collaboration.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+
+        rows = response.context['rows']
+        requested_row = next(
+            r for r in rows if r['participation'].community.name == '集会C'
+        )
+        self.assertFalse(requested_row['is_confirmed'])
+        self.assertEqual(requested_row['date'], today)
+        self.assertEqual(requested_row['start_time'], time(22, 0))
+        self.assertContains(response, '集会C')
+        self.assertContains(response, '申請中')
+
     def test_manage_schedule_page_marks_lt_slot(self):
         """LT詳細があるスロットにlt_timesが設定される"""
         EventDetail.objects.create(

--- a/app/vket/views/manage.py
+++ b/app/vket/views/manage.py
@@ -303,6 +303,6 @@ class ManageScheduleView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         collaboration = get_object_or_404(VketCollaboration, pk=kwargs['pk'])
-        schedule_ctx = _build_schedule_context(collaboration, include_requested=False)
+        schedule_ctx = _build_schedule_context(collaboration, include_requested=True)
         context.update({'collaboration': collaboration, **schedule_ctx})
         return context


### PR DESCRIPTION
## なぜこの変更が必要か

Vket管理者が `/vket/<pk>/manage/schedule/` で日程調整するとき、確定済みの日程だけが表示され、希望日程のみの未確定イベントを把握できなかった。
参加状況ページでは未確定イベントも表示されているため、管理画面でも同じ日程表として確認できる必要がある。

## 変更内容

- 管理日程ページの `_build_schedule_context()` 呼び出しを `include_requested=True` に変更
- 管理日程ページでも確定・申請中・LT開始の凡例を表示
- 未確定の希望日程が管理日程表に表示される回帰テストを追加

## 意思決定

### 採用アプローチ
- 既存の共通日程表 `vket/includes/schedule_table.html` と `_build_schedule_context()` を利用。理由: 参加状況ページで既に未確定表示の表現が実装済みで、表示ロジックを増やさずに管理画面と揃えられるため。

### 却下した代替案
- 管理日程ページ専用に未確定行を追加する実装 → 却下: 共通化要件に反し、日程表の表示仕様がページ間で分岐するため。

### トレードオフ
- 未確定イベントも重複警告の対象に含まれる。管理者の日程調整画面では、希望日程段階の衝突も見えるほうを優先した。

## テスト

- [x] `docker compose exec vrc-ta-hub python manage.py test vket.tests.test_vket.VketManageViewsTests`
- [x] `docker compose exec vrc-ta-hub python manage.py test vket.tests`
- [x] `git diff --check`
- [x] ローカルブラウザで `http://localhost:8015/vket/1/manage/schedule/` を開き、未確定イベントが `申請中` バッジ付きで表示されることを確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)