### PR TITLE
feat: EventDetail APIに集会IDフィルターを追加

### DIFF
--- a/app/api_v1/README.md
+++ b/app/api_v1/README.md
@@ -36,6 +36,7 @@
 
 #### フィルタリングオプション
 
+- `community`: 集会ID（完全一致）。例: `/api/v1/event_detail/?community=42`
 - `theme`: テーマ（部分一致）
 - `speaker`: 発表者（部分一致）
 - `start_date`: イベント開催日（以降）

--- a/app/api_v1/tests/test_event_detail_api.py
+++ b/app/api_v1/tests/test_event_detail_api.py
@@ -132,6 +132,13 @@ class EventDetailAPITest(TestCase):
         
         self.client = APIClient()
         self.url = reverse('event-detail-api-list')
+        self.public_url = '/api/v1/event_detail/'
+
+    def _response_items(self, response):
+        """ページネーション有無を吸収してレスポンス配列を返す."""
+        if 'results' in response.data:
+            return response.data['results']
+        return response.data
     
     def test_api_key_authentication(self):
         """APIキー認証のテスト"""
@@ -161,10 +168,7 @@ class EventDetailAPITest(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # ページネーションがある場合とない場合の両方に対応
-        if 'results' in response.data:
-            ids = {item['id'] for item in response.data['results']}
-        else:
-            ids = {item['id'] for item in response.data}
+        ids = {item['id'] for item in self._response_items(response)}
         self.assertEqual(ids, {self.event_detail1.id, self.locked_event_detail.id})
         
         # Superuserは全て取得
@@ -175,6 +179,58 @@ class EventDetailAPITest(TestCase):
             self.assertEqual(len(response.data['results']), 2)
         else:
             self.assertEqual(len(response.data), 2)
+
+    def test_public_event_detail_filter_by_community(self):
+        """公開 EventDetail API は community ID で絞り込める."""
+        community2_detail = EventDetail.objects.create(
+            event=self.event2,
+            detail_type='LT',
+            start_time=time(21, 0),
+            duration=20,
+            speaker='Speaker 2',
+            theme='Test Theme 2',
+            h1='Test Title 2',
+            contents='Test contents 2'
+        )
+
+        response = self.client.get(self.public_url, {'community': self.community1.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item['id'] for item in self._response_items(response)}
+        self.assertEqual(ids, {self.event_detail1.id, self.locked_event_detail.id})
+
+        response = self.client.get(self.public_url, {'community': self.community2.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item['id'] for item in self._response_items(response)}
+        self.assertEqual(ids, {community2_detail.id})
+
+    def test_public_event_detail_filter_by_unknown_community_returns_empty(self):
+        """存在しない community ID は空の一覧を返す."""
+        response = self.client.get(self.public_url, {'community': 999999})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._response_items(response), [])
+
+    def test_public_event_detail_filter_combines_community_and_speaker(self):
+        """community と既存フィルターを併用できる."""
+        community2_detail = EventDetail.objects.create(
+            event=self.event2,
+            detail_type='LT',
+            start_time=time(21, 0),
+            duration=20,
+            speaker='Speaker 1',
+            theme='Community 2 Theme',
+            h1='Community 2 Title',
+            contents='Community 2 contents'
+        )
+
+        response = self.client.get(
+            self.public_url,
+            {'community': self.community2.id, 'speaker': 'Speaker 1'}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item['id'] for item in self._response_items(response)}
+        self.assertEqual(ids, {community2_detail.id})
     
     def test_create_event_detail(self):
         """イベント詳細作成のテスト"""

--- a/app/api_v1/views.py
+++ b/app/api_v1/views.py
@@ -181,6 +181,7 @@ class EventViewSet(DatabaseReconnectListMixin, viewsets.ReadOnlyModelViewSet):
 
 
 class EventDetailFilter(filters.FilterSet):
+    community = filters.NumberFilter(field_name='event__community_id')
     theme = filters.CharFilter(lookup_expr='icontains')
     speaker = filters.CharFilter(lookup_expr='icontains')
     start_date = filters.DateFilter(field_name='event__date', lookup_expr='gte')
@@ -189,7 +190,7 @@ class EventDetailFilter(filters.FilterSet):
 
     class Meta:
         model = EventDetail
-        fields = ['theme', 'speaker', 'start_date', 'end_date', 'start_time']
+        fields = ['community', 'theme', 'speaker', 'start_date', 'end_date', 'start_time']
 
 
 @extend_schema_view(


### PR DESCRIPTION
## なぜこの変更が必要か

公開 EventDetail API で特定の集会だけを取得したい場合、これまでは `community` を指定できず、全件取得後に利用側で絞り込む必要がありました。
集会 ID を指定して取得できるようにし、用途ごとの API 利用をしやすくします。

## 変更内容

- `GET /api/v1/event_detail/?community=<id>` で集会 ID による絞り込みを追加
- 既存の `theme` / `speaker` / 日付 / 開始時刻フィルターとの併用を維持
- API README に `community` フィルターの使用例を追記
- community 指定、存在しない ID、`speaker` との併用をテストに追加

## 意思決定

- パラメータ名は要望に合わせて `community` とし、値は `Community.id` として扱います。
- serializer やレスポンス形式は変更せず、既存の公開条件（承認済み・終了していない集会、承認済み EventDetail）を維持します。
- 管理 API `/api/v1/event-details/` は今回の対象外です。

## テスト

- [x] `docker compose run --rm vrc-ta-hub python manage.py test api_v1.tests.test_event_detail_api`
- [x] `docker compose run --rm vrc-ta-hub python manage.py test api_v1.tests.test_schema_api`