### PR TITLE
refactor: Cloud RunカナリアタグをCloud Buildから外しdeploy-watch側に集約

### DIFF
--- a/app/website/tests/test_cloudbuild_config.py
+++ b/app/website/tests/test_cloudbuild_config.py
@@ -12,10 +12,23 @@ class CloudBuildConfigTest(SimpleTestCase):
     def setUp(self):
         self.cloudbuild = (REPO_ROOT / 'cloudbuild.yaml').read_text()
 
-    def test_production_deploy_uses_single_preview_tag(self):
-        self.assertIn("--update-tags='preview=LATEST'", self.cloudbuild)
-        self.assertIn("--remove-tags", self.cloudbuild)
-        self.assertNotIn("rev-$SHORT_SHA", self.cloudbuild)
+    def test_production_deploy_does_not_auto_assign_traffic_tag(self):
+        """Cloud Build はカナリアタグ付与を行わない。タグ運用は deploy-watch に集約する。
+
+        参照: ~/.claude/skills/deploy-watch/SKILL.md
+        """
+        # 自動付与は preview / canary / smoke / candidate いずれも禁止
+        self.assertNotIn("--update-tags='preview=LATEST'", self.cloudbuild)
+        self.assertNotIn("--update-tags='canary=LATEST'", self.cloudbuild)
+        self.assertNotIn("--update-tags=canary=LATEST", self.cloudbuild)
+        self.assertNotIn("--update-tags='smoke=LATEST'", self.cloudbuild)
+        self.assertNotIn("--update-tags='candidate=LATEST'", self.cloudbuild)
 
     def test_production_deploy_does_not_assign_tag_during_deploy(self):
         self.assertNotIn("'--tag'", self.cloudbuild)
+        self.assertNotIn("rev-$SHORT_SHA", self.cloudbuild)
+
+    def test_production_deploy_cleans_up_legacy_rev_tags(self):
+        """旧 `rev-*` タグの掃除処理は維持する（残骸タグ削減のため）。"""
+        self.assertIn("grep '^rev-'", self.cloudbuild)
+        self.assertIn("--remove-tags", self.cloudbuild)

--- a/app/website/tests/test_host_middleware.py
+++ b/app/website/tests/test_host_middleware.py
@@ -48,6 +48,25 @@ class CanonicalCloudRunHostMiddlewareTest(SimpleTestCase):
     @override_settings(
         ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
     )
+    def test_cloud_run_canary_host_validator_allows_supported_service(self):
+        """deploy-watch がカナリア検証で叩く `canary---` ホストも検証で許可される。
+
+        参照: ~/.claude/skills/deploy-watch/SKILL.md
+        """
+        install_cloud_run_preview_host_validator()
+        request = self.request_factory.get(
+            '/healthz/',
+            HTTP_HOST='canary---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+        )
+
+        self.assertEqual(
+            request.get_host(),
+            'canary---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+        )
+
+    @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+    )
     def test_cloud_run_revision_host_reported_by_disallowed_host_is_canonicalized(self):
         calls = []
 

--- a/app/website/tests/test_host_settings.py
+++ b/app/website/tests/test_host_settings.py
@@ -98,6 +98,28 @@ class AllowedHostsSettingsTest(SimpleTestCase):
             pattern,
         )
 
+    def test_cloud_run_preview_host_pattern_allows_canary_tag(self):
+        """deploy-watch がカナリア検証時に付与する `canary` タグの URL もパターンに通る。
+
+        deploy-watch は `gcloud run services update-traffic --update-tags=canary=<REV>` で
+        新リビジョンに `canary` タグを付け、`https://canary---vrc-ta-hub-...run.app/` を直接叩く。
+        参照: ~/.claude/skills/deploy-watch/SKILL.md
+        """
+        pattern = _build_cloud_run_preview_host_pattern()
+
+        self.assertRegex(
+            'canary---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+            pattern,
+        )
+        self.assertRegex(
+            'canary---vrc-ta-hub-dev-mhbhtr6sha-an.a.run.app',
+            pattern,
+        )
+        self.assertNotRegex(
+            'canary---other-service-mhbhtr6sha-an.a.run.app',
+            pattern,
+        )
+
     @override_settings(
         ROOT_URLCONF=__name__,
         ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,6 +31,9 @@ steps:
       - 'DISCORD_WEBHOOK_URL=DISCORD_WEBHOOK_URL:latest,DISCORD_CLIENT_ID=DISCORD_CLIENT_ID:latest,DISCORD_CLIENT_SECRET=DISCORD_CLIENT_SECRET:latest,DISCORD_REPORT_WEBHOOK_URL=DISCORD_REPORT_WEBHOOK_URL:latest,X_API_KEY=X_API_KEY:latest,X_API_SECRET=X_API_SECRET:latest,X_ACCESS_TOKEN=X_ACCESS_TOKEN:latest,X_ACCESS_TOKEN_SECRET=X_ACCESS_TOKEN_SECRET:latest'
       - '${_SERVICE_NAME}'
 
+  # 旧 `rev-*` タグの掃除のみ実施。カナリア検証用の `canary` タグは deploy-watch スキルが
+  # 必要なタイミングで `gcloud run services update-traffic --update-tags=canary=<REV>` で付与する。
+  # 参照: ~/.claude/skills/deploy-watch/SKILL.md（タグ運用は deploy-watch に集約）
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:
@@ -47,18 +50,15 @@ steps:
           | paste -sd, -
         )"
 
-        UPDATE_ARGS=(
-          run services update-traffic "${_SERVICE_NAME}"
-          --project="${PROJECT_ID}"
-          --region='asia-northeast1'
-          --update-tags='preview=LATEST'
-        )
-
-        if [ -n "$${LEGACY_TAGS}" ]; then
-          UPDATE_ARGS+=(--remove-tags="$${LEGACY_TAGS}")
+        if [ -z "$${LEGACY_TAGS}" ]; then
+          echo 'No legacy rev-* tags to clean up.'
+          exit 0
         fi
 
-        gcloud "$${UPDATE_ARGS[@]}"
+        gcloud run services update-traffic "${_SERVICE_NAME}" \
+          --project="${PROJECT_ID}" \
+          --region='asia-northeast1' \
+          --remove-tags="$${LEGACY_TAGS}"
 
 substitutions:
   _SERVICE_NAME: 'vrc-ta-hub'

--- a/nginx-app.conf
+++ b/nginx-app.conf
@@ -1,6 +1,6 @@
 # nginx-app.conf
 
-# Cloud Run の tagged preview host だけを正規ホストへ寄せて、
+# Cloud Run の tagged preview host（`rev-*---` / `canary---` 等）だけを正規ホストへ寄せて、
 # Django に raw run.app host が届かないようにする。参照: PR #193（Cloud Run preview host を nginx 前段で正規化した理由）
 map $http_host $django_upstream_host {
     default $http_host;


### PR DESCRIPTION
## Summary

- Cloud Run のリビジョン traffic tag 運用を、cloudbuild が自動付与する \`preview\` から、deploy-watch スキルが必要時に付与する \`canary\` に集約
- プロジェクト横断で Cloud Run カナリアタグを \`canary\` に統一する作業の一環
- 関連 PR: ondoku3#722（マージ済み）、mojiokoshi3#318、ghost-writer-cms#119

## 変更内容

- \`cloudbuild.yaml\`: \`--update-tags='preview=LATEST'\` を削除（自動タグ付与をやめる）。\`rev-*\` legacy tag 一括掃除処理は維持し、空時は早期リターンに整理
- \`nginx-app.conf\`: コメントを \`canary---\` も対象であることを明記
- \`app/website/tests/test_cloudbuild_config.py\`: 「preview=LATEST 必須」のテストを「自動タグ付与なし」を担保する形に反転、rev-* 掃除処理維持の assert を追加
- \`app/website/tests/test_host_settings.py\`: \`canary---vrc-ta-hub-...\` のパターンマッチ + 他サービスの canary 拒否テストを追加
- \`app/website/tests/test_host_middleware.py\`: \`canary---vrc-ta-hub-...\` Host が validator で許可されるテストを追加

## なぜ既存 settings.py / middleware.py に変更がないか

PR #300 で導入された \`_build_cloud_run_preview_host_pattern\` が \`[a-z0-9-]+---vrc-ta-hub.*\` という汎用 prefix を許可するため、\`canary---\` も既存実装でそのまま通る。新規追加したテストはリグレッション防止用。

## Test plan

- [x] ローカルで 29 件 pass（test_cloudbuild_config / test_host_settings / test_host_middleware / test_nginx_config）
- [x] code-reviewer 通過（ブロッキング無し）
- [x] security-checker 通過（preview 常設 URL 廃止で攻撃面縮小と評価）
- [ ] CI 通過
- [ ] マージ後、Cloud Build → 新リビジョン → \`canary---vrc-ta-hub-mhbhtr6sha-an.a.run.app\` が HTTP 200
- [ ] \`rev-*\` × 76 個の残骸タグが Cloud Build で自動掃除される（\`grep '^rev-' | paste -sd,\` で一括 \`--remove-tags\`）
- [ ] 既存 \`preview\` タグの掃除（別作業）

## Notes

- 関連: \`/Users/ms25/.claude/plans/cloud-run-ondoku3-mojiokoshi3-distributed-noodle.md\`
- 既存ローカル変更（管理日程表系）には触れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)