### PR TITLE
fix: Cloud Runホスト検証をミドルウェア初期化時に適用

### DIFF
--- a/app/website/middleware.py
+++ b/app/website/middleware.py
@@ -4,6 +4,7 @@ import os
 import re
 
 from django.core.exceptions import DisallowedHost
+from django.http import request as request_module
 
 from website.hosts import get_canonical_host, normalize_host
 
@@ -12,6 +13,8 @@ DEFAULT_CLOUD_RUN_SERVICE_NAMES = (
     'vrc-ta-hub',
     'vrc-ta-hub-dev',
 )
+
+_ORIGINAL_VALIDATE_HOST = request_module.validate_host
 
 
 def _build_cloud_run_service_names() -> tuple[str, ...]:
@@ -60,16 +63,13 @@ def _extract_disallowed_host(error: DisallowedHost) -> str:
 
 def install_cloud_run_preview_host_validator() -> None:
     """Django の Host 検証に Cloud Run preview host の限定許可を追加する。"""
-    from django.http import request as request_module
-
-    original_validate_host = request_module.validate_host
-    if getattr(original_validate_host, '_cloud_run_preview_host_validator', False):
+    if getattr(request_module.validate_host, '_cloud_run_preview_host_validator', False):
         return
 
     cloud_run_preview_host_pattern = _build_cloud_run_preview_host_pattern()
 
     def validate_host(host: str, allowed_hosts: list[str]) -> bool:
-        if original_validate_host(host, allowed_hosts):
+        if _ORIGINAL_VALIDATE_HOST(host, allowed_hosts):
             return True
 
         normalized_host = _normalize_preview_host_candidate(host)
@@ -83,6 +83,7 @@ class CanonicalCloudRunHostMiddleware:
     """Cloud Run のプレビューURLを正規ホストへ寄せる。"""
 
     def __init__(self, get_response):
+        install_cloud_run_preview_host_validator()
         self.get_response = get_response
         self.canonical_host = get_canonical_host()
         self.cloud_run_preview_host_pattern = _build_cloud_run_preview_host_pattern()

--- a/app/website/tests/test_host_middleware.py
+++ b/app/website/tests/test_host_middleware.py
@@ -2,12 +2,14 @@
 
 from asgiref.sync import async_to_sync
 from django.core.exceptions import DisallowedHost
+from django.http import request as request_module
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 
 from website.asgi import CloudRunHostCanonicalizingASGIApplication
 from website.middleware import (
     CanonicalCloudRunHostMiddleware,
+    _ORIGINAL_VALIDATE_HOST,
     install_cloud_run_preview_host_validator,
 )
 from website.wsgi import CloudRunHostCanonicalizingWSGIApplication
@@ -63,6 +65,28 @@ class CanonicalCloudRunHostMiddlewareTest(SimpleTestCase):
             request.get_host(),
             'canary---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
         )
+
+    @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+    )
+    def test_middleware_initialization_installs_preview_host_validator(self):
+        original_validate_host = request_module.validate_host
+        request_module.validate_host = _ORIGINAL_VALIDATE_HOST
+
+        try:
+            CanonicalCloudRunHostMiddleware(lambda request: HttpResponse('ok'))
+            request = self.request_factory.get(
+                '/healthz/',
+                HTTP_HOST='rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+            )
+
+            self.assertEqual(
+                request.get_host(),
+                'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app',
+            )
+        finally:
+            request_module.validate_host = original_validate_host
+            install_cloud_run_preview_host_validator()
 
     @override_settings(
         ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],


### PR DESCRIPTION
## なぜこの変更が必要か

- VRC技術学術Hub で観測された `django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: 'rev-24d1224---vrc-ta-hub-mhbhtr6sha-an.a.run.app'. ...` に対する TASK-1695 の自動修正として作成した差分です

## 変更内容

- `app/website/middleware.py`
- `app/website/tests/test_host_middleware.py`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
