### PR TITLE
fix: LT保存ボタンの連打を防止

### DIFF
--- a/app/event/templates/event/includes/article_generation_submit_feedback.html
+++ b/app/event/templates/event/includes/article_generation_submit_feedback.html
@@ -170,6 +170,7 @@
         const submitButton = form.querySelector('[data-article-submit-button]');
         const defaultLabel = submitButton?.querySelector('[data-submit-default]');
         const loadingLabel = submitButton?.querySelector('[data-submit-loading]');
+        const loadingLabelDefaultHtml = loadingLabel?.innerHTML || '';
         const feedback = form.querySelector('[data-article-submit-feedback]');
         const feedbackTitle = form.querySelector('[data-article-submit-title]');
         const feedbackDetail = form.querySelector('[data-article-submit-detail]');
@@ -191,6 +192,7 @@
         ];
 
         let messageTimer = null;
+        let isSubmitting = false;
 
         function hasGenerationSource() {
             const youtubeUrl = form.querySelector('#id_youtube_url')?.value.trim();
@@ -238,6 +240,7 @@
                 defaultLabel.hidden = true;
             }
             if (loadingLabel) {
+                loadingLabel.innerHTML = loadingLabelDefaultHtml;
                 loadingLabel.hidden = false;
             }
             feedback.hidden = false;
@@ -248,13 +251,55 @@
             startMessageLoop();
         }
 
-        window.addEventListener('pageshow', stopMessageLoop);
-
-        form.addEventListener('submit', function() {
-            if (!shouldShowGenerationState()) {
+        function activateSavingState() {
+            if (!submitButton) {
                 return;
             }
-            activatePendingState();
+            submitButton.dataset.submitState = 'saving';
+            submitButton.disabled = true;
+            if (defaultLabel) {
+                defaultLabel.hidden = true;
+            }
+            if (loadingLabel) {
+                loadingLabel.innerHTML = '保存中…';
+                loadingLabel.hidden = false;
+            }
+            form.setAttribute('aria-busy', 'true');
+        }
+
+        function resetSubmitState() {
+            isSubmitting = false;
+            stopMessageLoop();
+            form.removeAttribute('aria-busy');
+            if (submitButton) {
+                submitButton.disabled = false;
+                delete submitButton.dataset.submitState;
+            }
+            if (defaultLabel) {
+                defaultLabel.hidden = false;
+            }
+            if (loadingLabel) {
+                loadingLabel.innerHTML = loadingLabelDefaultHtml;
+                loadingLabel.hidden = true;
+            }
+            if (feedback) {
+                feedback.hidden = true;
+            }
+        }
+
+        window.addEventListener('pageshow', resetSubmitState);
+
+        form.addEventListener('submit', function(event) {
+            if (isSubmitting) {
+                event.preventDefault();
+                return;
+            }
+            isSubmitting = true;
+            if (shouldShowGenerationState()) {
+                activatePendingState();
+                return;
+            }
+            activateSavingState();
         });
     })();
 </script>

--- a/app/event/tests/test_event_detail_template.py
+++ b/app/event/tests/test_event_detail_template.py
@@ -53,3 +53,29 @@ class EventDetailTemplateTest(SimpleTestCase):
             "show: ['theme', 'speaker', 'start_time', 'duration', 'slide_file', 'slide_url'",
             template,
         )
+
+    def test_article_submit_feedback_prevents_double_submit(self):
+        """保存ボタン連打による二重送信をフォーム側で止める."""
+        template = (
+            Path(__file__).resolve().parents[1] / "templates" / "event" / "includes"
+            / "article_generation_submit_feedback.html"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("let isSubmitting = false;", template)
+        self.assertIn("if (isSubmitting) {", template)
+        self.assertIn("event.preventDefault();", template)
+        self.assertIn("isSubmitting = true;", template)
+        self.assertIn("submitButton.disabled = true;", template)
+
+    def test_article_submit_feedback_shows_saving_state_without_generation(self):
+        """記事生成しない通常保存でも保存中表示に切り替える."""
+        template = (
+            Path(__file__).resolve().parents[1] / "templates" / "event" / "includes"
+            / "article_generation_submit_feedback.html"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("function activateSavingState()", template)
+        self.assertIn("submitButton.dataset.submitState = 'saving';", template)
+        self.assertIn("const loadingLabelDefaultHtml = loadingLabel?.innerHTML || '';", template)
+        self.assertIn("loadingLabel.innerHTML = '保存中…';", template)
+        self.assertIn("window.addEventListener('pageshow', resetSubmitState);", template)


### PR DESCRIPTION
## なぜこの変更が必要か

LT作成ページで保存ボタンを連打すると、押した回数分だけEventDetailが作成される可能性がありました。通常保存時は送信中のボタン無効化がなく、ユーザー操作だけで重複登録が起きるため対応します。

## 変更内容

- LT詳細フォームの共有submit処理で、初回送信後に保存ボタンを無効化
- 2回目以降のsubmitを `preventDefault()` で抑止
- 記事生成ありの場合は既存の生成中表示を維持
- 記事生成なしの通常保存では「保存中…」表示へ切り替え
- ブラウザバック時に送信状態をリセット

## 意思決定

通常保存と記事生成保存の両方が同じsubmitボタンを使っているため、サーバー側の重複判定を追加する前に、まずフォームの二重送信を共通includeで止める方針にしました。これにより、LT作成・編集と申請者編集の送信UIを同じ挙動で保てます。

## テスト

- [x] `docker compose run --rm -T vrc-ta-hub python manage.py test event.tests.test_event_detail_template event.tests.test_event_detail_permissions`
- [x] `git diff --check`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)