### PR TITLE
feat: Event APIに集会IDフィルターを追加

### DIFF
--- a/app/api_v1/README.md
+++ b/app/api_v1/README.md
@@ -24,6 +24,7 @@
 
 #### フィルタリングオプション
 
+- `community`: 集会ID（完全一致）。例: `/api/v1/event/?community=42`
 - `name`: コミュニティ名（部分一致）
 - `weekday`: 開催曜日
 - `start_date`: 開始日（以降）

--- a/app/api_v1/tests/test_event_api.py
+++ b/app/api_v1/tests/test_event_api.py
@@ -1,0 +1,162 @@
+from datetime import timedelta, time
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from community.models import Community
+from event.models import Event
+
+
+class EventAPITest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse('event-list')
+        today = timezone.localdate()
+
+        self.community1 = Community.objects.create(
+            name='Event Community 1',
+            start_time=time(20, 0),
+            duration=120,
+            weekdays=['Mon'],
+            frequency='weekly',
+            organizers='Organizer 1',
+            status='approved'
+        )
+        self.community2 = Community.objects.create(
+            name='Event Community 2',
+            start_time=time(21, 0),
+            duration=90,
+            weekdays=['Tue'],
+            frequency='weekly',
+            organizers='Organizer 2',
+            status='approved'
+        )
+        self.pending_community = Community.objects.create(
+            name='Pending Event Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Wed'],
+            frequency='weekly',
+            organizers='Organizer 3',
+            status='pending'
+        )
+        self.ended_community = Community.objects.create(
+            name='Ended Event Community',
+            start_time=time(23, 0),
+            duration=60,
+            weekdays=['Thu'],
+            frequency='weekly',
+            organizers='Organizer 4',
+            status='approved',
+            end_at=today - timedelta(days=1)
+        )
+
+        self.event1 = Event.objects.create(
+            community=self.community1,
+            date=today + timedelta(days=1),
+            start_time=time(20, 0),
+            duration=120,
+            weekday='Mon'
+        )
+        self.event1_later = Event.objects.create(
+            community=self.community1,
+            date=today + timedelta(days=8),
+            start_time=time(20, 0),
+            duration=120,
+            weekday='Mon'
+        )
+        self.event2 = Event.objects.create(
+            community=self.community2,
+            date=today + timedelta(days=2),
+            start_time=time(21, 0),
+            duration=90,
+            weekday='Tue'
+        )
+        self.pending_event = Event.objects.create(
+            community=self.pending_community,
+            date=today + timedelta(days=3),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Wed'
+        )
+        self.ended_event = Event.objects.create(
+            community=self.ended_community,
+            date=today + timedelta(days=4),
+            start_time=time(23, 0),
+            duration=60,
+            weekday='Thu'
+        )
+
+    def _response_items(self, response):
+        if 'results' in response.data:
+            return response.data['results']
+        return response.data
+
+    def test_filter_by_community(self):
+        response = self.client.get(self.url, {'community': self.community1.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item['id'] for item in self._response_items(response)}
+        self.assertEqual(ids, {self.event1.id, self.event1_later.id})
+
+        response = self.client.get(self.url, {'community': self.community2.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item['id'] for item in self._response_items(response)}
+        self.assertEqual(ids, {self.event2.id})
+
+    def test_filter_by_unknown_community_returns_empty(self):
+        response = self.client.get(self.url, {'community': 999999})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._response_items(response), [])
+
+    def test_filter_combines_community_and_weekday(self):
+        response = self.client.get(
+            self.url,
+            {'community': self.community1.id, 'weekday': 'Mon'}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item['id'] for item in self._response_items(response)}
+        self.assertEqual(ids, {self.event1.id, self.event1_later.id})
+
+        response = self.client.get(
+            self.url,
+            {'community': self.community1.id, 'weekday': 'Tue'}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._response_items(response), [])
+
+    def test_filter_combines_community_and_name(self):
+        response = self.client.get(
+            self.url,
+            {'community': self.community2.id, 'name': 'Community 2'}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item['id'] for item in self._response_items(response)}
+        self.assertEqual(ids, {self.event2.id})
+
+        response = self.client.get(
+            self.url,
+            {'community': self.community2.id, 'name': 'Community 1'}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._response_items(response), [])
+
+    def test_filter_by_hidden_community_returns_empty(self):
+        response = self.client.get(self.url, {'community': self.pending_community.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._response_items(response), [])
+
+        response = self.client.get(self.url, {'community': self.ended_community.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._response_items(response), [])

--- a/app/api_v1/views.py
+++ b/app/api_v1/views.py
@@ -144,6 +144,7 @@ class CommunityViewSet(DatabaseReconnectListMixin, viewsets.ReadOnlyModelViewSet
 
 
 class EventFilter(filters.FilterSet):
+    community = filters.NumberFilter(field_name='community_id')
     name = filters.CharFilter(
         field_name='community__name', lookup_expr='icontains')
     weekday = filters.CharFilter(field_name='weekday')
@@ -152,7 +153,7 @@ class EventFilter(filters.FilterSet):
 
     class Meta:
         model = Event
-        fields = ['name', 'weekday', 'start_date', 'end_date']
+        fields = ['community', 'name', 'weekday', 'start_date', 'end_date']
 
 
 @extend_schema_view(


### PR DESCRIPTION
## なぜこの変更が必要か

公開 Event API で特定の集会のイベント一覧だけを取得したい場合、これまでは community 名の部分一致である `name` しか指定できませんでした。
プログラムから扱う用途では名前より ID 指定のほうが安定するため、`community` クエリパラメータで集会 ID による絞り込みを追加します。

## 変更内容

- `GET /api/v1/event/?community=<id>` で集会 ID による絞り込みを追加
- 既存の `name` / `weekday` / 日付フィルターとの併用を維持
- pending / ended community は ID 指定しても返さないことをテストで確認
- API README に `community` フィルターの使用例を追記

## 意思決定

- パラメータ名は直近の EventDetail API 対応と揃えて `community` とし、値は `Community.id` として扱います。
- `name` は互換性のため残し、community 名の部分一致検索として維持します。
- serializer やレスポンス形式は変更しません。

## テスト

- [x] `docker compose run --rm vrc-ta-hub python manage.py test api_v1.tests.test_event_api api_v1.tests.test_schema_api`