### PR TITLE
refactor: DB再接続Mixinを共通化

### DIFF
--- a/app/api_v1/base.py
+++ b/app/api_v1/base.py
@@ -1,0 +1,61 @@
+"""API v1 viewset の共通基底クラス。"""
+
+import logging
+from typing import Any
+
+from django.db import connections
+from django.db.utils import OperationalError
+from rest_framework import status
+from rest_framework.response import Response
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseReconnectListMixin:
+    """MySQL の切断系エラー時に読み取り list API を一度だけ再試行する。"""
+
+    MYSQL_DISCONNECT_ERROR_CODES = {2002, 2006, 2013, 2055}
+    MYSQL_DISCONNECT_ERROR_MESSAGES = (
+        "can't connect",
+        "lost connection",
+        "reading initial communication packet",
+        "server has gone away",
+    )
+
+    def list(self, request: Any, *args: Any, **kwargs: Any) -> Response:
+        try:
+            return super().list(request, *args, **kwargs)
+        except OperationalError as exc:
+            if not self._should_retry_after_disconnect(exc):
+                raise
+
+            logger.warning(
+                "Retrying %s.list after a transient database disconnect: %s",
+                self.__class__.__name__,
+                exc,
+            )
+            connections.close_all()
+            try:
+                return super().list(request, *args, **kwargs)
+            except OperationalError as retry_exc:
+                if not self._should_retry_after_disconnect(retry_exc):
+                    raise
+
+                logger.warning(
+                    "%s.list returned 503 because the database remained unavailable after reconnect: %s",
+                    self.__class__.__name__,
+                    retry_exc,
+                )
+                return Response(
+                    {"detail": "Database temporarily unavailable."},
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                )
+
+    def _should_retry_after_disconnect(self, exc: OperationalError) -> bool:
+        if exc.args:
+            code = exc.args[0]
+            if isinstance(code, int) and code in self.MYSQL_DISCONNECT_ERROR_CODES:
+                return True
+
+        message = str(exc).lower()
+        return any(fragment in message for fragment in self.MYSQL_DISCONNECT_ERROR_MESSAGES)

--- a/app/api_v1/tests/test_database_reconnect.py
+++ b/app/api_v1/tests/test_database_reconnect.py
@@ -1,10 +1,25 @@
+from unittest.mock import patch
+
 from django.db.utils import OperationalError
 from django.test import SimpleTestCase
 from rest_framework import viewsets
 from rest_framework.response import Response
-from rest_framework.test import APIRequestFactory
+from rest_framework.test import APIRequestFactory, force_authenticate
 
-from api_v1.views import DatabaseReconnectListMixin
+from api_v1.base import DatabaseReconnectListMixin
+from api_v1.views import (
+    CommunityViewSet,
+    EventDetailAPIViewSet,
+    EventDetailViewSet,
+    EventViewSet,
+    RecurrenceRuleViewSet,
+)
+
+
+class AuthenticatedUser:
+    is_authenticated = True
+    is_superuser = True
+    pk = 1
 
 
 class TransientFailureListViewSet(viewsets.ViewSet):
@@ -91,3 +106,34 @@ class DatabaseReconnectListMixinTest(SimpleTestCase):
 
         with self.assertRaises(OperationalError):
             view(request)
+
+    def test_all_api_v1_viewsets_retry_list_after_mysql_disconnect(self):
+        target_viewsets = (
+            CommunityViewSet,
+            EventViewSet,
+            EventDetailViewSet,
+            EventDetailAPIViewSet,
+            RecurrenceRuleViewSet,
+        )
+
+        for viewset_class in target_viewsets:
+            with self.subTest(viewset=viewset_class.__name__):
+                view = viewset_class.as_view({'get': 'list'})
+                request = self.factory.get('/api/v1/test/')
+                force_authenticate(request, user=AuthenticatedUser())
+
+                with (
+                    patch('api_v1.base.connections.close_all') as mock_close_all,
+                    patch('rest_framework.mixins.ListModelMixin.list') as mock_list,
+                ):
+                    mock_list.side_effect = [
+                        OperationalError(2013, 'Lost connection to server during query'),
+                        Response({'viewset': viewset_class.__name__}),
+                    ]
+
+                    response = view(request)
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.data, {'viewset': viewset_class.__name__})
+                self.assertEqual(mock_list.call_count, 2)
+                mock_close_all.assert_called_once_with()

--- a/app/api_v1/views.py
+++ b/app/api_v1/views.py
@@ -1,9 +1,5 @@
 # Create your views here.
 # from corsheaders.middleware import CorsMiddleware  # No longer needed
-import logging
-
-from django.db import connections
-from django.db.utils import OperationalError
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -29,6 +25,7 @@ from event.datetime_lock import (
 )
 from event.models import Event, EventDetail, RecurrenceRule
 from .authentication import APIKeyAuthentication
+from .base import DatabaseReconnectListMixin
 from .serializers import (
     CommunitySerializer, EventSerializer, EventDetailSerializer, EventDetailWriteSerializer,
     RecurrenceRuleSerializer, RecurrenceRuleDeleteSerializer, GatheringListSerializer,
@@ -36,60 +33,7 @@ from .serializers import (
 )
 
 
-logger = logging.getLogger(__name__)
-
-
 # CORSMixin is no longer needed as CORS is handled by Django middleware
-
-
-class DatabaseReconnectListMixin:
-    """MySQL の切断系エラー時に読み取り list API を一度だけ再試行する。"""
-
-    MYSQL_DISCONNECT_ERROR_CODES = {2002, 2006, 2013, 2055}
-    MYSQL_DISCONNECT_ERROR_MESSAGES = (
-        "can't connect",
-        "lost connection",
-        "reading initial communication packet",
-        "server has gone away",
-    )
-
-    def list(self, request, *args, **kwargs):
-        try:
-            return super().list(request, *args, **kwargs)
-        except OperationalError as exc:
-            if not self._should_retry_after_disconnect(exc):
-                raise
-
-            logger.warning(
-                "Retrying %s.list after a transient database disconnect: %s",
-                self.__class__.__name__,
-                exc,
-            )
-            connections.close_all()
-            try:
-                return super().list(request, *args, **kwargs)
-            except OperationalError as retry_exc:
-                if not self._should_retry_after_disconnect(retry_exc):
-                    raise
-
-                logger.warning(
-                    "%s.list returned 503 because the database remained unavailable after reconnect: %s",
-                    self.__class__.__name__,
-                    retry_exc,
-                )
-                return Response(
-                    {"detail": "Database temporarily unavailable."},
-                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
-                )
-
-    def _should_retry_after_disconnect(self, exc):
-        if exc.args:
-            code = exc.args[0]
-            if isinstance(code, int) and code in self.MYSQL_DISCONNECT_ERROR_CODES:
-                return True
-
-        message = str(exc).lower()
-        return any(fragment in message for fragment in self.MYSQL_DISCONNECT_ERROR_MESSAGES)
 
 
 class CommunityFilter(filters.FilterSet):


### PR DESCRIPTION
## なぜこの変更が必要か

- Issue #328「refactor(api_v1): DatabaseReconnectListMixin を共通Baseに統一」に対する fix-flow の自動修正として作成した差分です

## 変更内容

- `app/api_v1/base.py` を新規作成し、`DatabaseReconnectListMixin` を共通実装として移動しました。
- `app/api_v1/views.py` から重複していた Mixin 定義と不要 import を削除し、共通 Mixin の import に置き換えました。
- `app/api_v1/tests/test_database_reconnect.py` の import 先を `api_v1.base` に変更しました。
- 既存の5つの API v1 ViewSet すべてで、DB接続断後に `list` が一度だけ再試行されることを検証するテストを追加しました。
- コミット: `6cab679 refactor: DB再接続Mixinを共通化`

## 意思決定

### 採用アプローチ
`DatabaseReconnectListMixin` は API v1 ViewSet 専用の共通部品なので、`api_v1` 配下の `base.py` に集約しました。  
既存 ViewSet の継承順とレスポンス挙動は維持し、呼び出し側は import だけを差し替える最小変更にしています。

### トレードオフ または 却下した代替案
`twitter.db` の再接続ヘルパーへ統合する案も考えましたが、戻り値や 503 応答の責務が ViewSet 固有のため今回は分けました。  
DRF の `ListModelMixin.list` を patch するテストにし、実DBを壊さず全 ViewSet の継承経路を検証しています。

### 残課題やリスク
全アプリの Django テストは未実行です。変更範囲は `api_v1` に閉じており、`api_v1.tests` と `ruff check app/` は通過しています。  
保護対象ファイルの変更はありません。


## テスト

- `uv run --no-project --with ruff==0.11.6 ruff check app/` -> pass
- `docker compose run --rm --no-deps ... python manage.py test api_v1.tests.test_database_reconnect -v 2` -> 5 tests pass
- `docker compose run --rm --no-deps ... python manage.py test api_v1.tests -v 2` -> 53 tests pass

---
🤖 Generated with [Codex](https://Codex.com/Codex)
