### PR TITLE
feat: アカウント設定から Discord 連携解除ページへの導線を追加

### DIFF
--- a/app/user_account/templates/account/settings.html
+++ b/app/user_account/templates/account/settings.html
@@ -99,14 +99,18 @@
                             </a>
                             {% get_social_accounts user as social_accounts %}
                             {% if social_accounts.discord %}
-                                <div class="list-group-item d-flex justify-content-between align-items-center">
+                                <a href="{% url 'socialaccount_connections' %}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                                     <span>
                                         <i class="fa-brands fa-discord me-2" style="color: #5865F2;"></i>Discord連携
                                     </span>
-                                    <span class="badge bg-success">
-                                        <i class="fa-solid fa-check me-1"></i>連携済み
+                                    <span class="d-flex align-items-center">
+                                        <span class="badge bg-success me-2">
+                                            <i class="fa-solid fa-check me-1"></i>連携済み
+                                        </span>
+                                        <span class="text-muted me-2">連携を管理</span>
+                                        <i class="fa-solid fa-chevron-right text-muted"></i>
                                     </span>
-                                </div>
+                                </a>
                             {% else %}
                                 {% discord_oauth_available as discord_oauth_enabled %}
                                 {% if discord_oauth_enabled %}


### PR DESCRIPTION
## 背景

PR #342（マージ済み, e7946b5）で Discord 連携の「解除」ボタンが allauth 標準ページ `/accounts/3rdparty/` に追加されたが、`/account/settings/`（settings.html）から `/accounts/3rdparty/` への導線がなく、ユーザーが解除ボタンに到達できなかった。

## 変更内容

- `app/user_account/templates/account/settings.html` の Discord「連携済み」行を `<div>` から `<a href="{% url 'socialaccount_connections' %}">` に変更
- 既存の `list-group-item-action` パターンに合わせてホバー可・キーボード操作可
- 「連携済み」バッジを残しつつ「連携を管理 >」テキストとシェブロンを追加し、解除導線だと分かるようにした
- 未連携時の UI は変更していない（既存の連携リンクをそのまま維持）

## 検証

- `docker compose exec vrc-ta-hub python manage.py test user_account` → 152 tests OK
- Playwright で testuser ログイン → `/account/settings/` → 「Discord連携」行クリック → `/accounts/3rdparty/` に遷移して「解除」ボタンを確認

### スクリーンショット

- 設定画面: `docs/tmp/screenshots/01-settings-discord-link-20260526124005.png`
- 連携管理ページ: `docs/tmp/screenshots/02-connections-page-20260526124005.png`

## 関連

- 親PR: #342