### PR TITLE
feat: 発表申請フォームの選択肢に発表開始予定時刻を表示

### DIFF
--- a/app/event/forms.py
+++ b/app/event/forms.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timedelta
-
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils import timezone
@@ -12,6 +10,7 @@ from .datetime_lock import (
     is_event_detail_datetime_locked,
 )
 from .form_validators import validate_and_sanitize_pdf, validate_thumbnail_image
+from .lt_time import calc_lt_start_time
 from .models import EventDetail, RecurrenceRule, Event
 from .thumbnail import SLIDE_THUMBNAIL_ASPECT_RATIO_TEXT
 
@@ -567,7 +566,7 @@ class LTApplicationForm(forms.Form):
         queryset=Event.objects.none(),
         label='開催日',
         widget=forms.Select(attrs={'class': 'form-control'}),
-        help_text='発表したい開催日を選択してください'
+        help_text='発表したい開催日を選択してください（発表開始時刻は主催者の設定で自動決定されます）'
     )
 
     theme = forms.CharField(
@@ -609,6 +608,8 @@ class LTApplicationForm(forms.Form):
         help_text='主催者が設定したテンプレートに沿って入力してください'
     )
 
+    WEEKDAY_JP = ['月', '火', '水', '木', '金', '土', '日']
+
     def __init__(self, *args, **kwargs):
         self.community = kwargs.pop('community', None)
         self.user = kwargs.pop('user', None)
@@ -625,6 +626,21 @@ class LTApplicationForm(forms.Form):
                 accepts_lt_application=True,
                 date__gte=today
             ).order_by('date', 'start_time')
+
+            # 申請者が「自分の発表が何時から始まるか」を申請前に把握できるよう、
+            # 選択肢ラベルに 集会開始時刻 + 発表開始予定時刻（offset 加算後）を併記する
+            offset = self.community.lt_start_offset_minutes or 0
+            weekday_jp = self.WEEKDAY_JP
+
+            def _label(event):
+                lt_start = calc_lt_start_time(event.start_time, offset)
+                wd = weekday_jp[event.date.weekday()]
+                return (
+                    f'{event.date:%Y/%m/%d}({wd}) '
+                    f'集会 {event.start_time:%H:%M}〜 / 発表 {lt_start:%H:%M}〜'
+                )
+
+            self.fields['event'].label_from_instance = _label
 
             # テンプレートが設定されている場合は初期値として編集可能にする
             if self.community.lt_application_template:

--- a/app/event/lt_time.py
+++ b/app/event/lt_time.py
@@ -1,0 +1,12 @@
+from datetime import datetime, timedelta
+
+
+def calc_lt_start_time(event_start_time, offset_minutes):
+    """集会の start_time に offset(分) を加算した time を返す。
+
+    datetime.time は加算非対応のため、datetime.combine で日付を仮置きして演算する。
+    23:50 + 30分 → 00:20 のように 24h を跨ぐケースも循環する（Community.end_time と同じ慣例）。
+    申請フォームのラベル表示と View の保存ロジックで同じ結果を保証するための共通ヘルパー。
+    """
+    base = datetime.combine(datetime.today(), event_start_time)
+    return (base + timedelta(minutes=offset_minutes)).time()

--- a/app/event/tests/test_lt_application.py
+++ b/app/event/tests/test_lt_application.py
@@ -99,6 +99,56 @@ class LTApplicationFormTest(TweetGenerationPatchMixin, TestCase):
         # django-allauthのログインURL
         self.assertTrue('login' in response.url.lower())
 
+    def test_event_option_label_shows_lt_start_time(self):
+        """イベント選択肢のラベルに発表開始予定時刻が含まれる"""
+        # オフセット 30 分の集会
+        self.community.lt_start_offset_minutes = 30
+        self.community.save()
+
+        self.client.login(username='TestUser', password='testpass123')
+        url = reverse('event:lt_application_create', kwargs={'community_pk': self.community.pk})
+        response = self.client.get(url)
+
+        # 集会開始 22:00 + 30分 = 発表開始 22:30 がラベルに含まれる
+        self.assertContains(response, '集会 22:00〜')
+        self.assertContains(response, '発表 22:30〜')
+
+    def test_event_option_label_handles_zero_offset(self):
+        """オフセット 0 分の場合、集会開始時刻と発表開始時刻が同一になる"""
+        self.community.lt_start_offset_minutes = 0
+        self.community.save()
+
+        self.client.login(username='TestUser', password='testpass123')
+        url = reverse('event:lt_application_create', kwargs={'community_pk': self.community.pk})
+        response = self.client.get(url)
+
+        self.assertContains(response, '集会 22:00〜 / 発表 22:00〜')
+
+    def test_event_option_label_handles_24h_wrap(self):
+        """集会開始 + offset が 24h を跨ぐ場合は循環した発表開始時刻が表示される"""
+        # 集会開始を 23:50 にし、offset=30 で発表開始は翌 00:20
+        self.future_event.start_time = time(23, 50)
+        self.future_event.save()
+        self.community.lt_start_offset_minutes = 30
+        self.community.save()
+
+        self.client.login(username='TestUser', password='testpass123')
+        url = reverse('event:lt_application_create', kwargs={'community_pk': self.community.pk})
+        response = self.client.get(url)
+
+        self.assertContains(response, '集会 23:50〜 / 発表 00:20〜')
+
+    def test_event_option_label_includes_japanese_weekday(self):
+        """選択肢ラベルに日本語の曜日が含まれる"""
+        self.client.login(username='TestUser', password='testpass123')
+        url = reverse('event:lt_application_create', kwargs={'community_pk': self.community.pk})
+        response = self.client.get(url)
+
+        # future_event は date.today()+7日 で固定の曜日に当たる。weekday を計算して照合
+        weekday_jp = ['月', '火', '水', '木', '金', '土', '日']
+        expected_wd = weekday_jp[self.future_event.date.weekday()]
+        self.assertContains(response, f'({expected_wd})')
+
     def test_lt_application_only_shows_accepting_events(self):
         """LT受付中のイベントのみ選択肢に表示される"""
         self.client.login(username='TestUser', password='testpass123')

--- a/app/event/views/lt_application.py
+++ b/app/event/views/lt_application.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timedelta
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -9,19 +8,10 @@ from django.views.generic import FormView, View
 
 from community.models import Community
 from event.forms import LTApplicationForm, LTApplicationReviewForm
+from event.lt_time import calc_lt_start_time
 from event.models import EventDetail
 
 logger = logging.getLogger(__name__)
-
-
-def _calc_lt_start_time(event_start_time, offset_minutes):
-    """集会の start_time に offset(分) を加算した time を返す。
-
-    datetime.time は加算非対応のため、datetime.combine で日付を仮置きして演算する。
-    23:50 + 30分 → 00:20 のように 24h を跨ぐケースも循環する（Community.end_time と同じ慣例）。
-    """
-    base = datetime.combine(datetime.today(), event_start_time)
-    return (base + timedelta(minutes=offset_minutes)).time()
 
 
 class LTApplicationCreateView(LoginRequiredMixin, FormView):
@@ -48,7 +38,7 @@ class LTApplicationCreateView(LoginRequiredMixin, FormView):
         # EventDetailを作成
         event = form.cleaned_data['event']
         offset = self.community.lt_start_offset_minutes or 0
-        lt_start = _calc_lt_start_time(event.start_time, offset)
+        lt_start = calc_lt_start_time(event.start_time, offset)
         event_detail = EventDetail.objects.create(
             event=event,
             detail_type='LT',


### PR DESCRIPTION
## Summary

`/event/apply/<community_pk>/` の発表申請フォームで、申請者が自分の発表開始時刻を申請前に把握できるよう、イベント選択ドロップダウンのラベルに集会開始時刻と発表開始予定時刻を併記する。

発表開始時刻は主催者の設定 (`Community.lt_start_offset_minutes`) で自動決定されるため、申請者は時刻を編集できない。それゆえ「いつ始まるか分からないまま申し込む」状態だったのを解消する。

## 表示例

```
2026/06/16(火) 集会 22:00〜 / 発表 22:30〜
```

![apply-form](https://gh-image-uploader.kaisha3.com/uploads/2026/05/6656e94bddca-04-apply-form-2026-05-26T14-05-00.avif)

## 変更内容

- `app/event/forms.py`: `LTApplicationForm.__init__` で `event` フィールドの `label_from_instance` を上書き
- `app/event/lt_time.py` を新設: `calc_lt_start_time` を切り出して View と Form で共有（表示値と保存値の乖離を構造的に防ぐ）
- `app/event/views/lt_application.py`: 旧 `_calc_lt_start_time` を撤去し新ヘルパーを利用
- `event` フィールドの help_text に「発表開始時刻は主催者の設定で自動決定されます」を追記
- テスト3件追加: offset=0 / 24h跨ぎ (23:50 + 30分 → 00:20) / 日本語曜日表示

## レビュー

- ✅ code-reviewer: 初回 DRY 違反指摘 → `calc_lt_start_time` を共通化することで解消
- ✅ security-reviewer: ブロッキングなし（型保証された値のみ、XSS/権限境界に影響なし）

## Test plan

- [x] `python manage.py test event.tests.test_lt_application` → 45/45 pass
- [x] localhost:8015 でログイン → /event/apply/95/ を開いてドロップダウン表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)