### PR TITLE
feat(event-detail): アクセス解析を管理者向けメニューとしてサムネイル上に配置

### DIFF
--- a/app/event/templates/event/detail.html
+++ b/app/event/templates/event/detail.html
@@ -86,6 +86,19 @@
             margin-bottom: 0.1em;
         }
 
+        /* アクセス解析セクションは .post 配下にあるが、記事本文用の見出しスタイル
+           （青背景・青下線等）を当てない。Bootstrap の fs-4/fs-6 等を尊重するため初期化する。 */
+        .post .analytics-card :is(h1, h2, h3, h4) {
+            background: transparent;
+            border: none;
+            padding: 0;
+            margin-top: 0;
+            font-family: inherit;
+            letter-spacing: normal;
+            font-size: revert;
+            font-weight: revert;
+        }
+
         blockquote {
             background-color: #f9f9f9;
             border-left: 5px solid #3187de;
@@ -191,7 +204,9 @@
 
                 {# アクセス解析（管理者向けメニュー扱いのためサムネイル上に配置。集会管理者 / superuser のみ表示） #}
                 {% if can_view_analytics %}
-                    {% include 'analytics/_chart_section.html' %}
+                    <div class="analytics-card">
+                        {% include 'analytics/_chart_section.html' %}
+                    </div>
                 {% endif %}
 
                 {# detail_typeによって詳細情報の表示を切り替え #}

--- a/app/event/templates/event/detail.html
+++ b/app/event/templates/event/detail.html
@@ -189,6 +189,11 @@
                     {% endif %}
                 {% endif %}
 
+                {# アクセス解析（管理者向けメニュー扱いのためサムネイル上に配置。集会管理者 / superuser のみ表示） #}
+                {% if can_view_analytics %}
+                    {% include 'analytics/_chart_section.html' %}
+                {% endif %}
+
                 {# detail_typeによって詳細情報の表示を切り替え #}
                 {% if event_detail.thumbnail_image %}
                     <div class="mb-4">
@@ -284,13 +289,6 @@
         </div>
     </div>
     </div>
-
-    {# アクセス解析（集会管理者 / superuser のみ。集計データは view 側で出し分け済み） #}
-    {% if can_view_analytics %}
-    <div class="container">
-        {% include 'analytics/_chart_section.html' %}
-    </div>
-    {% endif %}
 
     <script>
         const generateButton = document.getElementById('generate-button');


### PR DESCRIPTION
## なぜこの変更が必要か

PR #370 で実装したアクセス解析セクションが、ブログ表示としても使われるイベント詳細ページ（`/event/detail/{N}/`）の本文最下部にあったため、集会主催者がアクセス推移を確認するには記事末尾まで毎回スクロールする必要があった。「管理者向けメニュー」の一部として、編集・記事生成ボタンと同じ位置（=サムネイル画像の上）に配置することで、運営者がページを開いた直後にアクセス数を把握できるようにする。

## 変更内容

- `app/event/templates/event/detail.html`: アクセス解析セクション（`{% include 'analytics/_chart_section.html' %}`）を本文末尾から、`{% if can_manage_event_detail %}` ブロック直後・`{% if event_detail.thumbnail_image %}` 直前に移動
- `extra_js` の Chart.js include は権限ガード付きでそのまま維持
- 削除元の `<div class="container">` ラッパーも一緒に除去

## 意思決定

### 採用アプローチ
- **管理者ボタン群（編集・記事生成・集会名）の直下、サムネイル画像の上**: 管理者向け要素を縦に並べる自然な配置。記事タイトル → 動画 → 管理者ボタン → アクセス解析 → 詳細情報 → 記事本文 という流れになる
- 既存のテンプレ include / 権限ガード / Chart.js 読み込みロジックには一切手を入れない

### 却下した代替案
- **「アクセス解析を見る」リンクで別ページへ遷移** → 却下: 1クリック増える。管理者向けの常時表示で十分
- **ページ最上部（タイトル直下）に配置** → 却下: 一般ユーザー（権限なし）には表示されないため不在時の余白が目立つ、動画より上は本末転倒

### トレードオフ
- 管理者にとって UX 改善 > 記事閲覧者にとっての変化なし（権限ガードで非管理者には影響ゼロ）

## レビュー結果

実装後に code-reviewer / security-checker / design-checker の3並列レビューを実施:

| レビュアー | 判定 |
|---|---|
| code-reviewer | 承認（テンプレ if 構造健全・DOM存在前にChart.js起動なし・テスト互換） |
| security-checker | 承認（権限ガード三重防御維持: view context / template if / chart-section内部） |
| design-checker | 承認（全軸B以上、論理的なヒエラルキー） |

## テスト

- [x] `event.tests.test_event_detail_analytics analytics` 全38件OK
- [x] ローカルで nori（superuser）として `/event/detail/1/` を開き、サムネイル上にアクセス解析が表示されることを確認（Playwright スクショ撮影済み: `docs/tmp/screenshots/ja-above-thumbnail-top-20260601-171624.png`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)