### PR TITLE
refactor: 定期イベント日付生成のLLM呼び出しを抽象化

### DIFF
--- a/app/event/llm_service.py
+++ b/app/event/llm_service.py
@@ -1,0 +1,222 @@
+"""定期イベントの日付生成に使うLLMアダプタ。"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, datetime
+from typing import Protocol
+
+from django.conf import settings
+from openai import OpenAI
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RECURRENCE_LLM_PROVIDER = "openrouter"
+DEFAULT_RECURRENCE_MODEL = "google/gemini-2.0-flash-exp"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+OPENROUTER_EXTRA_HEADERS = {
+    "HTTP-Referer": "https://vrc-ta-hub.com/",
+    "X-Title": "VRC TA Hub",
+}
+SYSTEM_PROMPT = "あなたは定期イベントの日付を生成する専門家です。必ず指定されたJSON形式で出力してください。"
+
+
+class EventDateLlmService(Protocol):
+    """定期イベントの日付生成をLLMプロバイダから切り離す。"""
+
+    def generate_event_dates(self, prompt: str) -> list[date]:
+        """Generate event dates from the given prompt.
+
+        Args:
+            prompt: 日付生成条件を含むユーザープロンプト。
+
+        Returns:
+            LLM応答から抽出した日付リスト。
+        """
+
+
+class OpenAICompatibleProviderConfig(BaseModel):
+    """OpenAI互換APIへ接続するための設定。"""
+
+    provider: str
+    api_key_env: str
+    model_name: str
+    base_url: str | None = None
+    extra_headers: dict[str, str] = Field(default_factory=dict)
+
+
+class GeminiProviderConfig(BaseModel):
+    """Google Gemini APIへ接続するための設定。"""
+
+    api_key_env: str
+    model_name: str
+
+
+class OpenAICompatibleEventDateLlmService:
+    """OpenAI SDK互換のChat Completions APIで日付を生成する。"""
+
+    def __init__(self, config: OpenAICompatibleProviderConfig):
+        self.config = config
+
+    def generate_event_dates(self, prompt: str) -> list[date]:
+        """Generate event dates with an OpenAI-compatible provider.
+
+        Args:
+            prompt: 日付生成条件を含むユーザープロンプト。
+
+        Returns:
+            LLM応答から抽出した日付リスト。
+
+        Raises:
+            ValueError: 必須APIキーが環境変数にない場合。
+        """
+        api_key = os.environ.get(self.config.api_key_env)
+        if not api_key:
+            raise ValueError(f"{self.config.api_key_env} is required for {self.config.provider}")
+
+        client_kwargs = {"api_key": api_key}
+        if self.config.base_url:
+            client_kwargs["base_url"] = self.config.base_url
+
+        client = OpenAI(**client_kwargs)
+        completion = client.chat.completions.create(
+            extra_headers=self.config.extra_headers,
+            model=self.config.model_name,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.3,
+            max_tokens=2000,
+        )
+        text = completion.choices[0].message.content or ""
+        return extract_event_dates(text)
+
+
+class GeminiEventDateLlmService:
+    """Google Gemini APIで日付を生成する。"""
+
+    def __init__(self, config: GeminiProviderConfig):
+        self.config = config
+
+    def generate_event_dates(self, prompt: str) -> list[date]:
+        """Generate event dates with Google Gemini.
+
+        Args:
+            prompt: 日付生成条件を含むユーザープロンプト。
+
+        Returns:
+            LLM応答から抽出した日付リスト。
+
+        Raises:
+            ValueError: 必須APIキーが環境変数またはsettingsにない場合。
+        """
+        api_key = os.environ.get(self.config.api_key_env) or getattr(settings, self.config.api_key_env, None)
+        if not api_key:
+            raise ValueError(f"{self.config.api_key_env} is required for gemini")
+
+        import google.generativeai as genai
+
+        genai.configure(api_key=api_key)
+        model = genai.GenerativeModel(_normalize_gemini_model_name(self.config.model_name))
+        response = model.generate_content(
+            [SYSTEM_PROMPT, prompt],
+            generation_config={
+                "temperature": 0.3,
+                "max_output_tokens": 2000,
+            },
+        )
+        return extract_event_dates(getattr(response, "text", "") or "")
+
+
+def get_event_date_llm_service() -> EventDateLlmService:
+    """Build the configured event-date LLM service.
+
+    Returns:
+        settings.RECURRENCE_LLM_PROVIDER に対応する日付生成サービス。
+
+    Raises:
+        ValueError: 未対応のプロバイダ名が指定された場合。
+    """
+    provider = str(
+        getattr(settings, "RECURRENCE_LLM_PROVIDER", DEFAULT_RECURRENCE_LLM_PROVIDER)
+    ).strip().lower()
+    model_name = str(
+        getattr(settings, "RECURRENCE_LLM_MODEL", getattr(settings, "GEMINI_MODEL", DEFAULT_RECURRENCE_MODEL))
+    )
+
+    if provider == "openrouter":
+        return OpenAICompatibleEventDateLlmService(
+            OpenAICompatibleProviderConfig(
+                provider=provider,
+                api_key_env=str(getattr(settings, "RECURRENCE_LLM_API_KEY_ENV", "OPENROUTER_API_KEY")),
+                base_url=str(getattr(settings, "RECURRENCE_LLM_BASE_URL", OPENROUTER_BASE_URL)),
+                model_name=model_name,
+                extra_headers=OPENROUTER_EXTRA_HEADERS,
+            )
+        )
+
+    if provider == "openai":
+        base_url = getattr(settings, "RECURRENCE_LLM_BASE_URL", None)
+        return OpenAICompatibleEventDateLlmService(
+            OpenAICompatibleProviderConfig(
+                provider=provider,
+                api_key_env=str(getattr(settings, "RECURRENCE_LLM_API_KEY_ENV", "OPENAI_API_KEY")),
+                base_url=str(base_url) if base_url else None,
+                model_name=model_name,
+            )
+        )
+
+    if provider in {"gemini", "google"}:
+        return GeminiEventDateLlmService(
+            GeminiProviderConfig(
+                api_key_env=str(getattr(settings, "RECURRENCE_LLM_API_KEY_ENV", "GOOGLE_API_KEY")),
+                model_name=model_name,
+            )
+        )
+
+    raise ValueError(f"Unsupported RECURRENCE_LLM_PROVIDER: {provider}")
+
+
+def extract_event_dates(text: str) -> list[date]:
+    """Extract YYYY-MM-DD date values from a JSON list in LLM text.
+
+    Args:
+        text: LLMが返したテキスト。
+
+    Returns:
+        パースできた日付の昇順リスト。
+    """
+    json_start = text.find("[")
+    json_end = text.rfind("]") + 1
+    if json_start == -1 or json_end <= json_start:
+        return []
+
+    try:
+        values = json.loads(text[json_start:json_end])
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse LLM date JSON", exc_info=True)
+        return []
+
+    if not isinstance(values, list):
+        return []
+
+    dates = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        try:
+            dates.append(datetime.strptime(value, "%Y-%m-%d").date())
+        except ValueError:
+            continue
+    return sorted(set(dates))
+
+
+def _normalize_gemini_model_name(model_name: str) -> str:
+    if model_name.startswith("google/"):
+        model_name = model_name.split("/", 1)[1]
+    if ":" in model_name:
+        model_name = model_name.split(":", 1)[0]
+    return model_name

--- a/app/event/recurrence_service.py
+++ b/app/event/recurrence_service.py
@@ -1,17 +1,16 @@
 """定期イベントの日付生成サービス"""
-import json
+import logging
 import re
 from calendar import monthrange
 from datetime import datetime, timedelta, date
 from typing import List, Optional, Dict
-import traceback
 
-from django.conf import settings
 from django.db import models
-import os
-from openai import OpenAI
 
+from event.llm_service import EventDateLlmService, get_event_date_llm_service
 from event.models import Event, RecurrenceRule
+
+logger = logging.getLogger(__name__)
 
 WEEKDAY_TOKEN_MAP = {
     '月': 0,
@@ -40,21 +39,14 @@ WEEK_TOKEN_MAP = {
 
 class RecurrenceService:
     """定期イベントの日付を生成するサービス"""
-    
-    def __init__(self):
-        # OpenRouter用の設定
-        self.api_key = os.environ.get("OPENROUTER_API_KEY")
-        if not self.api_key:
-            raise ValueError("OPENROUTER_API_KEY is required")
-        
-        # モデル名を環境変数から取得
-        self.model_name = getattr(settings, 'GEMINI_MODEL', 'google/gemini-2.0-flash-exp')
-        
-        # OpenAI SDKを使用してOpenRouterクライアントを初期化
-        self.client = OpenAI(
-            base_url="https://openrouter.ai/api/v1",
-            api_key=self.api_key
-        )
+
+    def __init__(self, llm_service: Optional[EventDateLlmService] = None):
+        self._llm_service = llm_service
+
+    def _get_llm_service(self) -> EventDateLlmService:
+        if self._llm_service is None:
+            self._llm_service = get_event_date_llm_service()
+        return self._llm_service
     
     def generate_dates(self, rule: RecurrenceRule, base_date: date, base_time: datetime.time, months: int = 1, community=None) -> List[date]:
         """定期ルールに基づいて日付リストを生成"""
@@ -450,8 +442,8 @@ class RecurrenceService:
             
             return "\n".join(history_lines)
             
-        except Exception as e:
-            print(f"Error getting recent events history: {e}")
+        except Exception:
+            logger.exception("Error getting recent events history")
             return "過去の開催履歴: 取得エラー"
     
     def _generate_dates_by_llm(self, rule: RecurrenceRule, base_date: date, base_time: datetime.time, months: int, community=None) -> List[date]:
@@ -495,48 +487,10 @@ class RecurrenceService:
 """
         
         try:
-            # OpenRouterにリクエスト
-            completion = self.client.chat.completions.create(
-                extra_headers={
-                    "HTTP-Referer": "https://vrc-ta-hub.com/",
-                    "X-Title": "VRC TA Hub"
-                },
-                model=self.model_name,
-                messages=[
-                    {"role": "system", "content": "あなたは定期イベントの日付を生成する専門家です。必ず指定されたJSON形式で出力してください。"},
-                    {"role": "user", "content": prompt}
-                ],
-                temperature=0.3,
-                max_tokens=2000
-            )
-            
-            # レスポンスからテキストを取得
-            text = completion.choices[0].message.content
-            
-            # JSONの開始と終了を見つける
-            json_start = text.find('[')
-            json_end = text.rfind(']') + 1
-            
-            if json_start != -1 and json_end > json_start:
-                json_str = text[json_start:json_end]
-                date_strings = json.loads(json_str)
-                
-                # 文字列を日付オブジェクトに変換
-                dates = []
-                for date_str in date_strings:
-                    try:
-                        parsed_date = datetime.strptime(date_str, '%Y-%m-%d').date()
-                        if base_date <= parsed_date <= end_date:
-                            dates.append(parsed_date)
-                    except ValueError:
-                        continue
-                
-                return sorted(dates)
-        except Exception as e:
-            print(f"LLM date generation error: {e}")
-            print(f"Model: {self.model_name}")
-            print(f"API Key exists: {bool(self.api_key)}")
-            traceback.print_exc()
+            dates = self._get_llm_service().generate_event_dates(prompt)
+            return sorted({generated_date for generated_date in dates if base_date <= generated_date <= end_date})
+        except Exception:
+            logger.exception("LLM date generation failed")
         
         return []
     

--- a/app/event/tests/test_llm_service.py
+++ b/app/event/tests/test_llm_service.py
@@ -1,0 +1,61 @@
+from datetime import date
+
+from django.test import SimpleTestCase, override_settings
+
+from event.llm_service import (
+    GeminiEventDateLlmService,
+    OpenAICompatibleEventDateLlmService,
+    extract_event_dates,
+    get_event_date_llm_service,
+)
+
+
+class EventDateLlmServiceTest(SimpleTestCase):
+    def test_extract_event_dates_from_llm_text(self):
+        text = """
+        以下が生成した日付です。
+        ["2024-12-23", "invalid", "2025-01-27", "2024-12-23"]
+        """
+
+        self.assertEqual(
+            extract_event_dates(text),
+            [
+                date(2024, 12, 23),
+                date(2025, 1, 27),
+            ],
+        )
+
+    @override_settings(
+        RECURRENCE_LLM_PROVIDER="openrouter",
+        RECURRENCE_LLM_MODEL="google/test-model",
+    )
+    def test_factory_uses_openrouter_provider(self):
+        service = get_event_date_llm_service()
+
+        self.assertIsInstance(service, OpenAICompatibleEventDateLlmService)
+        self.assertEqual(service.config.provider, "openrouter")
+        self.assertEqual(service.config.api_key_env, "OPENROUTER_API_KEY")
+        self.assertEqual(service.config.model_name, "google/test-model")
+
+    @override_settings(
+        RECURRENCE_LLM_PROVIDER="openai",
+        RECURRENCE_LLM_MODEL="gpt-test-model",
+    )
+    def test_factory_uses_openai_provider(self):
+        service = get_event_date_llm_service()
+
+        self.assertIsInstance(service, OpenAICompatibleEventDateLlmService)
+        self.assertEqual(service.config.provider, "openai")
+        self.assertEqual(service.config.api_key_env, "OPENAI_API_KEY")
+        self.assertEqual(service.config.model_name, "gpt-test-model")
+
+    @override_settings(
+        RECURRENCE_LLM_PROVIDER="gemini",
+        RECURRENCE_LLM_MODEL="gemini-test-model",
+    )
+    def test_factory_uses_gemini_provider(self):
+        service = get_event_date_llm_service()
+
+        self.assertIsInstance(service, GeminiEventDateLlmService)
+        self.assertEqual(service.config.api_key_env, "GOOGLE_API_KEY")
+        self.assertEqual(service.config.model_name, "gemini-test-model")

--- a/app/event/tests/test_recurrence_llm_generation.py
+++ b/app/event/tests/test_recurrence_llm_generation.py
@@ -45,8 +45,8 @@ class TestRecurrenceLLMGeneration(TestCase):
     def test_real_llm_generation_for_monthly_pattern(self):
         """実際のLLMを使用して月次パターンの定期ルールを生成"""
         # APIキーが設定されていない場合はスキップ
-        if not os.environ.get('GOOGLE_API_KEY'):
-            self.skipTest("GOOGLE_API_KEY not set")
+        if not os.environ.get('OPENROUTER_API_KEY'):
+            self.skipTest("OPENROUTER_API_KEY not set")
         
         # RecurrenceRuleを作成
         rule = RecurrenceRule.objects.create(

--- a/app/event/tests/test_recurrence_rule_generation.py
+++ b/app/event/tests/test_recurrence_rule_generation.py
@@ -4,9 +4,19 @@ from django.contrib.auth import get_user_model
 from community.models import Community
 from event.models import Event, RecurrenceRule
 from event.recurrence_service import RecurrenceService
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 User = get_user_model()
+
+
+class FakeEventDateLlmService:
+    def __init__(self):
+        self.dates = []
+        self.prompts = []
+
+    def generate_event_dates(self, prompt: str) -> list[date]:
+        self.prompts.append(prompt)
+        return self.dates
 
 
 class TestRecurrenceRuleGeneration(TestCase):
@@ -40,7 +50,8 @@ class TestRecurrenceRuleGeneration(TestCase):
         ]
         Event.objects.bulk_create(past_events)
         
-        self.service = RecurrenceService()
+        self.llm_service = FakeEventDateLlmService()
+        self.service = RecurrenceService(llm_service=self.llm_service)
     
     def test_generate_monthly_fourth_monday_with_llm(self):
         """LLMを使用して毎月第4月曜の定期ルールを生成"""
@@ -52,40 +63,35 @@ class TestRecurrenceRuleGeneration(TestCase):
             start_date=date(2024, 12, 1)
         )
         
-        # LLMのモックレスポンス（第4月曜日の日付）
-        mock_response = MagicMock()
-        mock_response.text = """
-        以下が生成した日付リストです：
-        ["2024-12-23", "2025-01-27", "2025-02-24"]
-        """
+        # LLMサービスのモックレスポンス（第4月曜日の日付）
+        self.llm_service.dates = [
+            date(2024, 12, 23),
+            date(2025, 1, 27),
+            date(2025, 2, 24),
+        ]
+
+        # 日付を生成
+        dates = self.service.generate_dates(
+            rule=rule,
+            base_date=date(2024, 12, 1),
+            base_time=time(22, 0),
+            months=3,
+            community=self.community
+        )
+
+        # 生成された日付を確認
+        expected_dates = [
+            date(2024, 12, 23),  # 第4月曜
+            date(2025, 1, 27),   # 第4月曜
+            date(2025, 2, 24),   # 第4月曜
+        ]
         
-        # OpenRouter用のモックレスポンス
-        mock_completion = MagicMock()
-        mock_completion.choices = [MagicMock()]
-        mock_completion.choices[0].message.content = mock_response.text
+        self.assertEqual(dates, expected_dates)
+        self.assertEqual(len(self.llm_service.prompts), 1)
         
-        with patch.object(self.service.client.chat.completions, 'create', return_value=mock_completion):
-            # 日付を生成
-            dates = self.service.generate_dates(
-                rule=rule,
-                base_date=date(2024, 12, 1),
-                base_time=time(22, 0),
-                months=3,
-                community=self.community
-            )
-            
-            # 生成された日付を確認
-            expected_dates = [
-                date(2024, 12, 23),  # 第4月曜
-                date(2025, 1, 27),   # 第4月曜
-                date(2025, 2, 24),   # 第4月曜
-            ]
-            
-            self.assertEqual(dates, expected_dates)
-            
-            # 全て月曜日であることを確認
-            for d in dates:
-                self.assertEqual(d.weekday(), 0, f"{d} は月曜日ではありません (weekday={d.weekday()})")
+        # 全て月曜日であることを確認
+        for d in dates:
+            self.assertEqual(d.weekday(), 0, f"{d} は月曜日ではありません (weekday={d.weekday()})")
     
     def test_llm_prompt_for_monthly_pattern(self):
         """月次パターンのLLMプロンプトを確認"""
@@ -96,36 +102,18 @@ class TestRecurrenceRuleGeneration(TestCase):
             start_date=date(2024, 12, 1)
         )
         
-        # プロンプト生成をキャプチャ
-        captured_prompt = None
-        
-        def capture_prompt(*args, **kwargs):
-            nonlocal captured_prompt
-            # メッセージからプロンプトを取得
-            messages = kwargs.get('messages', [])
-            for msg in messages:
-                if msg.get('role') == 'user':
-                    captured_prompt = msg.get('content', '')
-            # モックレスポンスを返す
-            mock_completion = MagicMock()
-            mock_completion.choices = [MagicMock()]
-            mock_completion.choices[0].message.content = '[\"2024-12-23\"]'
-            return mock_completion
-        
-        with patch.object(self.service.client.chat.completions, 'create', side_effect=capture_prompt):
-            self.service.generate_dates(
-                rule=rule,
-                base_date=date(2024, 12, 1),
-                base_time=time(22, 0),
-                months=1,
-                community=self.community
-            )
+        self.llm_service.dates = [date(2024, 12, 23)]
+        self.service.generate_dates(
+            rule=rule,
+            base_date=date(2024, 12, 1),
+            base_time=time(22, 0),
+            months=1,
+            community=self.community
+        )
+        captured_prompt = self.llm_service.prompts[0]
         
         # プロンプトの内容を確認
         self.assertIsNotNone(captured_prompt)
-        print("\n=== Captured LLM Prompt ===")
-        print(captured_prompt)
-        print("=== End of Prompt ===\n")
         
         self.assertIn('毎月第4月曜', captured_prompt)
         self.assertIn('基準日: 2024-12-01 (日曜日)', captured_prompt)
@@ -137,6 +125,32 @@ class TestRecurrenceRuleGeneration(TestCase):
         # 月の最終週は第5週として計算される場合がある
         week_pattern_found = '主な開催週: 第4週' in captured_prompt or '主な開催週: 第5週' in captured_prompt
         self.assertTrue(week_pattern_found, "週のパターンが正しく検出されていません")
+
+    def test_custom_rule_uses_llm_service_abstraction(self):
+        """自由記述ルールは注入したLLMサービスで日付を生成する"""
+        rule = RecurrenceRule.objects.create(
+            community=self.community,
+            frequency='OTHER',
+            custom_rule='祝日の翌営業日',
+            start_date=date(2024, 12, 1)
+        )
+        self.llm_service.dates = [
+            date(2024, 12, 20),
+            date(2025, 3, 1),
+            date(2024, 12, 20),
+        ]
+
+        dates = self.service.generate_dates(
+            rule=rule,
+            base_date=date(2024, 12, 1),
+            base_time=time(22, 0),
+            months=2,
+            community=self.community
+        )
+
+        self.assertEqual(dates, [date(2024, 12, 20)])
+        self.assertEqual(len(self.llm_service.prompts), 1)
+        self.assertIn('祝日の翌営業日', self.llm_service.prompts[0])
     
     def test_monthly_by_week_rule_generation(self):
         """MONTHLY_BY_WEEK頻度での第N曜日生成テスト"""


### PR DESCRIPTION
## なぜこの変更が必要か

- Issue #331「refactor(event): recurrence_service.py の LLM呼び出しを抽象化」に対する fix-flow の自動修正として作成した差分です

## 変更内容

- `app/event/llm_service.py` を追加し、`generate_event_dates(prompt: str) -> list[date]` のLLM抽象と OpenRouter/OpenAI/Gemini アダプタを実装しました。
- `app/event/recurrence_service.py` から OpenAI SDK / OpenRouter 直呼び出しを削除し、注入可能な `EventDateLlmService` 経由に変更しました。
- `settings.RECURRENCE_LLM_PROVIDER` による provider 切り替えを追加しました。既定は既存挙動に合わせて `openrouter` です。
- `app/event/tests/test_llm_service.py` を追加し、日付抽出と provider factory を検証しました。
- 既存の recurrence テストを LLM サービス注入方式へ更新し、コミット `488eefc` を作成しました。

## 意思決定

### 採用アプローチ
`RecurrenceService` は日付計算とプロンプト構築に責務を寄せ、LLM API 呼び出しとレスポンスの日付抽出を `llm_service.py` に分離しました。
テストでは fake LLM サービスを注入できるようにし、外部APIキーやネットワークに依存せず自由記述ルールの挙動を検証できる構成にしました。
settings ファイルは保護対象のため変更せず、`getattr(settings, ...)` で未定義時の既定値を持たせました。

### トレードオフ または 却下した代替案
`recurrence_service.py` 内に provider 分岐だけを追加する案は、密結合が残り mock test もしづらいため却下しました。
settings へ `RECURRENCE_LLM_PROVIDER` を追記する案はDoDに近いものの、今回の保護対象ファイルに該当するため変更せず、コード側で未定義時の既定値を扱う方針にしました。

### 残課題やリスク
なし。保護対象ファイルは変更していません。


## テスト

- `COMPOSE_PROJECT_NAME=vrc-ta-hub-issue331 ... docker compose run --rm -T vrc-ta-hub python manage.py test event.tests.test_llm_service event.tests.test_recurrence_rule_generation -v 2`: 13 tests OK
- `COMPOSE_PROJECT_NAME=vrc-ta-hub-issue331 ... docker compose run --rm -T vrc-ta-hub python manage.py test event.tests -v 1`: 290 tests OK, skipped=13
- `COMPOSE_PROJECT_NAME=vrc-ta-hub-issue331 ... docker compose run --rm -T vrc-ta-hub python manage.py test api_v1.tests community.tests event.tests event_calendar.tests guide.tests ta_hub.tests twitter.tests user_account.tests website.tests --verbosity=0`: 1168 tests OK, skipped=13
- `COMPOSE_PROJECT_NAME=vrc-ta-hub-issue331 ... docker compose run --rm -T vrc-ta-hub python -m py_compile ...`: pass
- `uvx ruff check app/event/llm_service.py app/event/recurrence_service.py app/event/tests/test_llm_service.py app/event/tests/test_recurrence_rule_generation.py app/event/tests/test_recurrence_llm_generation.py`: All checks passed

---
🤖 Generated with [Codex](https://Codex.com/Codex)
