### PR TITLE
fix: テスト中のTweet生成スレッド起動を抑制

### DIFF
--- a/app/twitter/signals.py
+++ b/app/twitter/signals.py
@@ -4,9 +4,11 @@
 """
 
 import logging
+import sys
 import threading
 import uuid
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import DatabaseError
 from django.db.models.signals import post_delete, post_save, pre_save
@@ -23,6 +25,19 @@ logger = logging.getLogger(__name__)
 PRESENTATION_DETAIL_TYPES = ("LT", "SPECIAL")
 SAME_DAY_INDIVIDUAL_SKIP_REASON = '当日リマインドに統合したため個別告知は投稿しません'
 NO_APPROVED_PRESENTATIONS_SKIP_REASON = '承認済みの当日発表がないため投稿対象外'
+
+
+def _should_skip_tweet_generation_thread() -> bool:
+    """テスト実行時は TweetQueue 生成後のバックグラウンドスレッドだけ抑制する。"""
+    if getattr(settings, 'ENABLE_TWEET_GENERATION_THREADS_IN_TESTS', False):
+        return False
+
+    is_test_run = getattr(settings, 'TESTING', False) or 'test' in sys.argv
+    if not is_test_run:
+        return False
+
+    # Thread を明示 patch するテストは、この経路自体を検証している。
+    return getattr(threading.Thread, '__module__', 'threading') == 'threading'
 
 
 def _save_generation_failure(queue_id: int, generation_token: str, error_message: str) -> None:
@@ -128,6 +143,11 @@ def _start_tweet_generation(queue_item) -> None:
     generation_token = uuid.uuid4().hex
     queue_item.generation_token = generation_token
     queue_item.save(update_fields=['generation_token'])
+
+    if _should_skip_tweet_generation_thread():
+        logger.debug("Skipped tweet generation thread in tests for queue %d", queue_item.pk)
+        return
+
     thread = threading.Thread(
         target=_generate_tweet_async, args=(queue_item.pk, generation_token), daemon=True,
     )

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -56,6 +56,37 @@ class EventTestPatchScopeTest(TestCase):
         self.assertIs(signals._start_tweet_generation, original)
 
 
+class TweetGenerationThreadGuardTest(TestCase):
+    """テスト実行時の本文生成スレッド起動ガードを検証する。"""
+
+    @patch("twitter.signals.threading.Thread.start")
+    def test_testing_mode_saves_generation_token_without_starting_thread(self, mock_start):
+        """manage.py test では generation_token を保存しつつスレッドを起動しない。"""
+        community = Community.objects.create(
+            name="Thread Guard Community",
+            start_time=datetime.time(22, 0),
+            duration=60,
+            weekdays=["Mon"],
+            frequency="毎週",
+            organizers="Test Organizer",
+            status="pending",
+        )
+        queue = TweetQueue.objects.create(
+            tweet_type="new_community",
+            community=community,
+            status="generating",
+        )
+
+        from twitter import signals
+
+        with patch.object(signals.sys, "argv", ["manage.py", "test"]):
+            signals._start_tweet_generation(queue)
+
+        queue.refresh_from_db()
+        self.assertTrue(queue.generation_token)
+        mock_start.assert_not_called()
+
+
 class DBReconnectHelperTest(TestCase):
     """MySQL 接続断の再試行ヘルパーのテスト"""
 

--- a/docs/research/issue-354-tweet-generation-test-threads.md
+++ b/docs/research/issue-354-tweet-generation-test-threads.md
@@ -1,0 +1,47 @@
+# Issue #354 テスト中の TweetQueue 本文生成スレッド抑制 調査メモ
+
+## 概要
+
+`Community(status="approved")` や承認済み `EventDetail` の保存で `TweetQueue` が作成されると、
+`twitter.signals._start_tweet_generation()` が本文生成用のバックグラウンドスレッドを起動していた。
+SQLite テスト DB ではこの別スレッドが同じテーブルへアクセスし、`database table is locked` の
+ランダムなログを出す原因になり得る。
+
+## 観測結果
+
+- `app/twitter/signals.py` は `queue_new_community_tweet()`、
+  `queue_event_detail_tweet()`、`queue_slide_share_tweet()` から
+  `_start_tweet_generation()` を呼び、`threading.Thread.start()` で非同期生成を開始する。
+- `app/website/settings.py` は `TESTING` または `sys.argv` の `test` で SQLite テスト DB へ切り替える。
+  `TESTING` 変数自体は環境変数由来のため、保護対象の設定ファイルは変更せず、
+  シグナル側でも `sys.argv` の `test` をテスト実行判定に含めた。
+- 既知の影響箇所である `app/user_account/tests/test_lt_application_views.py` と
+  `app/ta_hub/tests/test_index_view_degraded_mode.py` は、承認済み `Community` / `EventDetail` を保存し、
+  テスト対象外の TweetQueue 本文生成を副作用として起動していた。
+- `event.tests.tweet_generation.TweetGenerationPatchMixin` は event テスト内の明示的な抑制には有効だが、
+  他アプリのテストへ適用漏れが起きる。
+
+## 原因
+
+本文生成スレッドの起動可否がテスト実行状態を見ておらず、`TweetQueue` 作成を検証したいだけの
+テストでも実スレッドが開始されていた。`TestCase` の SQLite DB は同一プロセス内の別スレッドから
+読まれる前提になっていないため、ロック競合が発生しやすい。
+
+## 改善案と採用方針
+
+`_start_tweet_generation()` で `generation_token` の保存までは従来通り行い、
+`settings.TESTING=True` または `manage.py test` 実行時だけスレッド起動前に返すようにした。
+
+この方針は、全アプリのテストに横断的に効き、個別テストへ mixin を追加し忘れるリスクを減らせる。
+一方で、Twitter シグナル自体のテストは `twitter.signals.threading.Thread` を明示的に
+patch しているため、従来通り本番相当のスレッド起動経路を検証できる。
+
+## 検証手順
+
+- `twitter.tests.test_auto_tweet.TweetGenerationThreadGuardTest` で、`manage.py test` 判定時は
+  `generation_token` が保存され、`threading.Thread.start()` が呼ばれないことを確認する。
+- `user_account.tests.test_lt_application_views` と
+  `ta_hub.tests.test_index_view_degraded_mode` で、既知の他アプリテストが副作用スレッドなしで通ることを確認する。
+- `twitter.tests.test_auto_tweet` のシグナル系テストで、`threading.Thread` を明示 patch した場合は従来通り
+  `threading.Thread.start()` 経路を検証できることを確認する。
+- `python manage.py test` 全体で `database table is locked` が出ないことを確認する。


### PR DESCRIPTION
## なぜこの変更が必要か

- Issue #354「test: 他アプリのテストでも _start_tweet_generation のスレッド起動副作用を抑制する」に対する fix-flow の自動修正として作成した差分です

## 変更内容

- `app/twitter/signals.py` にテスト実行時の Tweet 生成スレッド抑制判定を追加
- `generation_token` 保存は維持し、`threading.Thread.start()` の前で返すよう変更
- `app/twitter/tests/test_auto_tweet.py` に回帰テストを追加
- `docs/research/issue-354-tweet-generation-test-threads.md` に原因・方針・検証手順を記録
- コミット作成済み: `861cd3a`

## 意思決定

### 採用アプローチ
`settings.py` は保護対象なので変更せず、`signals.py` 側で `settings.TESTING` と `manage.py test` 実行状態を判定しました。  
Thread を明示 patch している Twitter シグナルテストは従来通りスレッド起動経路を検証できるようにしています。

### トレードオフ または 却下した代替案
個別テストへ mixin を追加する案は、他アプリへの適用漏れが再発しやすいため却下しました。  
本番処理そのものは変えず、テスト時の副作用だけを止める方針にしています。

### 残課題やリスク
なし。保護対象ファイルは変更していません。


## テスト

- `docker compose ... python manage.py test ...` 対象 65 件: OK
- `docker compose ... python manage.py test -v 1` 全体: 1369 件 OK、skipped 13
- `rg "database table is locked" /tmp/vrc-ta-hub-issue354-test.log`: 0 件
- `git diff --check`: pass

---
🤖 Generated with [Codex](https://Codex.com/Codex)
