### PR TITLE
feat: 発表申請の追加情報を承認後も閲覧できるようにする (#362)

### DIFF
--- a/app/event/templates/event/lt_application_review.html
+++ b/app/event/templates/event/lt_application_review.html
@@ -17,9 +17,18 @@
             </nav>
 
             <div class="card shadow-sm mb-4">
-                <div class="card-header bg-warning">
-                    <h1 class="h4 mb-0">
-                        <i class="bi bi-clipboard-check me-2"></i>発表申請の確認
+                <div class="card-header {% if event_detail.status == 'approved' %}bg-success text-white{% elif event_detail.status == 'rejected' %}bg-danger text-white{% else %}bg-warning{% endif %}">
+                    <h1 class="h4 mb-0 d-flex justify-content-between align-items-center flex-wrap gap-2">
+                        <span>
+                            <i class="bi bi-clipboard-check me-2"></i>発表申請の確認
+                        </span>
+                        {% if event_detail.status == 'approved' %}
+                            <span class="badge bg-light text-success"><i class="fas fa-check me-1"></i>承認済み</span>
+                        {% elif event_detail.status == 'rejected' %}
+                            <span class="badge bg-light text-danger"><i class="fas fa-times me-1"></i>却下</span>
+                        {% else %}
+                            <span class="badge bg-light text-warning"><i class="fas fa-clock me-1"></i>承認待ち</span>
+                        {% endif %}
                     </h1>
                 </div>
                 <div class="card-body">
@@ -62,12 +71,19 @@
                                     <td><pre class="mb-0" style="white-space: pre-wrap; font-family: inherit;">{{ event_detail.additional_info }}</pre></td>
                                 </tr>
                                 {% endif %}
+                                {% if event_detail.status == 'rejected' and event_detail.rejection_reason %}
+                                <tr>
+                                    <th scope="row" class="bg-light">却下理由</th>
+                                    <td><pre class="mb-0" style="white-space: pre-wrap; font-family: inherit;">{{ event_detail.rejection_reason }}</pre></td>
+                                </tr>
+                                {% endif %}
                             </tbody>
                         </table>
                     </div>
                 </div>
             </div>
 
+            {% if event_detail.status == 'pending' %}
             <div class="card shadow-sm">
                 <div class="card-header">
                     <h5 class="mb-0"><i class="bi bi-check2-square me-2"></i>アクション</h5>
@@ -134,10 +150,18 @@
                     </form>
                 </div>
             </div>
+            {% else %}
+            <div class="d-flex justify-content-start">
+                <a href="{% url 'event:my_list' %}" class="btn btn-outline-secondary">
+                    <i class="bi bi-arrow-left me-2"></i>マイリストに戻る
+                </a>
+            </div>
+            {% endif %}
         </div>
     </div>
 </div>
 
+{% if event_detail.status == 'pending' %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const actionRadios = document.querySelectorAll('input[name="action"]');
@@ -159,4 +183,5 @@ document.addEventListener('DOMContentLoaded', function() {
     toggleRejectionField();
 });
 </script>
+{% endif %}
 {% endblock %}

--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -238,7 +238,7 @@
 
                                             {% if detail.applicant %}
                                             <a href="{% url 'event:lt_application_review' detail.pk %}"
-                                               class="btn btn-outline-info btn-sm">
+                                               class="btn btn-outline-primary btn-sm">
                                                 <i class="fas fa-file-lines"></i> 申請内容
                                             </a>
                                             {% endif %}

--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -236,6 +236,13 @@
                                                 {% endif %}
                                             {% endif %}
 
+                                            {% if detail.applicant %}
+                                            <a href="{% url 'event:lt_application_review' detail.pk %}"
+                                               class="btn btn-outline-info btn-sm">
+                                                <i class="fas fa-file-lines"></i> 申請内容
+                                            </a>
+                                            {% endif %}
+
                                             {% if detail.applicant and detail.status == 'pending' %}
                                             <button type="button" class="btn btn-outline-success btn-sm"
                                                     data-bs-toggle="modal" data-bs-target="#approveModal{{ detail.pk }}">

--- a/app/event/tests/test_lt_application.py
+++ b/app/event/tests/test_lt_application.py
@@ -342,6 +342,56 @@ class LTApplicationReviewTest(TweetGenerationPatchMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '却下する場合は理由を入力してください')
 
+    def test_owner_can_view_approved_application(self):
+        """承認済み申請も主催者は閲覧でき、追加情報が表示される"""
+        self.pending_application.status = 'approved'
+        self.pending_application.additional_info = 'Discord ID: somnicat#1234\n配信時注意: BGM注意'
+        self.pending_application.save()
+
+        self.client.login(username='Owner', password='ownerpass123')
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Test Theme')
+        self.assertContains(response, 'Discord ID: somnicat#1234')
+        self.assertContains(response, '承認済み')
+        # 承認/却下フォームは表示されない
+        self.assertNotContains(response, 'name="action"')
+
+    def test_owner_can_view_rejected_application_with_reason(self):
+        """却下済み申請も閲覧でき、却下理由が表示される"""
+        self.pending_application.status = 'rejected'
+        self.pending_application.rejection_reason = 'テーマが集会の趣旨に合いません'
+        self.pending_application.save()
+
+        self.client.login(username='Owner', password='ownerpass123')
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'テーマが集会の趣旨に合いません')
+        self.assertContains(response, '却下')
+        self.assertNotContains(response, 'name="action"')
+
+    def test_post_to_processed_application_is_blocked(self):
+        """処理済み申請への POST はリダイレクトされ、状態は変わらない"""
+        self.pending_application.status = 'approved'
+        self.pending_application.save()
+
+        self.client.login(username='Owner', password='ownerpass123')
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        response = self.client.post(url, {
+            'action': 'reject',
+            'rejection_reason': '気が変わった',
+        })
+
+        # review ページにリダイレクトされる（my_list ではなく自身に戻して閲覧継続）
+        self.assertEqual(response.status_code, 302)
+        self.pending_application.refresh_from_db()
+        # 既に approved のまま、上書きされない
+        self.assertEqual(self.pending_application.status, 'approved')
+
 
 class LTApplicationListTest(TweetGenerationPatchMixin, TestCase):
     """LT申請一覧のテスト"""

--- a/app/event/views/lt_application.py
+++ b/app/event/views/lt_application.py
@@ -96,12 +96,14 @@ class LTApplicationReviewView(LoginRequiredMixin, FormView):
             messages.error(request, 'この申請を確認する権限がありません。')
             return redirect('community:detail', pk=self.community.pk)
 
-        # 既に処理済みの場合
+        return super().dispatch(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        # 処理済み申請の二重 POST を防ぐ（GET は閲覧モードとして許可）
         if self.event_detail.status != 'pending':
             messages.info(request, 'この申請は既に処理されています。')
-            return redirect('event:my_list')
-
-        return super().dispatch(request, *args, **kwargs)
+            return redirect('event:lt_application_review', pk=self.event_detail.pk)
+        return super().post(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
## Summary

Closes #362

主催者が発表申請を承認/却下した後でも、申請者が記入した「追加情報」(`EventDetail.additional_info`) を再確認できるようにする。承認時にコピーし損ねた連絡事項を、申請者に問い合わせなくても再確認できるようになる。

## 変更内容

### 1. `LTApplicationReviewView` のリダイレクト解除（GET/POST 分離）
- `dispatch` から「処理済みは `event:my_list` にリダイレクト」のガードを撤去
- 代わりに `post()` をオーバーライドし、`status != 'pending'` の二重承認/却下 POST のみブロック（自ページにリダイレクト + flash message）
- 権限チェック (`community.can_edit`) は dispatch に残し、未ログイン・非主催者は従来どおり弾く

### 2. テンプレ `lt_application_review.html`
- status に応じてヘッダー色とバッジを切り替え（pending=黄, approved=緑, rejected=赤）
- pending 以外はアクションフォームを非表示にし、戻るリンクのみ表示
- 却下時は「却下理由」を申請内容テーブルに表示

### 3. `my_list.html`
- `applicant` が紐づく detail に「申請内容」ボタンを全状態で追加
- 既存の承認/却下ボタン（pending 時のみ）と並べる形

### 4. テスト追加（`test_lt_application.py`）
- `test_owner_can_view_approved_application` — 承認済み GET 閲覧 + 追加情報表示 + フォーム非表示
- `test_owner_can_view_rejected_application_with_reason` — 却下済み GET 閲覧 + 却下理由表示
- `test_post_to_processed_application_is_blocked` — 処理済み POST が無視されステータスが上書きされない

## スクリーンショット

### マイリスト（申請内容ボタン追加）
![my_list](https://gh-image-uploader.kaisha3.com/uploads/2026/05/8c7416ab002b-01b-my_list-2026-05-26T13-35-00.avif)

### レビュー画面: 承認待ち（従来通りフォーム表示）
![review-pending](https://gh-image-uploader.kaisha3.com/uploads/2026/05/efab65c662b1-02-review-pending-2026-05-26T13-27-56.avif)

### レビュー画面: 承認済み（追加情報のみ表示・フォーム非表示）
![review-approved](https://gh-image-uploader.kaisha3.com/uploads/2026/05/05fb8e0ce8d9-02b-review-approved-2026-05-26T13-35-00.avif)

### レビュー画面: 却下済み（却下理由も表示）
![review-rejected](https://gh-image-uploader.kaisha3.com/uploads/2026/05/a3563102ef97-02-review-rejected-2026-05-26T13-27-56.avif)

## レビュー

- ✅ code-reviewer: ブロッキングなし
- ✅ security-reviewer: ブロッキングなし（権限境界・XSS・IDOR・二重 POST ガード・CSRF いずれも OK）

## Test plan

- [x] `docker compose exec vrc-ta-hub python manage.py test event.tests.test_lt_application` → 41/41 pass
- [x] ブラウザで testuser ログイン → my_list で3状態の申請内容ボタン表示確認
- [x] `/event/application/<pk>/review/` を pending/approved/rejected 各状態で GET 確認
- [x] 処理済み申請への POST がステータスを上書きしないことを Playwright で確認（form 自体が画面に存在しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)