### PR TITLE
feat: OpenRouter Refererを公開URLに固定

### DIFF
--- a/app/event/libs.py
+++ b/app/event/libs.py
@@ -24,7 +24,11 @@ from youtube_transcript_api._errors import NoTranscriptFound
 from event.models import EventDetail
 from event.prompts import BLOG_GENERATION_TEMPLATE
 from event.thumbnail import crop_to_slide_thumbnail_aspect_ratio
-from website.constants import OPENROUTER_BASE_URL, build_site_url, is_site_domain
+from website.constants import (
+    OPENROUTER_BASE_URL,
+    build_openrouter_extra_headers,
+    is_site_domain,
+)
 from website.settings import GOOGLE_API_KEY
 
 logger = logging.getLogger(__name__)
@@ -290,10 +294,7 @@ def generate_blog(event_detail: EventDetail, model=None) -> BlogOutput:
 
             # Function Callingを使用したリクエスト
             completion = client.chat.completions.create(
-                extra_headers={
-                    "HTTP-Referer": build_site_url("/"),  # OpenRouterのランキング用サイトURL
-                    "X-Title": "VRC TA Hub"  # OpenRouterのランキング用サイト名
-                },
+                extra_headers=build_openrouter_extra_headers(),
                 model=model,
                 messages=[
                     {"role": "system",

--- a/app/event/llm_service.py
+++ b/app/event/llm_service.py
@@ -11,16 +11,13 @@ from django.conf import settings
 from openai import OpenAI
 from pydantic import BaseModel, Field
 
-from website.constants import OPENROUTER_BASE_URL, build_site_url
+from website.constants import OPENROUTER_BASE_URL, build_openrouter_extra_headers
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_RECURRENCE_LLM_PROVIDER = "openrouter"
 DEFAULT_RECURRENCE_MODEL = "google/gemini-2.0-flash-exp"
-OPENROUTER_EXTRA_HEADERS = {
-    "HTTP-Referer": build_site_url("/"),
-    "X-Title": "VRC TA Hub",
-}
+OPENROUTER_EXTRA_HEADERS = build_openrouter_extra_headers()
 SYSTEM_PROMPT = "あなたは定期イベントの日付を生成する専門家です。必ず指定されたJSON形式で出力してください。"
 
 

--- a/app/event/tests/test_llm_service.py
+++ b/app/event/tests/test_llm_service.py
@@ -45,19 +45,17 @@ class EventDateLlmServiceTest(SimpleTestCase):
         """OpenRouter 設定が website.constants から組み立てられることを保証する。
 
         OPENROUTER_BASE_URL と HTTP-Referer がハードコードされた値ではなく、
-        website.constants 経由（build_site_url / 環境変数）になっていることを
-        確認する。preview/本番で SITE_URL を切り替えたときに壊れていないか拾う。
+        website.constants 経由（OPENROUTER_HTTP_REFERER / 環境変数）になっている
+        ことを確認する。preview/本番で SITE_URL を切り替えたときに壊れていないか拾う。
         """
-        from website.constants import OPENROUTER_BASE_URL, build_site_url
+        from website.constants import OPENROUTER_BASE_URL, build_openrouter_extra_headers
         from event.llm_service import OPENROUTER_EXTRA_HEADERS
 
         service = get_event_date_llm_service()
 
         self.assertEqual(service.config.base_url, OPENROUTER_BASE_URL)
-        self.assertEqual(
-            OPENROUTER_EXTRA_HEADERS["HTTP-Referer"],
-            build_site_url("/"),
-        )
+        self.assertEqual(OPENROUTER_EXTRA_HEADERS, build_openrouter_extra_headers())
+        self.assertEqual(service.config.extra_headers, build_openrouter_extra_headers())
 
     @override_settings(
         RECURRENCE_LLM_PROVIDER="openai",

--- a/app/twitter/tweet_generator.py
+++ b/app/twitter/tweet_generator.py
@@ -14,7 +14,11 @@ from django.db import connections
 from openai import OpenAI
 
 from ta_hub.libs import cloudflare_image_url
-from website.constants import OPENROUTER_BASE_URL, build_site_url
+from website.constants import (
+    OPENROUTER_BASE_URL,
+    build_openrouter_extra_headers,
+    build_site_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -374,10 +378,7 @@ def _call_llm(system_prompt: str, user_prompt: str) -> str | None:
             connections.close_all()
         client = OpenAI(base_url=OPENROUTER_BASE_URL, api_key=api_key)
         response = client.chat.completions.create(
-            extra_headers={
-                "HTTP-Referer": build_site_url("/"),
-                "X-Title": "VRC TA Hub",
-            },
+            extra_headers=build_openrouter_extra_headers(),
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},

--- a/app/website/constants.py
+++ b/app/website/constants.py
@@ -6,6 +6,8 @@ from website.hosts import normalize_host
 
 DEFAULT_SITE_DOMAIN = "vrc-ta-hub.com"
 DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_OPENROUTER_HTTP_REFERER = f"https://{DEFAULT_SITE_DOMAIN}/"
+OPENROUTER_SITE_TITLE = "VRC TA Hub"
 
 
 def _normalize_site_url(value: str) -> str:
@@ -13,6 +15,10 @@ def _normalize_site_url(value: str) -> str:
     if "://" not in stripped:
         return f"https://{stripped}"
     return stripped
+
+
+def _normalize_root_url(value: str) -> str:
+    return f"{_normalize_site_url(value)}/"
 
 
 SITE_DOMAIN = normalize_host(
@@ -26,6 +32,9 @@ OPENROUTER_BASE_URL = os.environ.get(
     "OPENROUTER_BASE_URL",
     DEFAULT_OPENROUTER_BASE_URL,
 ).rstrip("/")
+OPENROUTER_HTTP_REFERER = _normalize_root_url(
+    os.environ.get("OPENROUTER_HTTP_REFERER") or DEFAULT_OPENROUTER_HTTP_REFERER
+)
 
 CACHE_TTL_HOUR = 60 * 60
 MAX_THUMBNAIL_SIZE_BYTES = 10 * 1024 * 1024
@@ -48,6 +57,14 @@ def build_site_url(path: str = "") -> str:
     if path.startswith("/"):
         return f"{SITE_URL}{path}"
     return f"{SITE_URL}/{path}"
+
+
+def build_openrouter_extra_headers() -> dict[str, str]:
+    """OpenRouterへ送るサイト識別ヘッダを返す."""
+    return {
+        "HTTP-Referer": OPENROUTER_HTTP_REFERER,
+        "X-Title": OPENROUTER_SITE_TITLE,
+    }
 
 
 def is_site_domain(hostname: str | None) -> bool:

--- a/app/website/tests/test_site_constants.py
+++ b/app/website/tests/test_site_constants.py
@@ -12,7 +12,8 @@ class SiteConstantsTest(SimpleTestCase):
         importlib.reload(site_constants)
 
     def test_build_site_url_handles_relative_and_absolute_paths(self):
-        module = importlib.reload(site_constants)
+        with patch.dict(os.environ, {}, clear=True):
+            module = importlib.reload(site_constants)
 
         self.assertEqual(module.build_site_url("/community/1/"), "https://vrc-ta-hub.com/community/1/")
         self.assertEqual(module.build_site_url("event/detail/2/"), "https://vrc-ta-hub.com/event/detail/2/")
@@ -24,19 +25,39 @@ class SiteConstantsTest(SimpleTestCase):
             "SITE_DOMAIN": "preview.example.com",
             "SITE_URL": "https://preview.example.com/base/",
             "OPENROUTER_BASE_URL": "https://router.example.com/api/v1/",
+            "OPENROUTER_HTTP_REFERER": "https://public.example.com/project/",
             "DEFAULT_NEWS_IMAGE_URL": "https://assets.example.com/default.jpg",
         }
-        with patch.dict(os.environ, env, clear=False):
+        with patch.dict(os.environ, env, clear=True):
             module = importlib.reload(site_constants)
 
         self.assertEqual(module.SITE_DOMAIN, "preview.example.com")
         self.assertEqual(module.SITE_URL, "https://preview.example.com/base")
         self.assertEqual(module.OPENROUTER_BASE_URL, "https://router.example.com/api/v1")
+        self.assertEqual(module.OPENROUTER_HTTP_REFERER, "https://public.example.com/project/")
         self.assertEqual(module.DEFAULT_NEWS_IMAGE_URL, "https://assets.example.com/default.jpg")
+
+    def test_openrouter_http_referer_uses_public_default_not_preview_site_url(self):
+        env = {
+            "SITE_URL": "https://preview.example.com/branch-123/",
+            "APP_CANONICAL_HOST": "staging.example.com",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            module = importlib.reload(site_constants)
+
+        self.assertEqual(module.SITE_URL, "https://preview.example.com/branch-123")
+        self.assertEqual(module.OPENROUTER_HTTP_REFERER, "https://vrc-ta-hub.com/")
+        self.assertEqual(
+            module.build_openrouter_extra_headers(),
+            {
+                "HTTP-Referer": "https://vrc-ta-hub.com/",
+                "X-Title": "VRC TA Hub",
+            },
+        )
 
     def test_is_site_domain_matches_exact_and_subdomain_only(self):
         env = {"SITE_DOMAIN": "vrc-ta-hub.com"}
-        with patch.dict(os.environ, env, clear=False):
+        with patch.dict(os.environ, env, clear=True):
             module = importlib.reload(site_constants)
 
         self.assertTrue(module.is_site_domain("vrc-ta-hub.com"))

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -4,5 +4,6 @@
 
 ## レポート一覧
 
+- [Issue #356 OpenRouter HTTP-Referer 調査](issue-356-openrouter-http-referer.md) — preview/staging URL が OpenRouter の `HTTP-Referer` に漏れないようにする調査と検証方針
 - [Issue #343 LT申請「追加情報」テンプレート初期値化](issue-343-lt-application-additional-info-initial.md) — LT申請フォームのテンプレート表示を placeholder から initial に変更する調査と検証方針
 - [リファクタリング計画 (2026-05-25)](refactor-plan.html) — `app/` 配下のPythonコードを構造/品質/設計の3軸で機械的にスキャンし、優先度付き改善ロードマップを提示

--- a/docs/research/issue-356-openrouter-http-referer.md
+++ b/docs/research/issue-356-openrouter-http-referer.md
@@ -1,0 +1,29 @@
+# Issue 356 OpenRouter HTTP-Referer 調査
+
+## 背景
+
+Issue #356 では、OpenRouter へ送信する `HTTP-Referer` が `build_site_url("/")` 由来になったことで、preview/staging 環境の `SITE_URL` や `APP_CANONICAL_HOST` が第三者に送られる可能性が指摘された。
+
+## 観測結果
+
+- `app/event/llm_service.py` は定期イベント日付生成で `OPENROUTER_EXTRA_HEADERS` を定義し、`build_site_url("/")` を `HTTP-Referer` に使っていた。
+- `app/event/libs.py` はブログ記事生成時の OpenRouter 呼び出しで同じ `HTTP-Referer` をインライン定義していた。
+- `app/twitter/tweet_generator.py` は告知ポスト生成時の OpenRouter 呼び出しで同じ `HTTP-Referer` をインライン定義していた。
+- `SITE_URL` / `APP_CANONICAL_HOST` は preview/staging の公開リンク生成には必要だが、OpenRouter のランキング用ヘッダにそのまま使う必要はない。
+
+## 原因
+
+公開サイト URL の組み立てと OpenRouter へ送るサイト識別ヘッダが同じ `build_site_url("/")` に依存していたため、環境別ホストの上書きが外部 API の `HTTP-Referer` に伝播していた。
+
+## 改善方針
+
+保護対象の settings ファイルは変更せず、通常のアプリケーションコードである `app/website/constants.py` に `OPENROUTER_HTTP_REFERER` と `build_openrouter_extra_headers()` を追加した。デフォルトは公開 canonical URL の `https://vrc-ta-hub.com/` に固定し、必要な場合だけ `OPENROUTER_HTTP_REFERER` 環境変数で明示的に上書きできるようにした。
+
+OpenRouter 呼び出し側は共通ヘッダ生成関数を使うように統一し、preview/staging 用の `SITE_URL` を使う通常のリンク生成とは責務を分けた。
+
+## 検証手順
+
+- `website.tests.test_site_constants` で `SITE_URL` が preview URL の場合でも `OPENROUTER_HTTP_REFERER` が公開 canonical URL のままになることを検証する。
+- `website.tests.test_site_constants` で `OPENROUTER_HTTP_REFERER` 環境変数による明示上書きと末尾スラッシュ正規化を検証する。
+- `event.tests.test_llm_service` で定期イベント日付生成の OpenRouter 設定が共通ヘッダ生成関数を参照していることを検証する。
+- `rg` で OpenRouter の `HTTP-Referer` が `build_site_url("/")` から直接組み立てられていないことを確認する。


### PR DESCRIPTION
## なぜこの変更が必要か

- Issue #356「security: OpenRouter への HTTP-Referer に preview/staging URL が漏れる可能性」に対する fix-flow の自動修正として作成した差分です

## 変更内容

- `app/website/constants.py` に `OPENROUTER_HTTP_REFERER` と `build_openrouter_extra_headers()` を追加しました。
- OpenRouter への `HTTP-Referer` はデフォルトで `https://vrc-ta-hub.com/` に固定しました。
- `app/event/llm_service.py`、`app/event/libs.py`、`app/twitter/tweet_generator.py` の OpenRouter ヘッダ生成を共通関数へ統一しました。
- preview/staging の `SITE_URL` が OpenRouter ヘッダへ伝播しないテストを追加しました。
- `docs/research/issue-356-openrouter-http-referer.md` に調査結果・原因・改善方針・検証手順を記録しました。
- コミット: `f0eaa36 feat: OpenRouter Refererを公開URLに固定`

## 意思決定

### 採用アプローチ
`SITE_URL` / `APP_CANONICAL_HOST` は画面や通知のリンク生成に必要なため維持し、OpenRouter に送る第三者向けヘッダだけを別定数に分離しました。  
デフォルトは公開 canonical URL に固定し、必要時のみ `OPENROUTER_HTTP_REFERER` 環境変数で明示的に上書きできるようにしました。

### トレードオフ または 却下した代替案
本番以外で `HTTP-Referer` を送らない案は、OpenRouter 側のサイト識別情報が環境で変わるため却下しました。  
settings ファイルで制御する案もありますが、今回の保護対象ファイルに含まれるため、通常のアプリケーション定数で対応しました。

### 残課題やリスク
全テストスイートは実行していません。変更範囲に合わせて OpenRouter ヘッダ生成と Django system check の対象確認に絞っています。


## テスト

- `docker compose exec -T vrc-ta-hub python manage.py test website.tests.test_site_constants event.tests.test_llm_service -v 2`  
  結果: 8 tests passed
- `docker compose exec -T vrc-ta-hub python manage.py check`  
  結果: no issues
- `uv run ruff check app/website/constants.py app/event/llm_service.py app/event/libs.py app/twitter/tweet_generator.py app/website/tests/test_site_constants.py app/event/tests/test_llm_service.py`  
  結果: passed
- `git diff --check`  
  結果: passed

---
🤖 Generated with [Codex](https://Codex.com/Codex)
