### PR TITLE
fix: 設定値集約の見落としを追補 + 偽装ドメイン判定の統一 (#348)

### DIFF
--- a/app/community/tests/test_community_report.py
+++ b/app/community/tests/test_community_report.py
@@ -79,6 +79,12 @@ class CommunityReportViewTest(TestCase):
         self.assertIn('活動停止が通報されました', payload['content'])
         self.assertEqual(payload['embeds'][0]['title'], 'テスト集会')
         self.assertEqual(payload['embeds'][0]['fields'][0]['value'], '1')
+        # community_url が build_site_url 経由の絶対 URL で組み立てられていることを保証する。
+        # SITE_URL/APP_CANONICAL_HOST を切り替えても通報リンクが壊れないことの回帰テスト。
+        from website.constants import build_site_url
+        expected_url = build_site_url(f"/community/{self.community.pk}/")
+        self.assertEqual(payload['embeds'][0]['url'], expected_url)
+        self.assertIn(expected_url, payload['content'])
 
     def test_webhook_not_sent_when_url_empty(self):
         """Webhook URLが空の場合は送信しない"""

--- a/app/community/views/helpers.py
+++ b/app/community/views/helpers.py
@@ -4,6 +4,8 @@ import logging
 import requests
 from django.conf import settings
 
+from website.constants import build_site_url
+
 logger = logging.getLogger(__name__)
 
 # Discord Webhook 送信タイムアウト（秒）
@@ -20,7 +22,7 @@ def _send_report_webhook(community, report_count):
     if not webhook_url:
         return
 
-    community_url = f"https://vrc-ta-hub.com/community/{community.pk}/"
+    community_url = build_site_url(f"/community/{community.pk}/")
     message = {
         "content": (
             f"**集会の活動停止が通報されました**\n"

--- a/app/event/llm_service.py
+++ b/app/event/llm_service.py
@@ -11,13 +11,14 @@ from django.conf import settings
 from openai import OpenAI
 from pydantic import BaseModel, Field
 
+from website.constants import OPENROUTER_BASE_URL, build_site_url
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_RECURRENCE_LLM_PROVIDER = "openrouter"
 DEFAULT_RECURRENCE_MODEL = "google/gemini-2.0-flash-exp"
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_EXTRA_HEADERS = {
-    "HTTP-Referer": "https://vrc-ta-hub.com/",
+    "HTTP-Referer": build_site_url("/"),
     "X-Title": "VRC TA Hub",
 }
 SYSTEM_PROMPT = "あなたは定期イベントの日付を生成する専門家です。必ず指定されたJSON形式で出力してください。"

--- a/app/event/management/commands/sanitize_event_detail_security.py
+++ b/app/event/management/commands/sanitize_event_detail_security.py
@@ -9,11 +9,9 @@ from django.db import transaction
 from django.db.models import Q
 
 from event.models import EventDetail
+from website.constants import is_site_domain
 
 logger = logging.getLogger(__name__)
-
-
-SELF_DOMAIN_SUFFIX = "vrc-ta-hub.com"
 
 SCRIPT_TAG_RE = re.compile(r"<script\b[^>]*>.*?</script\s*>", flags=re.IGNORECASE | re.DOTALL)
 SCRIPT_SELF_CLOSING_RE = re.compile(r"<script\b[^>]*/\s*>", flags=re.IGNORECASE | re.DOTALL)
@@ -70,7 +68,10 @@ def _is_self_domain_url(url: str) -> bool:
             url,
         )
         return True
-    return parsed.netloc.endswith(SELF_DOMAIN_SUFFIX)
+    # hostname を使うとポート番号や userinfo を除去した正規化済みの値が得られる。
+    # endswith による suffix 一致は evilvrc-ta-hub.com のような偽装ドメインを許すため、
+    # is_site_domain (正確なドメイン or サブドメイン判定) を使う。
+    return is_site_domain(parsed.hostname)
 
 
 def sanitize_event_detail_contents(contents: str) -> tuple[str, tuple[str, ...]]:

--- a/app/event/tests/test_llm_service.py
+++ b/app/event/tests/test_llm_service.py
@@ -38,6 +38,28 @@ class EventDateLlmServiceTest(SimpleTestCase):
         self.assertEqual(service.config.model_name, "google/test-model")
 
     @override_settings(
+        RECURRENCE_LLM_PROVIDER="openrouter",
+        RECURRENCE_LLM_MODEL="google/test-model",
+    )
+    def test_openrouter_uses_website_constants(self):
+        """OpenRouter 設定が website.constants から組み立てられることを保証する。
+
+        OPENROUTER_BASE_URL と HTTP-Referer がハードコードされた値ではなく、
+        website.constants 経由（build_site_url / 環境変数）になっていることを
+        確認する。preview/本番で SITE_URL を切り替えたときに壊れていないか拾う。
+        """
+        from website.constants import OPENROUTER_BASE_URL, build_site_url
+        from event.llm_service import OPENROUTER_EXTRA_HEADERS
+
+        service = get_event_date_llm_service()
+
+        self.assertEqual(service.config.base_url, OPENROUTER_BASE_URL)
+        self.assertEqual(
+            OPENROUTER_EXTRA_HEADERS["HTTP-Referer"],
+            build_site_url("/"),
+        )
+
+    @override_settings(
         RECURRENCE_LLM_PROVIDER="openai",
         RECURRENCE_LLM_MODEL="gpt-test-model",
     )

--- a/app/event/tests/test_sanitize_event_detail_security_command.py
+++ b/app/event/tests/test_sanitize_event_detail_security_command.py
@@ -5,7 +5,11 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from community.models import Community
-from event.management.commands.sanitize_event_detail_security import _is_pdf_magic_bytes
+from event.management.commands.sanitize_event_detail_security import (
+    _is_pdf_magic_bytes,
+    _is_self_domain_url,
+    sanitize_event_detail_contents,
+)
 from event.models import Event, EventDetail
 
 
@@ -61,3 +65,57 @@ class TestSanitizeEventDetailSecurityCommand(TestCase):
         event_detail.refresh_from_db()
         self.assertNotIn("<iframe", event_detail.contents)
         self.assertFalse(bool(event_detail.slide_file))
+
+
+class TestIsSelfDomainUrl(TestCase):
+    """偽装ドメインを suffix 一致で誤って自ドメイン扱いしないことを確認する."""
+
+    def test_exact_self_domain_is_self(self):
+        self.assertTrue(_is_self_domain_url("https://vrc-ta-hub.com/foo"))
+
+    def test_subdomain_is_self(self):
+        self.assertTrue(_is_self_domain_url("https://data.vrc-ta-hub.com/slide.pdf"))
+
+    def test_spoofed_prefix_domain_is_not_self(self):
+        # 旧実装の endswith("vrc-ta-hub.com") は True を返してしまうが、
+        # is_site_domain ベースの判定では False になる。
+        self.assertFalse(_is_self_domain_url("https://evilvrc-ta-hub.com/exploit"))
+
+    def test_spoofed_domain_with_self_in_path_is_not_self(self):
+        self.assertFalse(
+            _is_self_domain_url("https://attacker.example.com/vrc-ta-hub.com"),
+        )
+
+    def test_different_domain_is_not_self(self):
+        self.assertFalse(_is_self_domain_url("https://example.com/page"))
+
+    def test_url_with_port_is_handled(self):
+        # hostname プロパティを使うので、ポート番号付きでも正しく判定できる。
+        self.assertTrue(_is_self_domain_url("https://vrc-ta-hub.com:8443/path"))
+        self.assertFalse(_is_self_domain_url("https://evilvrc-ta-hub.com:8443/path"))
+
+
+class TestSanitizeEventDetailContentsSpoofedIframe(TestCase):
+    """偽装ドメインの iframe を「自ドメイン」とみなさず温存することを確認する."""
+
+    def test_spoofed_iframe_is_preserved(self):
+        # 偽装ドメインへの iframe は外部扱いとなり、自ドメイン除去ロジックには引っかからない。
+        contents = (
+            "before\n"
+            '<iframe src="https://evilvrc-ta-hub.com/exploit" '
+            'width="500" height="500"></iframe>\n'
+            "after\n"
+        )
+        sanitized, notes = sanitize_event_detail_contents(contents)
+
+        # 偽装ドメインを自ドメインとして除去していないことを確認
+        self.assertNotIn("Removed self-domain <iframe>", notes)
+
+    def test_self_domain_iframe_is_removed(self):
+        contents = (
+            '<iframe src="https://data.vrc-ta-hub.com/slide.pdf"></iframe>'
+        )
+        sanitized, notes = sanitize_event_detail_contents(contents)
+
+        self.assertNotIn("<iframe", sanitized)
+        self.assertIn("Removed self-domain <iframe>", notes)

--- a/app/event/tests/test_sanitize_event_detail_security_command.py
+++ b/app/event/tests/test_sanitize_event_detail_security_command.py
@@ -96,10 +96,17 @@ class TestIsSelfDomainUrl(TestCase):
 
 
 class TestSanitizeEventDetailContentsSpoofedIframe(TestCase):
-    """偽装ドメインの iframe を「自ドメイン」とみなさず温存することを確認する."""
+    """偽装ドメインの iframe を「自ドメイン」と誤判定しないことを確認する.
 
-    def test_spoofed_iframe_is_preserved(self):
-        # 偽装ドメインへの iframe は外部扱いとなり、自ドメイン除去ロジックには引っかからない。
+    本コマンドの責務は「自ドメイン配下の iframe を除去する」ことに限定される
+    （外部 iframe は description にあるとおり対象外）。
+    したがって evilvrc-ta-hub.com のような偽装ドメインは "外部扱い" となり、
+    DB 上には残る。最終的な XSS 防止は `convert_markdown()` 側の allowlist が担う。
+    本テストは「偽装ドメインが自ドメインとして除去ロジックを発動させない」
+    （= is_site_domain 修正の回帰防止）ことだけを保証する。
+    """
+
+    def test_spoofed_iframe_is_not_classified_as_self_domain(self):
         contents = (
             "before\n"
             '<iframe src="https://evilvrc-ta-hub.com/exploit" '
@@ -108,8 +115,11 @@ class TestSanitizeEventDetailContentsSpoofedIframe(TestCase):
         )
         sanitized, notes = sanitize_event_detail_contents(contents)
 
-        # 偽装ドメインを自ドメインとして除去していないことを確認
+        # 自ドメインとして除去されていないことを確認
         self.assertNotIn("Removed self-domain <iframe>", notes)
+        # iframe 本体が外部扱いとして温存されていることを直接確認
+        self.assertIn("<iframe", sanitized)
+        self.assertIn("evilvrc-ta-hub.com", sanitized)
 
     def test_self_domain_iframe_is_removed(self):
         contents = (

--- a/app/event/views/detail.py
+++ b/app/event/views/detail.py
@@ -12,6 +12,7 @@ from event.libs import convert_markdown
 from event.models import EventDetail
 from event.views.helpers import can_manage_event_detail, extract_video_info
 from utils.vrchat_time import get_vrchat_today
+from website.constants import CACHE_TTL_HOUR
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +157,7 @@ class EventDetailView(DetailView):
         related_event_details = cache.get(cache_key)
         if related_event_details is None:
             max_related_items = 6
-            cache_timeout_seconds = 60 * 60
+            cache_timeout_seconds = CACHE_TTL_HOUR
             # キャッシュがない場合のみDBクエリを実行
             related_event_details = list(
                 EventDetail.objects

--- a/app/twitter/notifications.py
+++ b/app/twitter/notifications.py
@@ -8,6 +8,7 @@ import requests
 from django.conf import settings
 
 from twitter.x_api import PostTweetResult
+from website.constants import build_site_url
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ def notify_tweet_post_failure(queue_item, result: PostTweetResult) -> None:
     status_code = result.get("status_code")
     status_code_text = str(status_code) if status_code is not None else "N/A"
 
-    detail_url = f"https://vrc-ta-hub.com/twitter/queue/{queue_item.pk}/"
+    detail_url = build_site_url(f"/twitter/queue/{queue_item.pk}/")
 
     fields = [
         {"name": "集会", "value": queue_item.community.name, "inline": True},

--- a/app/twitter/tests/test_post_failure_notification.py
+++ b/app/twitter/tests/test_post_failure_notification.py
@@ -111,9 +111,12 @@ class NotifyTweetPostFailureTest(TestCase):
         self.assertIn("エラー内容", field_values_by_name)
         self.assertIn("Forbidden", field_values_by_name["エラー内容"])
         self.assertIn("キュー詳細", field_values_by_name)
-        self.assertIn(
-            f"/twitter/queue/{self.queue_item.pk}/",
+        # build_site_url 経由で組み立てられる絶対 URL を直接検証する。
+        # SITE_URL/APP_CANONICAL_HOST を切り替えたときに壊れないことを保証する。
+        from website.constants import build_site_url
+        self.assertEqual(
             field_values_by_name["キュー詳細"],
+            build_site_url(f"/twitter/queue/{self.queue_item.pk}/"),
         )
         self.assertIn("集会", field_values_by_name)
         self.assertEqual(field_values_by_name["集会"], self.community.name)


### PR DESCRIPTION
Closes #348

## 概要

PR #336（Issue #325）で導入した `website.constants` 経由化のうち、見落としていた 5 箇所を集約し、`sanitize_event_detail_security` の iframe 自ドメイン判定を `is_site_domain()` に置換した。`endswith('vrc-ta-hub.com')` は `evilvrc-ta-hub.com` のような suffix 偽装ドメインを許してしまう既存バグだったため、構造的に修正している。

## 変更内容

### 設定値の集約（5 箇所）

| ファイル | 変更 |
|---|---|
| `app/event/llm_service.py` | モジュール定数の `OPENROUTER_BASE_URL` / `HTTP-Referer` を `website.constants` 参照に変更 |
| `app/twitter/notifications.py` | `detail_url` を `build_site_url(...)` で組み立て |
| `app/community/views/helpers.py` | `community_url` を `build_site_url(...)` で組み立て |
| `app/event/views/detail.py` | `cache_timeout_seconds = 60 * 60` を `CACHE_TTL_HOUR` に |
| `app/event/management/commands/sanitize_event_detail_security.py` | `parsed.netloc.endswith(SELF_DOMAIN_SUFFIX)` → `is_site_domain(parsed.hostname)` |

### セキュリティ修正（偽装ドメイン対策）

- `parsed.netloc.endswith('vrc-ta-hub.com')` は `evilvrc-ta-hub.com` を `True` と判定してしまう
- `website.constants.is_site_domain()` は完全一致 or `.` 区切りサブドメインのみ True にするため、構造的に弾ける
- 加えて `parsed.netloc` ではなく `parsed.hostname` を使うことで、ポート番号付き URL も正規化される

### テスト

`app/event/tests/test_sanitize_event_detail_security_command.py` に以下を追加:

- `_is_self_domain_url` の単体テスト（完全一致 / サブドメイン / 偽装プレフィックス / ポート付き）
- `sanitize_event_detail_contents` で偽装ドメインの iframe が「自ドメイン扱い」されないことを確認

## 検証結果

- `python manage.py test`: 1376 tests, OK (skipped=13)
- `python manage.py test event twitter community website`: 882 tests, OK

## 注意点

- `OPENROUTER_BASE_URL` は `llm_service.py` 内のモジュール変数として再 export される形になる（`get_event_date_llm_service` の既存参照を壊さないため）。実体は `website.constants.OPENROUTER_BASE_URL`
- 後方互換性は不要のため、`SELF_DOMAIN_SUFFIX` 定数は削除した

🤖 Generated with [Claude Code](https://claude.com/claude-code)