### PR TITLE
fix: DB接続断時のAPI応答を安定化

### DIFF
--- a/app/api_v1/tests/test_database_reconnect.py
+++ b/app/api_v1/tests/test_database_reconnect.py
@@ -17,12 +17,36 @@ class TransientFailureListViewSet(viewsets.ViewSet):
         return Response({'attempts': self.attempts})
 
 
+class PersistentConnectFailureListViewSet(viewsets.ViewSet):
+    def list(self, request):
+        raise OperationalError(2002, "Can't connect to server on 'mysql.example.test' (115)")
+
+
+class HandshakeFailureListViewSet(viewsets.ViewSet):
+    def list(self, request):
+        raise OperationalError(
+            2013,
+            "Lost connection to server at 'handshake: reading initial communication packet'",
+        )
+
+
 class NonRetryableFailureListViewSet(viewsets.ViewSet):
     def list(self, request):
         raise OperationalError(1064, 'SQL syntax error')
 
 
 class RetryingListViewSet(DatabaseReconnectListMixin, TransientFailureListViewSet):
+    pass
+
+
+class PersistentConnectFailureRetryingListViewSet(
+    DatabaseReconnectListMixin,
+    PersistentConnectFailureListViewSet,
+):
+    pass
+
+
+class HandshakeFailureRetryingListViewSet(DatabaseReconnectListMixin, HandshakeFailureListViewSet):
     pass
 
 
@@ -42,6 +66,24 @@ class DatabaseReconnectListMixinTest(SimpleTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, {'attempts': 2})
+
+    def test_list_returns_503_when_mysql_connect_failure_persists(self):
+        view = PersistentConnectFailureRetryingListViewSet.as_view({'get': 'list'})
+        request = self.factory.get('/api/v1/community/')
+
+        response = view(request)
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.data, {'detail': 'Database temporarily unavailable.'})
+
+    def test_list_returns_503_when_mysql_handshake_failure_persists(self):
+        view = HandshakeFailureRetryingListViewSet.as_view({'get': 'list'})
+        request = self.factory.get('/api/v1/community/')
+
+        response = view(request)
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.data, {'detail': 'Database temporarily unavailable.'})
 
     def test_list_does_not_retry_non_disconnect_operational_error(self):
         view = NonRetryableListViewSet.as_view({'get': 'list'})

--- a/app/api_v1/views.py
+++ b/app/api_v1/views.py
@@ -2,7 +2,7 @@
 # from corsheaders.middleware import CorsMiddleware  # No longer needed
 import logging
 
-from django.db import close_old_connections
+from django.db import connections
 from django.db.utils import OperationalError
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -45,7 +45,13 @@ logger = logging.getLogger(__name__)
 class DatabaseReconnectListMixin:
     """MySQL の切断系エラー時に読み取り list API を一度だけ再試行する。"""
 
-    MYSQL_DISCONNECT_ERROR_CODES = {2006, 2013}
+    MYSQL_DISCONNECT_ERROR_CODES = {2002, 2006, 2013, 2055}
+    MYSQL_DISCONNECT_ERROR_MESSAGES = (
+        "can't connect",
+        "lost connection",
+        "reading initial communication packet",
+        "server has gone away",
+    )
 
     def list(self, request, *args, **kwargs):
         try:
@@ -55,17 +61,35 @@ class DatabaseReconnectListMixin:
                 raise
 
             logger.warning(
-                "Retrying %s.list after a transient database disconnect",
+                "Retrying %s.list after a transient database disconnect: %s",
                 self.__class__.__name__,
-                exc_info=True,
+                exc,
             )
-            close_old_connections()
-            return super().list(request, *args, **kwargs)
+            connections.close_all()
+            try:
+                return super().list(request, *args, **kwargs)
+            except OperationalError as retry_exc:
+                if not self._should_retry_after_disconnect(retry_exc):
+                    raise
+
+                logger.warning(
+                    "%s.list returned 503 because the database remained unavailable after reconnect: %s",
+                    self.__class__.__name__,
+                    retry_exc,
+                )
+                return Response(
+                    {"detail": "Database temporarily unavailable."},
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                )
 
     def _should_retry_after_disconnect(self, exc):
-        if not exc.args:
-            return False
-        return exc.args[0] in self.MYSQL_DISCONNECT_ERROR_CODES
+        if exc.args:
+            code = exc.args[0]
+            if isinstance(code, int) and code in self.MYSQL_DISCONNECT_ERROR_CODES:
+                return True
+
+        message = str(exc).lower()
+        return any(fragment in message for fragment in self.MYSQL_DISCONNECT_ERROR_MESSAGES)
 
 
 class CommunityFilter(filters.FilterSet):


### PR DESCRIPTION
## なぜこの変更が必要か

- VRC技術学術Hub で観測された `MySQLdb.OperationalError: (2002, "Can't connect to server on 'mysql.cahuqreinaou.ap-northeast-1.rds.amazonaws.com' (1...` に対する TASK-1698 の自動修正として作成した差分です

## 変更内容

- `app/api_v1/tests/test_database_reconnect.py`
- `app/api_v1/views.py`

## 意思決定

### 採用アプローチ
- 実行エージェントが差分を作成し、fix-flow worker がリスク評価後に PR を作成する方式を維持。
  理由: PR 作成経路を一元化し、重複 PR と安全ゲートのバイパスを防ぐため

### トレードオフ
- 安全な worker 管理 > 実行エージェントの自由な PR 本文:
  詳細な検証結果の転記は限定的になるが、PR 作成と auto-merge 判定を同じ経路で扱える

### 技術的負債
- 実行エージェントの完了報告から詳細なテスト結果を構造化抽出して PR 本文へ転記する処理は未実装

## テスト

- [x] fix-flow worker が自動修正を完了
- [x] PR 作成前のリスク評価を通過
- [ ] 実行エージェントの個別テスト結果は fix-flow 実行ログで確認

---
🤖 Generated with [Codex](https://Codex.com/Codex)
