### PR TITLE
chore: .claude/scheduled_tasks.lock を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ issue.md
 
 .claude/settings.local.json
 .claude/todo.md
+.claude/scheduled_tasks.lock
 
 # IDE
 .idea/


### PR DESCRIPTION
## Summary

Claude Code のスケジュール系機能 (`schedule` / `loop` / `ScheduleWakeup`) が二重起動防止に使うローカルロックファイル `.claude/scheduled_tasks.lock` を gitignore に追加。

- 中身はマシン固有の `pid` + `sessionId` + `acquiredAt`
- セッションごとに作成され、追跡対象に含めるべきではない
- 既存のgit管理対象には入っていない（新規追加分）

## Test plan

- [x] `.gitignore` に1行追加のみ。挙動への影響なし
- [x] `git status` でロックファイルが追跡対象外になることを確認