### PR TITLE
fix: フッターホバー時の横ズレを解消

### DIFF
--- a/app/ta_hub/templates/ta_hub/base.html
+++ b/app/ta_hub/templates/ta_hub/base.html
@@ -211,28 +211,30 @@
         }
 
         footer a {
-            transition: color 0.3s ease, transform 0.3s ease;
+            transition: color 0.2s ease;
+        }
+
+        footer ul li a {
+            display: inline-block;
+            text-underline-offset: 3px;
         }
 
         footer a:hover {
-            color: rgba(255, 255, 255, 0.8) !important;
-            transform: translateX(3px);
+            color: #ffffff !important;
+        }
+
+        footer ul li a:hover {
+            text-decoration: underline;
         }
 
         footer .bi {
-            transition: transform 0.3s ease;
-        }
-
-        footer a:hover .bi {
-            transform: scale(1.2);
-        }
-
-        footer ul li {
+            display: inline-block;
+            transform-origin: center;
             transition: transform 0.2s ease;
         }
 
-        footer ul li:hover {
-            transform: translateX(5px);
+        footer a:hover .bi {
+            transform: scale(1.15);
         }
 
         @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- footer の `a:hover` (`translateX(3px)`) と `ul li:hover` (`translateX(5px)`) が二重に効き、リンクがホバー時に最大 8px 右へズレてクリックしづらかった
- 特に X アイコンが動いてカーソルが外れる問題があったため、横方向の `transform` を廃止
- テキストリンクは色 (#fff) + 下線、アイコンは `transform-origin: center` の `scale(1.15)` のみで視覚フィードバック

## Test plan
- [x] フッターのテキストリンク (サイトマップ等) にホバーしても横にズレない
- [x] X / GitHub アイコンにホバーしてもクリック領域が動かず、安定してクリックできる
- [x] スマホ幅 (≤768px) でレイアウトが崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)