### PR TITLE
feat: 資料公開Discord通知にOGP画像を表示

### DIFF
--- a/app/event/notifications.py
+++ b/app/event/notifications.py
@@ -13,6 +13,38 @@ logger = logging.getLogger(__name__)
 
 # Discord Webhook送信タイムアウト（秒）
 DISCORD_TIMEOUT_SECONDS = 10
+PUBLIC_SITE_ORIGIN = "https://vrc-ta-hub.com"
+
+
+def _build_absolute_url(url: str) -> str:
+    """Discord が取得できる絶対 URL に整形する."""
+    if not url:
+        return ""
+    if url.startswith(("http://", "https://")):
+        return url
+    if url.startswith("//"):
+        return f"https:{url}"
+    if url.startswith("/"):
+        return f"{PUBLIC_SITE_ORIGIN}{url}"
+    return f"{PUBLIC_SITE_ORIGIN}/{url}"
+
+
+def _get_file_url(file_field) -> str:
+    """未設定ファイルを避けて URL を取得する."""
+    if not file_field:
+        return ""
+    try:
+        return _build_absolute_url(file_field.url)
+    except ValueError:
+        return ""
+
+
+def _get_event_detail_og_image_url(event_detail: EventDetail) -> str:
+    """EventDetail ページの OGP と同じ優先順位で画像 URL を返す."""
+    thumbnail_url = _get_file_url(event_detail.thumbnail_image)
+    if thumbnail_url:
+        return thumbnail_url
+    return _get_file_url(event_detail.event.community.poster_image)
 
 
 def notify_owners_of_new_application(event_detail: EventDetail, request=None) -> None:
@@ -335,15 +367,21 @@ def notify_slide_material_published(event_detail: EventDetail) -> None:
             "inline": False,
         })
 
+    embed = {
+        "title": "登壇資料が公開されました",
+        "url": detail_url,
+        "description": f"**{event_detail.theme}**",
+        "color": 3447003,
+        "fields": fields,
+        "footer": {"text": community.name},
+    }
+    image_url = _get_event_detail_og_image_url(event_detail)
+    if image_url:
+        embed["image"] = {"url": image_url}
+
     message = {
         "content": "📚 **資料公開のお知らせ**",
-        "embeds": [{
-            "title": "登壇資料が公開されました",
-            "description": f"**{event_detail.theme}**",
-            "color": 3447003,
-            "fields": fields,
-            "footer": {"text": community.name},
-        }],
+        "embeds": [embed],
     }
 
     try:

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -2673,6 +2673,47 @@ class SlideShareSignalTest(AutoTweetTestBase):
         self.assertEqual(payload["embeds"][0]["title"], "登壇資料が公開されました")
         self.assertEqual(payload["embeds"][0]["description"], f"**{self.detail.theme}**")
         self.assertIn("event/detail", payload["embeds"][0]["fields"][2]["value"])
+        self.assertIn("event/detail", payload["embeds"][0]["url"])
+
+    @override_settings(AWS_S3_CUSTOM_DOMAIN="data.vrc-ta-hub.com")
+    @patch("event.notifications.requests.post")
+    @patch("twitter.signals.threading.Thread")
+    def test_slide_share_webhook_uses_event_detail_thumbnail_image(
+        self, mock_thread_cls, mock_post,
+    ):
+        """資料公開通知にはEventDetailのOGP画像を表示する."""
+        mock_thread_cls.return_value = MagicMock()
+        mock_post.return_value = MagicMock(ok=True)
+        self.community.notification_webhook_url = "https://discord.com/api/webhooks/123/abc"
+        self.community.save(update_fields=["notification_webhook_url"])
+
+        self.detail.thumbnail_image = "thumbnail/generated.jpg"
+        self.detail.slide_url = "https://example.com/slides"
+        self.detail.save()
+
+        payload = mock_post.call_args[1]["json"]
+        image_url = payload["embeds"][0]["image"]["url"]
+        self.assertEqual(image_url, "https://data.vrc-ta-hub.com/thumbnail/generated.jpg")
+
+    @override_settings(AWS_S3_CUSTOM_DOMAIN="data.vrc-ta-hub.com")
+    @patch("event.notifications.requests.post")
+    @patch("twitter.signals.threading.Thread")
+    def test_slide_share_webhook_falls_back_to_community_poster_image(
+        self, mock_thread_cls, mock_post,
+    ):
+        """EventDetail画像がない場合は集会ポスターを表示する."""
+        mock_thread_cls.return_value = MagicMock()
+        mock_post.return_value = MagicMock(ok=True)
+        self.community.notification_webhook_url = "https://discord.com/api/webhooks/123/abc"
+        self.community.poster_image = "poster/community.webp"
+        self.community.save(update_fields=["notification_webhook_url", "poster_image"])
+
+        self.detail.slide_url = "https://example.com/slides"
+        self.detail.save()
+
+        payload = mock_post.call_args[1]["json"]
+        image_url = payload["embeds"][0]["image"]["url"]
+        self.assertEqual(image_url, "https://data.vrc-ta-hub.com/poster/community.webp")
 
     @patch("event.notifications.requests.post")
     @patch("twitter.signals.threading.Thread")


### PR DESCRIPTION
## 概要

スライド公開時にCommunityのDiscord Webhookへ送る「資料公開のお知らせ」Embedに、EventDetailのOGP画像を表示するようにした。

## 変更内容

- `app/event/notifications.py`
  - `_build_absolute_url` / `_get_file_url` / `_get_event_detail_og_image_url` の3ヘルパーを追加
    - 相対パス・`//host` 形式・FieldFile未設定など、URL構築で詰まりやすいケースを安全にハンドリング
  - `notify_slide_material_published()` のEmbedに `image.url` と `title.url`（詳細ページリンク）を追加

## 優先順位

EventDetailページのOGPと同じ順で画像URLを決定:

1. `event_detail.thumbnail_image`
2. なければ `event_detail.event.community.poster_image`
3. どちらも無ければ画像なし（Embed自体は送信）

## テスト

`twitter.tests.test_auto_tweet.SlideShareSignalTest` を実行（17件 OK）。新規テスト:

- `test_slide_share_webhook_uses_event_detail_thumbnail_image` — thumbnail優先
- `test_slide_share_webhook_falls_back_to_community_poster_image` — poster_imageフォールバック

```
Ran 17 tests in 1.195s
OK
```

## Test plan

- [x] `docker compose exec vrc-ta-hub python manage.py test twitter.tests.test_auto_tweet.SlideShareSignalTest`
- [ ] 本番反映後、実際のスライド公開でDiscord通知に画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)