### PR TITLE
fix: 本日開催カードを強調表示

### DIFF
--- a/app/ta_hub/templates/ta_hub/index.html
+++ b/app/ta_hub/templates/ta_hub/index.html
@@ -123,6 +123,24 @@
             box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
         }
 
+        .today-event-card {
+            border: 3px solid #f59e0b !important;
+            box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.18), 0 8px 22px rgba(15, 23, 42, 0.16) !important;
+        }
+
+        .today-event-card:hover {
+            box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.24), 0 10px 26px rgba(15, 23, 42, 0.18) !important;
+        }
+
+        .today-event-badge {
+            background: #f59e0b;
+            color: #1f2937;
+            border: 1px solid rgba(146, 64, 14, 0.28);
+            font-size: 0.875rem;
+            font-weight: 700;
+            letter-spacing: 0;
+        }
+
         .event-card .card-body {
             padding: 1.25rem;
         }
@@ -528,7 +546,8 @@
                     {% for event_group in event_list %}
                         <div class="col-12 col-md-10 offset-md-1"
                              {% if event_group.grouper.date >= vket_start_date and event_group.grouper.date <= vket_end_date %}data-vket-event="true"{% endif %}>
-                            <div class="card shadow h-100" style="position: relative;">
+                            <div class="card shadow h-100 {% if event_group.grouper.date == current_date %}today-event-card{% endif %}"
+                                 style="position: relative;">
                                 <a href="{% url 'community:detail' event_group.grouper.community.pk %}"
                                    class="text-decoration-none position-absolute w-100 h-100"
                                    style="z-index: 1;">
@@ -551,14 +570,19 @@
                                         <div class="card-body">
                                             <div class="d-flex justify-content-between align-items-start mb-3">
                                                 <h3 class="card-title mb-0 font-monospace">{{ event_group.grouper.community.name }}</h3>
-                                                <a href="{{ event_group.grouper.google_calendar_url }}"
-                                                   target="_blank"
-                                                   class="btn btn-outline-primary btn-sm"
-                                                   style="position: relative; z-index: 2;"
-                                                   data-bs-toggle="tooltip" data-bs-placement="left"
-                                                   title="Googleカレンダーに予定を追加">
-                                                    <i class="bi bi-calendar-plus"></i>
-                                                </a>
+                                                <div class="d-flex align-items-center gap-2">
+                                                    {% if event_group.grouper.date == current_date %}
+                                                        <span class="badge rounded-pill today-event-badge">本日開催</span>
+                                                    {% endif %}
+                                                    <a href="{{ event_group.grouper.google_calendar_url }}"
+                                                       target="_blank"
+                                                       class="btn btn-outline-primary btn-sm"
+                                                       style="position: relative; z-index: 2;"
+                                                       data-bs-toggle="tooltip" data-bs-placement="left"
+                                                       title="Googleカレンダーに予定を追加">
+                                                        <i class="bi bi-calendar-plus"></i>
+                                                    </a>
+                                                </div>
                                             </div>
                                             <p class="card-text">
                                                 <i class="bi bi-calendar3"></i> {{ event_group.grouper.date|date:"Y/m/d" }}
@@ -755,7 +779,7 @@
                     <div class="col">
                         <div class="position-relative card-hover-container">
                             <a href="{% url 'community:detail' event.community.id %}" class="text-decoration-none">
-                                <div class="card event-card shadow">
+                                <div class="card event-card shadow {% if event.date == current_date %}today-event-card{% endif %}">
                                     <div class="row g-0 h-100">
                                         <div class="col-4">
                                             <div class="event-image-container">
@@ -772,7 +796,12 @@
                                         </div>
                                         <div class="col-8">
                                             <div class="card-body d-flex flex-column h-100">
-                                                <h5 class="card-title">{{ event.community.name }}</h5>
+                                                <div class="d-flex justify-content-between align-items-start gap-2">
+                                                    <h5 class="card-title">{{ event.community.name }}</h5>
+                                                    {% if event.date == current_date %}
+                                                        <span class="badge rounded-pill today-event-badge">本日開催</span>
+                                                    {% endif %}
+                                                </div>
                                                 <div class="event-info">
                                                     <div class="datetime-container">
                                                         <div class="datetime-row">

--- a/app/ta_hub/tests/test_index_view_degraded_mode.py
+++ b/app/ta_hub/tests/test_index_view_degraded_mode.py
@@ -258,3 +258,83 @@ class IndexViewVrchatBoundaryTest(TestCase):
         self.assertNotIn(self.previous_special.id, special_ids)
         self.assertIn(self.current_event.id, event_ids)
         self.assertIn(self.current_lt.id, lt_ids)
+
+
+class IndexViewTodayHighlightTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    def _create_community(self, name):
+        return Community.objects.create(
+            name=name,
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Sun'],
+            frequency='Every week',
+            organizers='Highlight Organizer',
+            status='approved',
+            poster_image=SimpleUploadedFile(
+                f'{name}.png',
+                _create_test_image(),
+                content_type='image/png',
+            ),
+        )
+
+    @patch('ta_hub.views.get_vrchat_today')
+    @patch('ta_hub.views.timezone.localdate')
+    def test_today_events_are_highlighted_on_index_cards(self, mock_localdate, mock_get_vrchat_today):
+        """日本時間の今日に一致するトップページカードだけ本日開催として強調する"""
+        today = date(2026, 5, 3)
+        mock_localdate.return_value = today
+        mock_get_vrchat_today.return_value = today
+
+        today_community = self._create_community('Today Highlight Community')
+        future_community = self._create_community('Future Highlight Community')
+        today_event = Event.objects.create(
+            community=today_community,
+            date=today,
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Sun',
+        )
+        future_event = Event.objects.create(
+            community=future_community,
+            date=today + timedelta(days=1),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+        EventDetail.objects.create(
+            event=today_event,
+            detail_type='LT',
+            speaker='Today Speaker',
+            theme='Today LT',
+            status='approved',
+            start_time=time(22, 0),
+        )
+        EventDetail.objects.create(
+            event=future_event,
+            detail_type='LT',
+            speaker='Future Speaker',
+            theme='Future LT',
+            status='approved',
+            start_time=time(22, 0),
+        )
+
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'card shadow h-100 today-event-card')
+        self.assertContains(response, 'card event-card shadow today-event-card')
+        self.assertContains(response, '本日開催', count=2)
+
+        html = response.content.decode()
+        upcoming_events_section = html.split('毎日が技術学術祭', 1)[1]
+        future_event_card = upcoming_events_section.split(
+            'Future Highlight Community', 1
+        )[0].rsplit('<div class="card event-card', 1)[-1]
+        self.assertNotIn('today-event-card', future_event_card)

--- a/app/ta_hub/views.py
+++ b/app/ta_hub/views.py
@@ -56,6 +56,7 @@ class IndexView(TemplateView):
         context['show_vket_notice'] = current_datetime < vket_end_datetime
         context['vket_start_date'] = vket_start_datetime.date()
         context['vket_end_date'] = vket_end_datetime.date()
+        context['current_date'] = timezone.localdate()
         context['google_calendar_id'] = settings.GOOGLE_CALENDAR_ID
         logger.info(f"Vket notice visibility: {context['show_vket_notice']} (current: {current_datetime})")
 


### PR DESCRIPTION
## なぜこの変更が必要か

トップページの「予定されている発表一覧」と「VRChat技術学術系イベント」では、今日開催されるカードが他の日付のカードと同じ見た目で並んでいた。
利用者が当日参加できるイベントを見落としにくくするため、日本時間の今日に一致するカードを視覚的に強調する。

## 変更内容

- `IndexView` から日本時間の今日 `current_date` をテンプレートへ渡す
- 発表一覧カードとイベントカードで、開催日が `current_date` と一致する場合に強調クラスを付与
- 外枠強調に加えて「本日開催」バッジを表示し、色だけに依存しない見た目にする
- 今日開催カードだけが強調されることを確認するテストを追加

## 意思決定

### 採用アプローチ
- 一覧取得に使う `get_vrchat_today()` は変更せず、強調判定だけ `timezone.localdate()` で行う。理由: ユーザー指定の「日本時間の現在の日付」に合わせつつ、既存のVRChat向け4時区切り表示ロジックには影響させないため。

### トレードオフ
- テンプレート側の条件分岐で実装した。対象がトップページ2セクションに限定されており、データ構造やキャッシュに余計な変更を入れずに済むため。

## テスト

- [x] `docker compose exec -T vrc-ta-hub python manage.py test ta_hub.tests.test_index_view_degraded_mode`
- [x] `docker compose exec -T vrc-ta-hub python manage.py check`
- [x] `http://localhost:8015/` をPlaywrightで開いてトップページ表示を確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)