### PR TITLE
X投稿の重み付き文字数超過を防ぐ

### DIFF
--- a/app/twitter/management/commands/regenerate_ready_tweets.py
+++ b/app/twitter/management/commands/regenerate_ready_tweets.py
@@ -10,10 +10,11 @@ from django.core.management.base import BaseCommand
 
 from twitter.models import TweetQueue
 from twitter.tweet_generator import (
-    MAX_BODY_LINES,
     count_body_lines,
+    count_tweet_length,
     get_generator,
     get_tweet_image_url,
+    validate_tweet_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -72,9 +73,10 @@ class Command(BaseCommand):
         targets = []
         for item in candidates:
             body_lines = count_body_lines(item.generated_text)
-            needs_regen = regenerate_all or body_lines > MAX_BODY_LINES
+            validation_errors = validate_tweet_text(item.generated_text)
+            needs_regen = regenerate_all or bool(validation_errors)
             if needs_regen:
-                targets.append((item, body_lines))
+                targets.append((item, body_lines, validation_errors))
 
         self.stdout.write(
             f"ready キュー: {len(candidates)} 件, 再生成対象: {len(targets)} 件 "
@@ -85,8 +87,14 @@ class Command(BaseCommand):
         failed = 0
         still_over_limit = 0
 
-        for item, old_lines in targets:
-            prefix = f"#{item.pk} [{item.tweet_type}] 旧行数={old_lines}"
+        for item, old_lines, old_errors in targets:
+            old_weighted = count_tweet_length(item.generated_text)
+            prefix = (
+                f"#{item.pk} [{item.tweet_type}] "
+                f"旧weighted={old_weighted} 旧行数={old_lines}"
+            )
+            if old_errors:
+                prefix = f"{prefix} ({', '.join(old_errors)})"
             if dry_run:
                 self.stdout.write(f"  {prefix} -> (dry-run skip)")
                 continue
@@ -117,6 +125,8 @@ class Command(BaseCommand):
                 continue
 
             new_lines = count_body_lines(text)
+            new_weighted = count_tweet_length(text)
+            new_errors = validate_tweet_text(text)
             item.generated_text = text
 
             if not item.image_url:
@@ -130,15 +140,16 @@ class Command(BaseCommand):
                 item.save(update_fields=["generated_text"])
 
             updated += 1
-            if new_lines > MAX_BODY_LINES:
+            if new_errors:
                 still_over_limit += 1
                 self.stdout.write(
                     self.style.WARNING(
-                        f"  {prefix} -> 新行数={new_lines} (依然として制約超過)"
+                        f"  {prefix} -> 新weighted={new_weighted} 新行数={new_lines} "
+                        f"({', '.join(new_errors)})"
                     )
                 )
             else:
-                self.stdout.write(f"  {prefix} -> 新行数={new_lines} (OK)")
+                self.stdout.write(f"  {prefix} -> 新weighted={new_weighted} 新行数={new_lines} (OK)")
 
         self.stdout.write("")
         self.stdout.write(

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -1923,6 +1923,17 @@ class PostTweetFunctionTest(TestCase):
             result = post_tweet("テスト")
         self.assertFalse(result["ok"])
 
+    @patch("twitter.x_api.requests.post")
+    def test_post_tweet_rejects_weighted_length_before_api_call(self, mock_post):
+        """Python の len が280以内でも重み付き超過なら X API を呼ばない"""
+        with patch.dict("os.environ", self.OAUTH1_ENV):
+            from twitter.x_api import post_tweet
+            result = post_tweet("あ" * 141)
+
+        self.assertFalse(result["ok"])
+        self.assertIn("weighted_length", result["error_body"])
+        mock_post.assert_not_called()
+
 
 class UploadMediaFunctionTest(TestCase):
     """upload_media 関数のテスト"""
@@ -2207,6 +2218,47 @@ class TweetGeneratorTest(TestCase):
         self.assertIn("Pythonのテスト技法", user_prompt)
         self.assertIn("告知ポスト", user_prompt)
         self.assertNotIn("告知ツイート", user_prompt)
+
+    @patch("twitter.signals.threading.Thread")
+    @patch("twitter.tweet_generator._call_llm")
+    def test_lt_generator_fallback_fits_long_theme_under_weighted_limit(self, mock_llm, _mock_thread):
+        """LLM が長い本文を返し続けても LT 告知を決定的に280以内へ収める"""
+        mock_llm.return_value = (
+            "5/16(土) 22:00~ 「計算と自然」集会\n\n"
+            "nconcさん「続々 Claw Codeを参考にした、Mathematica-Claude Codeブリッジへの反復ループ型エージェント機能の追加について」\n"
+            "自律型エージェントの実装で計算体験がどう変わるかぜひ会場で確かめてください\n\n"
+            "詳細はこちら https://vrc-ta-hub.com/community/71/\n"
+            "#計算と自然\n"
+            "#VRChat技術学術"
+        )
+        self.community.name = "「計算と自然」集会"
+        self.community.twitter_hashtag = "計算と自然"
+        self.community.save(update_fields=["name", "twitter_hashtag"])
+        self.event.date = datetime.date(2026, 5, 16)
+        self.event.start_time = datetime.time(22, 0)
+        self.event.save(update_fields=["date", "start_time"])
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type="LT",
+            status="approved",
+            speaker="nconc",
+            theme="続々 Claw Codeを参考にした、Mathematica-Claude Codeブリッジへの反復ループ型エージェント機能の追加について",
+            start_time=datetime.time(22, 15),
+        )
+        queue = TweetQueue.objects.create(
+            tweet_type="lt",
+            community=self.community,
+            event=self.event,
+            event_detail=detail,
+            status="generating",
+        )
+
+        from twitter.tweet_generator import count_tweet_length, get_generator, is_tweet_text_valid
+        result = get_generator("lt")(queue)
+
+        self.assertTrue(is_tweet_text_valid(result))
+        self.assertLessEqual(count_tweet_length(result), 280)
+        self.assertNotIn("自律型エージェントの実装", result)
 
     @patch("twitter.signals.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")

--- a/app/twitter/tests/test_tweet_length.py
+++ b/app/twitter/tests/test_tweet_length.py
@@ -9,6 +9,8 @@ from twitter.tweet_generator import (
     _generate_with_retry,
     count_body_lines,
     count_tweet_length,
+    is_tweet_text_valid,
+    validate_tweet_text,
 )
 
 
@@ -125,6 +127,25 @@ class CountBodyLinesTest(TestCase):
         self.assertEqual(count_body_lines(text), 1)
 
 
+class TweetValidationTest(TestCase):
+    """投稿前バリデーションのテスト"""
+
+    def test_detects_weighted_length_over_limit_even_if_python_len_is_short(self):
+        text = (
+            "5/16(土) 22:00~ 「計算と自然」集会\n\n"
+            "nconcさん「続々 Claw Codeを参考にした、Mathematica-Claude Codeブリッジへの反復ループ型エージェント機能の追加について」\n"
+            "自律型エージェントの実装で計算体験がどう変わるかぜひ会場で確かめてください\n\n"
+            "詳細はこちら https://vrc-ta-hub.com/community/71/\n"
+            "#計算と自然\n"
+            "#VRChat技術学術"
+        )
+
+        self.assertLessEqual(len(text), 280)
+        self.assertGreater(count_tweet_length(text), TWEET_MAX_WEIGHTED_LENGTH)
+        self.assertFalse(is_tweet_text_valid(text))
+        self.assertIn("weighted_length=", validate_tweet_text(text)[0])
+
+
 class GenerateWithRetryTest(TestCase):
     """_generate_with_retry のテスト"""
 
@@ -153,13 +174,26 @@ class GenerateWithRetryTest(TestCase):
         self.assertEqual(result, "OK" * 10)
         self.assertEqual(call_count, 3)
 
-    def test_returns_last_result_after_all_retries(self):
-        """全リトライ後も超過なら最後の結果を返す"""
+    def test_returns_none_after_all_retries_without_fallback(self):
+        """全リトライ後も超過し、fallback がなければ None を返す"""
         def fake_generator(target_chars=140):
             return "あ" * 200
 
         result = _generate_with_retry(fake_generator, max_retries=3)
-        self.assertEqual(result, "あ" * 200)
+        self.assertIsNone(result)
+
+    def test_uses_fallback_after_all_retries(self):
+        """LLM が長文を返し続けたら決定的フォールバックへ切り替える"""
+        def fake_generator(target_chars=140):
+            return "あ" * 200
+
+        result = _generate_with_retry(
+            fake_generator,
+            max_retries=1,
+            fallback_fn=lambda: "短い告知",
+        )
+
+        self.assertEqual(result, "短い告知")
 
     def test_returns_none_on_generation_failure(self):
         """生成失敗(None)時はリトライせずNoneを返す"""

--- a/app/twitter/tweet_generator.py
+++ b/app/twitter/tweet_generator.py
@@ -4,6 +4,7 @@ OpenRouter API 経由で LLM を呼び出し、各種告知ポストを生成す
 既存の twitter/utils.py (テンプレートベース生成) とは独立したモジュール。
 """
 
+import inspect
 import logging
 import os
 import re
@@ -24,6 +25,7 @@ TWEET_MAX_WEIGHTED_LENGTH = 280
 URL_WEIGHTED_LENGTH = 23
 RETRY_TARGET_CHARS_STEP = 20
 MAX_BODY_LINES = 3
+TRUNCATION_SUFFIX = "..."
 
 WEEKDAY_NAMES = {
     "Sun": "日", "Mon": "月", "Tue": "火", "Wed": "水",
@@ -69,54 +71,275 @@ def count_body_lines(text: str) -> int:
     return count
 
 
-def _generate_with_retry(generate_fn, *args, max_retries=3, **kwargs) -> str | None:
+def validate_tweet_text(text: str) -> list[str]:
+    """投稿前に満たすべき X 向け制約の違反理由を返す。"""
+    errors = []
+    length = count_tweet_length(text)
+    if length > TWEET_MAX_WEIGHTED_LENGTH:
+        errors.append(f"weighted_length={length}>{TWEET_MAX_WEIGHTED_LENGTH}")
+
+    body_lines = count_body_lines(text)
+    if body_lines > MAX_BODY_LINES:
+        errors.append(f"body_lines={body_lines}>{MAX_BODY_LINES}")
+
+    return errors
+
+
+def is_tweet_text_valid(text: str) -> bool:
+    """生成済み本文が X 投稿前制約を満たすか返す。"""
+    return not validate_tweet_text(text)
+
+
+def _build_tweet(body_lines: list[str], url: str, hashtag_suffix: str) -> str:
+    lines = [line.strip() for line in body_lines if line and line.strip()]
+    if url:
+        lines.extend(["", url.strip()])
+    hashtags = [line.strip() for line in hashtag_suffix.splitlines() if line.strip()]
+    lines.extend(hashtags)
+    return "\n".join(lines)
+
+
+def _trim_to_weight(text: str, max_weight: int) -> str:
+    if max_weight <= 0:
+        return ""
+    if count_tweet_length(text) <= max_weight:
+        return text
+
+    suffix = TRUNCATION_SUFFIX
+    suffix_weight = count_tweet_length(suffix)
+    if max_weight <= suffix_weight:
+        suffix = ""
+        suffix_weight = 0
+
+    chars = []
+    current = 0
+    for ch in text:
+        weight = 2 if ord(ch) >= 0x1100 else 1
+        if current + weight + suffix_weight > max_weight:
+            break
+        chars.append(ch)
+        current += weight
+
+    return "".join(chars).rstrip() + suffix
+
+
+def _fit_candidate(
+    body_lines: list[str],
+    url: str,
+    hashtag_suffix: str,
+    trim_indexes: list[int],
+) -> str | None:
+    candidate = _build_tweet(body_lines, url, hashtag_suffix)
+    if is_tweet_text_valid(candidate):
+        return candidate
+
+    fitted_lines = body_lines[:]
+    for index in trim_indexes:
+        if index >= len(fitted_lines):
+            continue
+
+        for _ in range(3):
+            candidate = _build_tweet(fitted_lines, url, hashtag_suffix)
+            overage = count_tweet_length(candidate) - TWEET_MAX_WEIGHTED_LENGTH
+            if overage <= 0:
+                break
+
+            current_line = fitted_lines[index]
+            current_weight = count_tweet_length(current_line)
+            fitted_lines[index] = _trim_to_weight(current_line, current_weight - overage)
+            if fitted_lines[index] == current_line:
+                break
+
+        candidate = _build_tweet(fitted_lines, url, hashtag_suffix)
+        if is_tweet_text_valid(candidate):
+            return candidate
+
+    return None
+
+
+def _fallback_new_community_tweet(community, first_event=None) -> str | None:
+    weekdays_str = _format_weekdays(community.weekdays)
+    name = _sanitize_for_prompt(community.name)
+    url = f"詳細はこちら https://vrc-ta-hub.com/community/{community.pk}/"
+    hashtag_suffix = _build_hashtag_suffix(community)
+
+    if first_event:
+        weekday = WEEKDAY_NAMES.get(first_event.date.strftime("%a"), "")
+        schedule = f"{first_event.date.strftime('%-m/%-d')}({weekday}) {first_event.start_time.strftime('%H:%M')}~"
+    else:
+        schedule = f"{community.frequency} {weekdays_str}曜日 {community.start_time.strftime('%H:%M')}~"
+
+    body_lines = [
+        f"新しい集会「{name}」がはじまります",
+        schedule,
+    ]
+    return _fit_candidate(body_lines, url, hashtag_suffix, [0])
+
+
+def _fallback_presentation_tweet(event_detail, *, special: bool = False) -> str | None:
+    event = event_detail.event
+    community = event.community
+    weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
+    label = " 特別回" if special else ""
+    body_lines = [
+        f"{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~ {_sanitize_for_prompt(community.name)}{label}",
+        f"{_sanitize_for_prompt(event_detail.speaker)}さん「{_sanitize_for_prompt(event_detail.theme)}」",
+    ]
+    url = f"詳細はこちら https://vrc-ta-hub.com/community/{community.pk}/"
+    return _fit_candidate(body_lines, url, _build_hashtag_suffix(community), [1, 0])
+
+
+def _fallback_slide_share_tweet(event_detail) -> str | None:
+    community = event_detail.event.community
+    resources = []
+    if event_detail.slide_url or event_detail.slide_file:
+        resources.append("スライド")
+    if event_detail.youtube_url:
+        resources.append("動画")
+    resources_text = "・".join(resources) or "資料"
+    body_lines = [
+        (
+            f"{_sanitize_for_prompt(community.name)} "
+            f"{_sanitize_for_prompt(event_detail.speaker)}さん"
+            f"「{_sanitize_for_prompt(event_detail.theme)}」"
+        ),
+        f"{resources_text}が公開されました",
+    ]
+    url = f"詳細はこちら https://vrc-ta-hub.com/event/detail/{event_detail.pk}/"
+    return _fit_candidate(body_lines, url, _build_hashtag_suffix(community), [0])
+
+
+def _fallback_daily_reminder_tweet(event) -> str | None:
+    details = list(
+        event.details.filter(
+            status="approved",
+            detail_type__in=("LT", "SPECIAL"),
+        ).order_by("start_time", "pk")
+    )
+    if not details:
+        return None
+
+    community = event.community
+    name = _sanitize_for_prompt(community.name)
+    url = f"詳細はこちら https://vrc-ta-hub.com/community/{community.pk}/"
+    hashtag_suffix = _build_hashtag_suffix(community)
+
+    for count in range(min(3, len(details)), 0, -1):
+        body_lines = [f"今夜 {event.start_time.strftime('%H:%M')}〜 {name}"]
+        for detail in details[:count]:
+            body_lines.append(
+                f"{_sanitize_for_prompt(detail.speaker)}さん"
+                f"「{_sanitize_for_prompt(detail.theme)}」"
+            )
+        fitted = _fit_candidate(
+            body_lines,
+            url,
+            hashtag_suffix,
+            list(range(len(body_lines) - 1, -1, -1)),
+        )
+        if fitted:
+            return fitted
+
+    return None
+
+
+def _validation_feedback(text: str) -> str:
+    length = count_tweet_length(text)
+    body_lines = count_body_lines(text)
+    overage = max(0, length - TWEET_MAX_WEIGHTED_LENGTH)
+    return (
+        f"前回出力は weighted_length={length}/{TWEET_MAX_WEIGHTED_LENGTH}, "
+        f"body_lines={body_lines}/{MAX_BODY_LINES} でした。"
+        f"{overage} weighted 以上短くし、補足文を最優先で削ってください。"
+    )
+
+
+def _call_generate_fn(generate_fn, *args, target_chars: int, validation_feedback: str, **kwargs):
+    parameters = inspect.signature(generate_fn).parameters
+    accepts_feedback = (
+        "validation_feedback" in parameters
+        or any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
+    )
+    if accepts_feedback:
+        return generate_fn(
+            *args,
+            target_chars=target_chars,
+            validation_feedback=validation_feedback,
+            **kwargs,
+        )
+    return generate_fn(*args, target_chars=target_chars, **kwargs)
+
+
+def _generate_with_retry(
+    generate_fn,
+    *args,
+    max_retries=3,
+    fallback_fn=None,
+    **kwargs,
+) -> str | None:
     """生成関数をリトライラッパーで実行する。
 
     1. target_chars=140 で生成
     2. count_tweet_length() と count_body_lines() でバリデーション
        （文字数 <= TWEET_MAX_WEIGHTED_LENGTH かつ 本文行数 <= MAX_BODY_LINES）
     3. どちらか違反していたら target_chars を RETRY_TARGET_CHARS_STEP ずつ減らしてリトライ
-    4. max_retries 回リトライ後も違反している場合は最後の結果を返す
+    4. max_retries 回リトライ後も違反している場合は決定的な圧縮にフォールバック
     """
     target_chars = 140
     result = None
+    validation_feedback = ""
 
     for attempt in range(max_retries + 1):
-        result = generate_fn(*args, target_chars=target_chars, **kwargs)
+        result = _call_generate_fn(
+            generate_fn,
+            *args,
+            target_chars=target_chars,
+            validation_feedback=validation_feedback,
+            **kwargs,
+        )
         if result is None:
             return None
 
-        length = count_tweet_length(result)
-        body_lines = count_body_lines(result)
-        length_ok = length <= TWEET_MAX_WEIGHTED_LENGTH
-        lines_ok = body_lines <= MAX_BODY_LINES
+        errors = validate_tweet_text(result)
 
-        if length_ok and lines_ok:
+        if not errors:
             if attempt > 0:
                 logger.info(
                     "Tweet validation OK after %d retries (weighted=%d, body_lines=%d, target_chars=%d)",
                     attempt,
-                    length,
-                    body_lines,
+                    count_tweet_length(result),
+                    count_body_lines(result),
                     target_chars,
                 )
             return result
 
-        reasons = []
-        if not length_ok:
-            reasons.append(f"length={length}>{TWEET_MAX_WEIGHTED_LENGTH}")
-        if not lines_ok:
-            reasons.append(f"body_lines={body_lines}>{MAX_BODY_LINES}")
         logger.warning(
             "Tweet validation failed (%s, attempt=%d/%d, target_chars=%d). Retrying.",
-            ", ".join(reasons),
+            ", ".join(errors),
             attempt + 1,
             max_retries + 1,
             target_chars,
         )
+        validation_feedback = _validation_feedback(result)
         target_chars -= RETRY_TARGET_CHARS_STEP
 
-    return result
+    if fallback_fn is None:
+        return None
+
+    fallback_result = fallback_fn(*args)
+    if fallback_result and is_tweet_text_valid(fallback_result):
+        logger.info(
+            "Tweet deterministic fallback succeeded (weighted=%d, body_lines=%d)",
+            count_tweet_length(fallback_result),
+            count_body_lines(fallback_result),
+        )
+        return fallback_result
+
+    logger.error(
+        "Tweet deterministic fallback failed after generation retries: %s",
+        validate_tweet_text(fallback_result or ""),
+    )
+    return None
 
 
 def _sanitize_for_prompt(text: str, max_length: int = SANITIZE_MAX_LENGTH) -> str:
@@ -187,7 +410,12 @@ BODY_LINE_CONSTRAINT = (
 )
 
 
-def generate_new_community_tweet(community, first_event=None, target_chars=140) -> str | None:
+def generate_new_community_tweet(
+    community,
+    first_event=None,
+    target_chars=140,
+    validation_feedback="",
+) -> str | None:
     """新規集会の告知ポストを生成する。
 
     Args:
@@ -218,6 +446,7 @@ def generate_new_community_tweet(community, first_event=None, target_chars=140) 
 集会名: {name}
 開催: {community.frequency} {weekdays_str}曜日 {community.start_time.strftime('%H:%M')}~
 紹介: {description}{event_info}
+{validation_feedback}
 
 ## 必須要素（必ず本文に含めること）
 1. 集会名
@@ -249,7 +478,7 @@ def generate_new_community_tweet(community, first_event=None, target_chars=140) 
     return _call_llm(system_prompt, user_prompt)
 
 
-def generate_lt_tweet(event_detail, target_chars=140) -> str | None:
+def generate_lt_tweet(event_detail, target_chars=140, validation_feedback="") -> str | None:
     """発表告知ポストを生成する。
 
     Args:
@@ -276,6 +505,7 @@ def generate_lt_tweet(event_detail, target_chars=140) -> str | None:
 日時: {event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~
 発表者: {speaker}
 テーマ: {theme}
+{validation_feedback}
 
 ## 必須要素（必ず本文に含めること）
 1. 集会名（「{name}」）
@@ -310,7 +540,7 @@ def generate_lt_tweet(event_detail, target_chars=140) -> str | None:
     return _call_llm(system_prompt, user_prompt)
 
 
-def generate_slide_share_tweet(event_detail, target_chars=140) -> str | None:
+def generate_slide_share_tweet(event_detail, target_chars=140, validation_feedback="") -> str | None:
     """スライド/記事共有ポストを生成する。
 
     Args:
@@ -344,6 +574,7 @@ def generate_slide_share_tweet(event_detail, target_chars=140) -> str | None:
 発表者: {speaker}
 テーマ: {theme}
 公開された資料: {resources_text}
+{validation_feedback}
 
 ## 必須要素（必ず本文に含めること）
 1. 集会名（「{name}」）
@@ -379,7 +610,7 @@ def generate_slide_share_tweet(event_detail, target_chars=140) -> str | None:
     return _call_llm(system_prompt, user_prompt)
 
 
-def generate_daily_reminder_tweet(event, target_chars=140) -> str | None:
+def generate_daily_reminder_tweet(event, target_chars=140, validation_feedback="") -> str | None:
     """当日開催イベントのリマインダーポストを生成する。"""
     approved_details = list(
         event.details.filter(
@@ -418,6 +649,7 @@ def generate_daily_reminder_tweet(event, target_chars=140) -> str | None:
 登録発表数: {presentation_count}件（※この数字は本文に書かない。背景情報として参照するだけ）
 発表一覧:
 {chr(10).join(presentations)}{extra_line}
+{validation_feedback}
 
 ## 出力フォーマット（本文は3行以内、この構造に厳密に従うこと）
 
@@ -484,17 +716,30 @@ def get_generator(tweet_type: str):
     """
     generator_map = {
         "new_community": lambda qi: _generate_with_retry(
-            generate_new_community_tweet, qi.community, qi.event
+            generate_new_community_tweet,
+            qi.community,
+            qi.event,
+            fallback_fn=_fallback_new_community_tweet,
         ),
-        "lt": lambda qi: _generate_with_retry(generate_lt_tweet, qi.event_detail),
+        "lt": lambda qi: _generate_with_retry(
+            generate_lt_tweet,
+            qi.event_detail,
+            fallback_fn=_fallback_presentation_tweet,
+        ),
         "special": lambda qi: _generate_with_retry(
-            generate_special_event_tweet, qi.event_detail
+            generate_special_event_tweet,
+            qi.event_detail,
+            fallback_fn=lambda detail: _fallback_presentation_tweet(detail, special=True),
         ),
         "daily_reminder": lambda qi: _generate_with_retry(
-            generate_daily_reminder_tweet, qi.event
+            generate_daily_reminder_tweet,
+            qi.event,
+            fallback_fn=_fallback_daily_reminder_tweet,
         ),
         "slide_share": lambda qi: _generate_with_retry(
-            generate_slide_share_tweet, qi.event_detail
+            generate_slide_share_tweet,
+            qi.event_detail,
+            fallback_fn=_fallback_slide_share_tweet,
         ),
     }
     return generator_map.get(tweet_type)
@@ -546,7 +791,7 @@ def get_tweet_image_url(queue_item) -> str:
     return get_poster_image_url(queue_item.community)
 
 
-def generate_special_event_tweet(event_detail, target_chars=140) -> str | None:
+def generate_special_event_tweet(event_detail, target_chars=140, validation_feedback="") -> str | None:
     """特別回告知ポストを生成する。
 
     Args:
@@ -573,6 +818,7 @@ def generate_special_event_tweet(event_detail, target_chars=140) -> str | None:
 日時: {event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~
 発表者/ゲスト: {speaker}
 テーマ: {theme}
+{validation_feedback}
 
 ## 必須要素（必ず本文に含めること）
 1. 集会名（「{name}」）

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -257,6 +257,8 @@ def _post_tweet_queue_item(queue_item, *, failure_status: str | None = 'failed')
     queue_item.error_message = (
         f'X API投稿に失敗 (status={status_code})' if status_code else 'X API投稿に失敗'
     )
+    if result.get("error_body"):
+        queue_item.error_message = f"{queue_item.error_message}: {result['error_body'][:300]}"
     notify_tweet_post_failure(queue_item, result)
     return {
         "id": queue_item.pk, "status": "failed", "error": "post_failed",

--- a/app/twitter/x_api.py
+++ b/app/twitter/x_api.py
@@ -12,6 +12,8 @@ from urllib.parse import urlparse
 import requests
 from requests_oauthlib import OAuth1
 
+from twitter.tweet_generator import validate_tweet_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,7 +37,6 @@ X_API_TWEET_URL = "https://api.x.com/2/tweets"
 X_MEDIA_UPLOAD_URL = "https://upload.twitter.com/1.1/media/upload.json"
 REQUEST_TIMEOUT_SECONDS = 30
 MEDIA_UPLOAD_TIMEOUT_SECONDS = 60
-MAX_TWEET_LENGTH = 280
 MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5MB (X API の上限)
 ALLOWED_IMAGE_DOMAINS = frozenset({"data.vrc-ta-hub.com"})
 IMAGE_DOWNLOAD_CHUNK_SIZE = 8192
@@ -143,7 +144,7 @@ def post_tweet(text: str, media_ids: list[str] | None = None) -> PostTweetResult
     """X API v2 でツイートを投稿する（OAuth 1.0a User Context）。
 
     Args:
-        text: 投稿するテキスト (280文字以内)
+        text: 投稿するテキスト (X の重み付き280以内)
         media_ids: 添付するメディアIDのリスト (任意)
 
     Returns:
@@ -155,13 +156,15 @@ def post_tweet(text: str, media_ids: list[str] | None = None) -> PostTweetResult
         logger.warning("Blocked X API tweet post in test environment")
         return _failure_result(error_body="Blocked in test environment")
 
-    if not text or len(text) > MAX_TWEET_LENGTH:
-        logger.error(
-            "Tweet text is empty or exceeds %d characters: %d",
-            MAX_TWEET_LENGTH,
-            len(text) if text else 0,
-        )
-        return _failure_result(error_body="Tweet text is empty or too long")
+    if not text:
+        logger.error("Tweet text is empty")
+        return _failure_result(error_body="Tweet text is empty")
+
+    validation_errors = validate_tweet_text(text)
+    if validation_errors:
+        error_body = f"Tweet text violates local validation: {', '.join(validation_errors)}"
+        logger.error(error_body)
+        return _failure_result(error_body=error_body)
 
     auth = _get_oauth1()
     if not auth:


### PR DESCRIPTION
## Summary
- X投稿本文の重み付き文字数と本文行数を共通バリデーション化
- LLMリトライ後も超過する場合に種別ごとの決定的フォールバックで短縮
- 投稿直前と ready キュー再生成コマンドでも同じ制約を確認

## Tests
- docker compose exec -T vrc-ta-hub python manage.py test twitter.tests
- git diff --check

## Notes
- queue #113 のように Python len は280以内でも X重み付き文字数が超過するケースを防ぎます。