### PR TITLE
fix: スライド共有投稿のサムネイル画像を再同期

### DIFF
--- a/app/event/forms.py
+++ b/app/event/forms.py
@@ -385,8 +385,10 @@ class EventDetailForm(forms.ModelForm):
         instance = super().save(commit=commit)
         if commit:
             from event.libs import ensure_pdf_thumbnail
+            from twitter.signals import sync_slide_share_queue_image
 
             ensure_pdf_thumbnail(instance, save=True)
+            sync_slide_share_queue_image(instance)
         return instance
 
 
@@ -448,8 +450,10 @@ class LTApplicationEditForm(forms.ModelForm):
         instance = super().save(commit=commit)
         if commit:
             from event.libs import ensure_pdf_thumbnail
+            from twitter.signals import sync_slide_share_queue_image
 
             ensure_pdf_thumbnail(instance, save=True)
+            sync_slide_share_queue_image(instance)
         return instance
 
 

--- a/app/event/tests/test_event_detail_form.py
+++ b/app/event/tests/test_event_detail_form.py
@@ -2,12 +2,15 @@
 from datetime import date, time, timedelta
 from unittest.mock import patch
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, RequestFactory
+from django.test import override_settings
 from django.contrib.auth import get_user_model
 
 from community.models import Community
 from event.forms import EventDetailForm, LTApplicationEditForm
 from event.models import Event, EventDetail
+from twitter.models import TweetQueue
 from vket.models import VketCollaboration, VketParticipation
 
 User = get_user_model()
@@ -150,6 +153,68 @@ class EventDetailFormCleanTest(TestCase):
 
         self.assertEqual(saved, self.existing_detail)
         mock_ensure_pdf_thumbnail.assert_called_once_with(saved, save=True)
+
+    @override_settings(AWS_S3_CUSTOM_DOMAIN='data.vrc-ta-hub.com')
+    @patch('event.libs.ensure_pdf_thumbnail')
+    def test_event_detail_form_save_syncs_slide_share_thumbnail_image(self, mock_ensure_pdf_thumbnail):
+        """フォーム保存後に生成されたPDFサムネイルを未投稿slide_shareキューへ反映する."""
+        request = self._create_request()
+        past_event = Event.objects.create(
+            community=self.community,
+            date=date.today() - timedelta(days=1),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Mon',
+        )
+        detail = EventDetail.objects.create(
+            event=past_event,
+            detail_type='LT',
+            status='approved',
+            theme='Past Theme',
+            speaker='Past Speaker',
+            start_time=time(22, 0),
+            duration=30,
+        )
+        TweetQueue.objects.all().delete()
+
+        def set_thumbnail(instance, save=False):
+            instance.thumbnail_image = 'thumbnail/generated.jpg'
+            EventDetail.objects.filter(pk=instance.pk).update(
+                thumbnail_image='thumbnail/generated.jpg',
+            )
+            return True
+
+        mock_ensure_pdf_thumbnail.side_effect = set_thumbnail
+        form_data = {
+            'detail_type': 'LT',
+            'theme': 'Past Theme',
+            'speaker': 'Past Speaker',
+            'start_time': '22:00',
+            'duration': 30,
+            'slide_url': '',
+            'youtube_url': '',
+            'h1': '',
+            'contents': '',
+            'generate_blog_article': False,
+        }
+        pdf = SimpleUploadedFile(
+            'slides.pdf',
+            b'%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF',
+            content_type='application/pdf',
+        )
+        form = EventDetailForm(
+            data=form_data,
+            files={'slide_file': pdf},
+            request=request,
+            instance=detail,
+        )
+
+        self.assertTrue(form.is_valid(), msg=f"Form errors: {form.errors}")
+        form.save()
+
+        queue = TweetQueue.objects.get(tweet_type='slide_share', event_detail=detail)
+        self.assertIn('thumbnail/generated.jpg', queue.image_url)
+        mock_ensure_pdf_thumbnail.assert_called_once()
 
     @patch('event.libs.ensure_pdf_thumbnail')
     def test_lt_application_edit_form_save_generates_pdf_thumbnail(self, mock_ensure_pdf_thumbnail):

--- a/app/twitter/management/commands/regenerate_ready_tweets.py
+++ b/app/twitter/management/commands/regenerate_ready_tweets.py
@@ -74,9 +74,14 @@ class Command(BaseCommand):
         for item in candidates:
             body_lines = count_body_lines(item.generated_text)
             validation_errors = validate_tweet_text(item.generated_text)
-            needs_regen = regenerate_all or bool(validation_errors)
-            if needs_regen:
-                targets.append((item, body_lines, validation_errors))
+            image_url = get_tweet_image_url(item) if item.tweet_type == "slide_share" else ""
+            needs_image_sync = bool(image_url and item.image_url != image_url)
+            needs_text_regen = regenerate_all or bool(validation_errors)
+            if needs_text_regen or needs_image_sync:
+                targets.append((
+                    item, body_lines, validation_errors, image_url,
+                    needs_text_regen,
+                ))
 
         self.stdout.write(
             f"ready キュー: {len(candidates)} 件, 再生成対象: {len(targets)} 件 "
@@ -87,7 +92,7 @@ class Command(BaseCommand):
         failed = 0
         still_over_limit = 0
 
-        for item, old_lines, old_errors in targets:
+        for item, old_lines, old_errors, image_url, needs_text_regen in targets:
             old_weighted = count_tweet_length(item.generated_text)
             prefix = (
                 f"#{item.pk} [{item.tweet_type}] "
@@ -97,6 +102,13 @@ class Command(BaseCommand):
                 prefix = f"{prefix} ({', '.join(old_errors)})"
             if dry_run:
                 self.stdout.write(f"  {prefix} -> (dry-run skip)")
+                continue
+
+            if not needs_text_regen:
+                item.image_url = image_url
+                item.save(update_fields=["image_url"])
+                updated += 1
+                self.stdout.write(f"  {prefix} -> 画像URLを再同期 (OK)")
                 continue
 
             generator = get_generator(item.tweet_type)
@@ -129,8 +141,8 @@ class Command(BaseCommand):
             new_errors = validate_tweet_text(text)
             item.generated_text = text
 
-            if not item.image_url:
-                image_url = get_tweet_image_url(item)
+            if image_url or not item.image_url:
+                image_url = image_url or get_tweet_image_url(item)
                 if image_url:
                     item.image_url = image_url
                     item.save(update_fields=["generated_text", "image_url"])

--- a/app/twitter/signals.py
+++ b/app/twitter/signals.py
@@ -131,6 +131,25 @@ def _start_tweet_generation(queue_item) -> None:
     thread.start()
 
 
+def sync_slide_share_queue_image(event_detail) -> None:
+    """未投稿のスライド共有キュー画像を現在のサムネイル優先URLへ同期する。"""
+    from twitter.models import TweetQueue
+    from twitter.tweet_generator import get_tweet_image_url
+
+    existing_queue = TweetQueue.objects.select_related(
+        'community', 'event', 'event_detail',
+    ).filter(
+        event_detail=event_detail, tweet_type="slide_share",
+    ).order_by('created_at', 'pk').first()
+    if not existing_queue or existing_queue.status == 'posted':
+        return
+
+    image_url = get_tweet_image_url(existing_queue)
+    if image_url and existing_queue.image_url != image_url:
+        existing_queue.image_url = image_url
+        existing_queue.save(update_fields=['image_url'])
+
+
 @receiver(pre_save, sender=Community)
 def track_community_status_change(sender, instance, **kwargs):
     """Community の旧ステータスを保持する。"""
@@ -374,6 +393,7 @@ def queue_slide_share_tweet(sender, instance, created, **kwargs):
 
 def _queue_slide_share_tweet(instance, created):
     from twitter.models import TweetQueue
+    from twitter.tweet_generator import get_tweet_image_url
 
     if instance.detail_type not in PRESENTATION_DETAIL_TYPES:
         return
@@ -404,9 +424,11 @@ def _queue_slide_share_tweet(instance, created):
 
         notify_slide_material_published(instance)
 
-    if TweetQueue.objects.filter(
+    existing_queue = TweetQueue.objects.filter(
         event_detail=instance, tweet_type="slide_share",
-    ).exists():
+    ).order_by('created_at', 'pk').first()
+    if existing_queue:
+        sync_slide_share_queue_image(instance)
         return
 
     queue_item = TweetQueue.objects.create(
@@ -416,6 +438,10 @@ def _queue_slide_share_tweet(instance, created):
         event_detail=instance,
         scheduled_at=default_scheduled_at(tweet_type='slide_share', event=instance.event),
     )
+    image_url = get_tweet_image_url(queue_item)
+    if image_url:
+        queue_item.image_url = image_url
+        queue_item.save(update_fields=['image_url'])
     logger.info(
         "Queued slide share tweet: %s - %s", instance.speaker, instance.theme,
     )

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -2772,6 +2772,58 @@ class SlideShareSignalTest(AutoTweetTestBase):
         self.detail.save()
         self.assertEqual(TweetQueue.objects.count(), 1)
 
+    @override_settings(AWS_S3_CUSTOM_DOMAIN='data.vrc-ta-hub.com')
+    @patch("twitter.signals.threading.Thread")
+    def test_existing_unposted_slide_share_queue_syncs_thumbnail_image(self, mock_thread_cls):
+        """既存の未投稿slide_shareキューはサムネイルURLへ再同期される"""
+        mock_thread_cls.return_value = MagicMock()
+        self.community.poster_image = "poster/community.webp"
+        self.community.save(update_fields=["poster_image"])
+        queue = TweetQueue.objects.create(
+            tweet_type="slide_share",
+            community=self.community,
+            event=self.past_event,
+            event_detail=self.detail,
+            status="ready",
+            image_url="https://data.vrc-ta-hub.com/cdn-cgi/image/width=960,quality=80,format=auto/poster/community.webp",
+        )
+
+        self.detail.slide_file = "slide/test.pdf"
+        self.detail.thumbnail_image = "thumbnail/generated.jpg"
+        self.detail.save()
+
+        queue.refresh_from_db()
+        self.assertEqual(TweetQueue.objects.count(), 1)
+        self.assertIn("thumbnail/generated.jpg", queue.image_url)
+        self.assertNotIn("poster/community.webp", queue.image_url)
+
+    @override_settings(AWS_S3_CUSTOM_DOMAIN='data.vrc-ta-hub.com')
+    @patch("twitter.signals.threading.Thread")
+    def test_posted_slide_share_queue_image_is_not_changed(self, mock_thread_cls):
+        """投稿済みslide_shareキューの画像URLは履歴として保持する"""
+        mock_thread_cls.return_value = MagicMock()
+        poster_url = (
+            "https://data.vrc-ta-hub.com/cdn-cgi/image/"
+            "width=960,quality=80,format=auto/poster/community.webp"
+        )
+        queue = TweetQueue.objects.create(
+            tweet_type="slide_share",
+            community=self.community,
+            event=self.past_event,
+            event_detail=self.detail,
+            status="posted",
+            image_url=poster_url,
+            tweet_id="1234567890",
+        )
+
+        self.detail.slide_file = "slide/test.pdf"
+        self.detail.thumbnail_image = "thumbnail/generated.jpg"
+        self.detail.save()
+
+        queue.refresh_from_db()
+        self.assertEqual(TweetQueue.objects.count(), 1)
+        self.assertEqual(queue.image_url, poster_url)
+
     @patch("event.notifications.requests.post")
     @patch("twitter.signals.threading.Thread")
     def test_slide_webhook_still_sent_when_youtube_queue_already_exists(
@@ -2854,8 +2906,9 @@ class SlideShareSignalTest(AutoTweetTestBase):
 
         self.assertEqual(TweetQueue.objects.count(), 0)
 
+    @patch("event.libs.ensure_pdf_thumbnail", return_value=False)
     @patch("twitter.signals.threading.Thread")
-    def test_slide_file_first_set_creates_queue(self, mock_thread_cls):
+    def test_slide_file_first_set_creates_queue(self, mock_thread_cls, _mock_ensure_pdf_thumbnail):
         """slide_file が初めて設定され、発表日が過去ならキューが作成される"""
         mock_thread_cls.return_value = MagicMock()
 

--- a/app/twitter/tests/test_regenerate_ready_tweets.py
+++ b/app/twitter/tests/test_regenerate_ready_tweets.py
@@ -9,9 +9,10 @@ from io import StringIO
 from unittest.mock import patch
 
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from community.models import Community
+from event.models import Event, EventDetail
 from twitter.models import TweetQueue
 
 
@@ -158,6 +159,43 @@ class RegenerateReadyTweetsCommandTest(TestCase):
 
         posted_item.refresh_from_db()
         self.assertEqual(posted_item.generated_text, over_limit)
+
+    @override_settings(AWS_S3_CUSTOM_DOMAIN='data.vrc-ta-hub.com')
+    def test_slide_share_image_is_synced_without_text_regeneration(self):
+        """本文が制約内でもslide_shareの画像URL差分は同期する"""
+        event = Event.objects.create(
+            community=self.community,
+            date=datetime.date(2026, 1, 1),
+            start_time=datetime.time(21, 0),
+            duration=60,
+        )
+        detail = EventDetail.objects.create(
+            event=event,
+            detail_type="LT",
+            status="approved",
+            speaker="発表者",
+            theme="資料の話",
+            start_time=datetime.time(21, 10),
+            thumbnail_image="thumbnail/generated.jpg",
+        )
+        item = TweetQueue.objects.create(
+            tweet_type="slide_share",
+            community=self.community,
+            event=event,
+            event_detail=detail,
+            status="ready",
+            generated_text="行1\n行2\nhttps://example.com",
+            image_url="https://data.vrc-ta-hub.com/cdn-cgi/image/width=960,quality=80,format=auto/poster/community.webp",
+        )
+
+        with patch("twitter.management.commands.regenerate_ready_tweets.get_generator") as mock_get:
+            output = self._call()
+
+        item.refresh_from_db()
+        self.assertIn("thumbnail/generated.jpg", item.image_url)
+        self.assertEqual(item.generated_text, "行1\n行2\nhttps://example.com")
+        mock_get.assert_not_called()
+        self.assertIn("画像URLを再同期", output)
 
     def test_status_remains_ready_after_regeneration(self):
         """再生成後も status は ready のまま"""

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -190,8 +190,8 @@ def _retry_generation(queue_item) -> None:
         queue_item.status = 'ready'
         queue_item.error_message = ''
 
-        # 画像URLも設定（まだない場合）
-        if not queue_item.image_url:
+        # slide_share は記事サムネイルが後から作られることがあるため再同期する。
+        if queue_item.tweet_type == 'slide_share' or not queue_item.image_url:
             image_url = get_tweet_image_url(queue_item)
             if image_url:
                 queue_item.image_url = image_url


### PR DESCRIPTION
## 概要
- slide_share キュー作成前に PDF サムネイル生成を先に試行
- 新規・未投稿の slide_share キューで記事サムネイル優先の image_url を再同期
- 投稿済みキューの image_url は履歴として保持

## 背景
スライド共有投稿のキュー作成時点で EventDetail.thumbnail_image がまだ保存されていない場合、X投稿の添付画像が集会ポスターで確定していました。記事ページのOGPは後から正しいサムネイルになっても、既存キューの image_url が更新されないため、投稿画像とOGPがズレていました。

## テスト
- docker compose exec -T vrc-ta-hub python manage.py test twitter.tests.test_auto_tweet.SlideShareSignalTest twitter.tests.test_regenerate_ready_tweets.RegenerateReadyTweetsCommandTest
- docker compose exec -T vrc-ta-hub python manage.py test twitter.tests
- uvx ruff==0.11.6 check app/
- git diff --check