### PR TITLE
feat(community-detail): 集会スタッフがアクセス解析を閲覧可能に

### DIFF
--- a/app/community/templates/community/detail.html
+++ b/app/community/templates/community/detail.html
@@ -505,8 +505,8 @@
     </div>
     {% endif %}
 
-    {# アクセス解析（集会オーナー / superuser のみ。集計データは view 側で出し分け済み） #}
-    {% if request.user.is_superuser or is_owner %}
+    {# アクセス解析（集会管理者 / superuser のみ。集計データは view 側で出し分け済み） #}
+    {% if can_view_analytics %}
     <div class="container">
         {% include 'analytics/_chart_section.html' %}
     </div>
@@ -516,7 +516,7 @@
 
 {% block extra_js %}
     {{ block.super }}
-    {% if request.user.is_superuser or is_owner %}
+    {% if can_view_analytics %}
         {% include 'analytics/_chart_scripts.html' %}
     {% endif %}
 {% endblock %}

--- a/app/community/tests/test_analytics_section.py
+++ b/app/community/tests/test_analytics_section.py
@@ -117,6 +117,55 @@ class CommunityDetailAnalyticsTests(TestCase):
         owner_response = self.client.get(self._url(self.community_a))
         self.assertContains(owner_response, chart_cdn)
 
+    def test_staff_sees_own_community_analytics(self):
+        """staff として登録されたユーザーが自集会の解析を見られる（owner と同等）."""
+        staff_user = User.objects.create_user(
+            user_name='staffA', email='staff_a@example.com', password='pass-s',
+        )
+        CommunityMember.objects.create(
+            community=self.community_a, user=staff_user,
+            role=CommunityMember.Role.STAFF,
+        )
+        self.client.force_login(staff_user)
+        response = self.client.get(self._url(self.community_a))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('daily_series', response.context)
+        self.assertIn('source_breakdown', response.context)
+        self.assertContains(response, 'id="analytics-daily-chart"')
+        self.assertContains(response, 'source-A-only / organic')
+
+    def test_staff_cannot_see_other_community_analytics(self):
+        """集会Aのstaffが集会Bを見ても、Bのデータは漏れない（権限境界）."""
+        staff_user = User.objects.create_user(
+            user_name='staffA2', email='staff_a2@example.com', password='pass-s',
+        )
+        CommunityMember.objects.create(
+            community=self.community_a, user=staff_user,
+            role=CommunityMember.Role.STAFF,
+        )
+        self.client.force_login(staff_user)
+        response = self.client.get(self._url(self.community_b))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('daily_series', response.context)
+        self.assertNotIn('source_breakdown', response.context)
+        self.assertNotContains(response, 'source-B-only / referral')
+
+    def test_staff_does_not_see_edit_button(self):
+        """staff には集会編集ボタンは表示されない（is_owner ガード維持の回帰防止）."""
+        staff_user = User.objects.create_user(
+            user_name='staffA3', email='staff_a3@example.com', password='pass-s',
+        )
+        CommunityMember.objects.create(
+            community=self.community_a, user=staff_user,
+            role=CommunityMember.Role.STAFF,
+        )
+        self.client.force_login(staff_user)
+        response = self.client.get(self._url(self.community_a))
+        # is_owner は False のはず（編集ボタン用 context キー）
+        self.assertFalse(response.context['is_owner'])
+        # アクセス解析は見える
+        self.assertTrue(response.context['can_view_analytics'])
+
     def test_source_medium_is_json_escaped(self):
         """source_medium に危険な文字があっても json_script でエスケープされる（XSS回帰）."""
         # </script> を含む source_medium は GA4 由来データに混入し得る。

--- a/app/community/views/public.py
+++ b/app/community/views/public.py
@@ -227,15 +227,24 @@ class CommunityDetailView(DetailView):
             context['show_accept_button'] = True
             context['show_reject_button'] = True
 
-        # ユーザーが主催者かどうかを判定
+        # ユーザーが主催者かどうかを判定（集会編集ボタン用、owner 限定）
         if self.request.user.is_authenticated:
             context['is_owner'] = community.is_owner(self.request.user)
         else:
             context['is_owner'] = False
 
-        # 集会オーナーまたは superuser のときだけアクセス解析を context に入れる。
+        # アクセス解析の閲覧権限は owner/staff/superuser の3つ。
+        # 編集権限（is_owner）とは別の context キーにすることで、staff にも
+        # 解析を見せつつ集会情報の編集権限は owner に限定する。
+        # 未ログイン時は is_manager クエリを叩かないよう短絡評価
+        user = self.request.user
+        context['can_view_analytics'] = user.is_authenticated and (
+            user.is_superuser or community.is_manager(user)
+        )
+
+        # 集会管理者または superuser のときだけアクセス解析を context に入れる。
         # 権限が無ければキー自体を入れない（テンプレ側の if だけに頼らず view で出し分け）。
-        if context['is_owner'] or self.request.user.is_superuser:
+        if context['can_view_analytics']:
             context['daily_series'] = analytics_services.get_daily_series(
                 [community.pk],
                 content_type=PageAnalytics.ContentType.COMMUNITY,


### PR DESCRIPTION
## なぜこの変更が必要か

集会詳細ページ `/community/{N}/` のアクセス解析セクションが現状 **owner のみ閲覧可** で、CommunityMember `role=staff` で登録された協力者が見られなかった。一方、同じデータを扱う他 2 画面ではすでに owner + staff 両方が見られる状態になっており、画面ごとに権限境界がバラついていた:

| 画面 | 修正前 | 修正後 |
|---|---|---|
| `/community/{N}/` 集会詳細 | owner のみ | **owner + staff + superuser** |
| `/event/detail/{N}/` イベント詳細 | owner + staff + superuser | 変更なし |
| `/analytics/dashboard/` ダッシュボード | owner + staff + superuser | 変更なし |

集会運営は owner + staff の協業で行われており、解析データを owner が独占する根拠は無い。他 2 画面と揃えてユーザーの「どの画面で何が見えるか」予測コストを下げる。

## 変更内容

- `app/community/views/public.py` (`CommunityDetailView`):
  - `context['can_view_analytics']` を追加（`is_superuser or community.is_manager(user)`）
  - アクセス解析 context 注入条件を `can_view_analytics` ベースに変更
  - `context['is_owner']` は集会編集ボタン用にそのまま維持
- `app/community/templates/community/detail.html`:
  - L509（アクセス解析 include）と L519（Chart.js scripts include）を `{% if can_view_analytics %}` に変更
  - **L54 の集会編集ボタン（owner 限定）は意図的に変更せず**
- `app/community/tests/test_analytics_section.py`:
  - `test_staff_sees_own_community_analytics` — staff が自集会の解析を見られる
  - `test_staff_cannot_see_other_community_analytics` — staff が他人集会には依然アクセス不可（IDOR 回帰防止）
  - `test_staff_does_not_see_edit_button` — staff には編集ボタンが出ない（is_owner ガード維持の回帰防止）

## 意思決定

### 採用アプローチ
- **既存 `is_manager()` を流用**: owner/staff を判定する関数がすでに `community.models.Community.is_manager()` にあったため、新規メソッド追加なし
- **`is_owner` と `can_view_analytics` を別 context キーに分離**: 集会編集（owner 専用）と解析閲覧（owner+staff）の権限を独立して表現できる

### 却下した代替案
- `is_owner` を `is_manager` に書き換える → 却下: L54 の編集ボタンも staff に開放されてしまうため、編集権限を意図せず緩める

### トレードオフ
- 集会詳細を見たいだけの一般ユーザーへの影響なし（権限なしは引き続きセクション非表示）
- staff にデータ閲覧権を与える分、共有範囲は広がるが、データは「自集会の数値だけ」であり外部漏洩リスクは生まれない

## テスト

- [x] community.tests.test_analytics_section 全 9 件 OK（既存 6 + 新規 3）
- [x] 全 1483 テスト OK（回帰なし）
- [x] ローカル QA: nori を superuser/staff フラグ一時的に外した状態で community 19 に `role=staff` として登録、`/community/19/` を開き
  - 編集ボタン非表示
  - アクセス解析セクション表示（推移グラフ + 流入元テーブル）
  - 完了後にメンバーシップとテストデータをクリーンアップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)