### PR TITLE
feat: 発表一覧の詳細リンクを記事表記に変更

### DIFF
--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -214,7 +214,7 @@
                                         </div>
                                         {% endif %}
                                         <div class="mb-2">
-                                            <a href="{% url 'event:detail' detail.pk %}" class="btn btn-primary btn-sm">確認</a>
+                                            <a href="{% url 'event:detail' detail.pk %}" class="btn btn-primary btn-sm">記事</a>
                                             <a href="{% url 'event:detail_update' detail.pk %}"
                                                class="btn btn-success btn-sm">編集</a>
                                             <form method="post" action="{% url 'event:detail_delete' detail.pk %}"

--- a/docs/research/issue-372-my-list-article-label.md
+++ b/docs/research/issue-372-my-list-article-label.md
@@ -1,0 +1,36 @@
+# Issue 372: 発表一覧の詳細リンクラベル変更
+
+## 調査対象
+
+- 対象ページ: `app/event/templates/event/my_list.html`
+- 対象要素: 発表カード内の詳細リンク
+- 対象リンク: `{% url 'event:detail' detail.pk %}`
+
+## 観測結果
+
+- 発表カードの操作ボタン群では、先頭の primary ボタンが発表詳細ページへ遷移していた。
+- リンク先は `event:detail` のままで、発表詳細として自動生成された記事ページを表示する導線だった。
+- 隣接する「編集」「削除」ボタンは管理操作であり、表示ラベル以外のレイアウトやスタイル変更は不要だった。
+
+## 改善案
+
+詳細リンクのボタンラベルを「確認」から「記事」に変更する。
+リンク先と CSS クラスは変更せず、遷移先が記事ページであることだけを UI 文言で明確にする。
+
+## 検証手順
+
+1. `rg -n "btn-primary btn-sm\">記事|btn-primary btn-sm\">確認|event:detail" app/event/templates/event/my_list.html`
+2. `docker compose run --rm --no-deps -T vrc-ta-hub python manage.py check`
+
+## 検証結果
+
+- `rg -n "btn-primary btn-sm\">記事" app/event/templates/event/my_list.html`: 1 件一致。
+- `rg -n "btn-primary btn-sm\">確認" app/event/templates/event/my_list.html`: 一致なし。
+- `git diff --check`: pass。
+- `docker compose run --rm --no-deps -T vrc-ta-hub python manage.py check`: Docker イメージ内に `google.analytics` がなく、`ModuleNotFoundError` で fail。
+- `uv pip install -r requirements.txt`: macOS 環境で `pysqlite3==0.5.3` のビルドに失敗し、ローカル `.venv` での `manage.py check` は未実行。
+
+## 判断
+
+テンプレート文言のみの変更で要件を満たせるため、ビュー、URL、モデル、スタイルには手を入れない。
+ロジック変更がないため、追加の単体テストは作成しない。


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: [#372](https://github.com/noricha-vr/vrc-ta-hub/issues/372)「発表一覧（my_list）の「確認」ボタンのラベルを「記事」に変更する」
- 必要性: この Issue で報告された問題・要望により、VRC技術学術Hub が期待動作や要件を満たせないため、修正・対応が必要です。
- 対応意図: 発表一覧の該当ボタンは発表詳細、つまり自動生成された記事ページへの導線だったため、遷移先をより直感的に伝える文言へ変更しました。 挙動変更は不要だったため、テンプレートの表示文字列のみを差し替えました。

## 変更内容

- [app/event/templates/event/my_list.html](/Users/ms25/worktrees/vrc-ta-hub/app/event/templates/event/my_list.html:217) の発表詳細リンクの表示ラベルを「確認」から「記事」に変更しました。
- リンク先 `{% url 'event:detail' detail.pk %}` と既存 CSS クラスは維持しました。
- [docs/research/issue-372-my-list-article-label.md](/Users/ms25/worktrees/vrc-ta-hub/docs/research/issue-372-my-list-article-label.md:1) に調査結果、判断、検証結果を記録しました。
- コミット済み: `339f0c8 feat: 発表一覧の詳細リンクを記事表記に変更`

## 意思決定

### 採用アプローチ
発表一覧の該当ボタンは発表詳細、つまり自動生成された記事ページへの導線だったため、遷移先をより直感的に伝える文言へ変更しました。  
挙動変更は不要だったため、テンプレートの表示文字列のみを差し替えました。

### トレードオフ または 却下した代替案
ボタンのスタイル変更や URL 名の変更も考えられますが、今回の要件は文言改善のみで、リンク先とレイアウトは既に適切でした。  
そのため、ビュー、モデル、URL、CSS には触れない最小変更を採用しました。

### 残課題やリスク
`manage.py check` は環境依存の不足で完走できていません。今回の変更自体はテンプレート文言のみで、検索確認と whitespace チェックは通過しています。


## テスト

- `rg -n "btn-primary btn-sm\">記事" app/event/templates/event/my_list.html`: pass、1 件一致
- `rg -n "btn-primary btn-sm\">確認" app/event/templates/event/my_list.html`: pass、0 件
- `git diff --check`: pass
- `docker compose run --rm --no-deps -T vrc-ta-hub python manage.py check`: fail、Docker イメージ内で `google.analytics` が見つからず停止
- `uv pip install -r requirements.txt`: fail、macOS 環境で `pysqlite3==0.5.3` のビルドに失敗

---
🤖 Generated with [Codex](https://Codex.com/Codex)
