### PR TITLE
fix: GA4同期の一時的なgRPC失敗を再試行する

### DIFF
--- a/app/analytics/ga4_client.py
+++ b/app/analytics/ga4_client.py
@@ -8,6 +8,8 @@ import os
 from datetime import date
 
 from django.conf import settings
+from google.api_core import retry as api_retry
+from google.api_core import exceptions as google_exceptions
 from google.analytics.data_v1beta import BetaAnalyticsDataClient
 from google.analytics.data_v1beta.types import (
     DateRange,
@@ -29,6 +31,17 @@ _GA4_DATE_LENGTH = 8
 
 _DIMENSIONS = ['pagePath', 'date', 'sessionSourceMedium']
 _METRICS = ['screenPageViews', 'totalUsers', 'sessions']
+_GA4_RUN_REPORT_RETRY = api_retry.Retry(
+    predicate=api_retry.if_exception_type(
+        google_exceptions.DeadlineExceeded,
+        google_exceptions.InternalServerError,
+        google_exceptions.ServiceUnavailable,
+    ),
+    initial=1.0,
+    maximum=10.0,
+    multiplier=2.0,
+    deadline=30.0,
+)
 
 
 def _build_client() -> BetaAnalyticsDataClient:
@@ -79,7 +92,9 @@ def fetch_page_report(property_id: str, target_date: date) -> list[dict]:
         date_ranges=[DateRange(start_date=date_str, end_date=date_str)],
     )
 
-    response = client.run_report(request)
+    # GA4 Data API は gRPC 経路で一時的に UNAVAILABLE / DEADLINE_EXCEEDED を返すことがある。
+    # 日次同期を単発の通信断で失敗させないため、読み取りリクエストだけ明示的に再試行する。
+    response = client.run_report(request, retry=_GA4_RUN_REPORT_RETRY)
 
     # GA4 Data API のデフォルト limit は 10,000 行。サイレント欠落を Fail Loud で検知する。
     # 現規模（14日870行）では発生しないが、成長して上限に達したら警告ログから気付けるようにする。
@@ -144,7 +159,8 @@ def fetch_poster_click_report(property_id: str, target_date: date) -> list[dict]
         ),
     )
 
-    response = client.run_report(request)
+    # page_view と同じ一時失敗対策を poster_click 取得にも適用する。
+    response = client.run_report(request, retry=_GA4_RUN_REPORT_RETRY)
 
     if response.row_count > len(response.rows):
         logger.warning(

--- a/app/analytics/tests/test_ga4_client.py
+++ b/app/analytics/tests/test_ga4_client.py
@@ -3,6 +3,7 @@
 ローカル開発: GOOGLE_APPLICATION_CREDENTIALS ファイルから読み込む。
 Cloud Run 等: ファイル不在なら compute_engine 資格情報（metadata server 経由）。
 """
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
@@ -66,3 +67,41 @@ class BuildClientCredentialsTest(TestCase):
         # compute_engine 経由は呼ばれない
         mock_compute_engine.Credentials.assert_not_called()
         mock_client_cls.assert_called_once_with(credentials=mock_creds)
+
+
+class FetchReportRetryTest(TestCase):
+    """GA4 run_report に一時失敗向けリトライを設定することを確認する。"""
+
+    def _empty_response(self):
+        response = MagicMock()
+        response.row_count = 0
+        response.rows = []
+        return response
+
+    @patch.object(ga4_client, '_build_client')
+    def test_fetch_page_report_passes_retry_policy(self, mock_build_client):
+        """ページ別レポート取得は gRPC 一時失敗に備えた retry を渡す。"""
+        client = MagicMock()
+        client.run_report.return_value = self._empty_response()
+        mock_build_client.return_value = client
+
+        rows = ga4_client.fetch_page_report('123456789', date(2026, 5, 31))
+
+        self.assertEqual(rows, [])
+        client.run_report.assert_called_once()
+        _, kwargs = client.run_report.call_args
+        self.assertIs(kwargs['retry'], ga4_client._GA4_RUN_REPORT_RETRY)
+
+    @patch.object(ga4_client, '_build_client')
+    def test_fetch_poster_click_report_passes_retry_policy(self, mock_build_client):
+        """poster_click レポート取得も同じ retry を渡す。"""
+        client = MagicMock()
+        client.run_report.return_value = self._empty_response()
+        mock_build_client.return_value = client
+
+        rows = ga4_client.fetch_poster_click_report('123456789', date(2026, 5, 31))
+
+        self.assertEqual(rows, [])
+        client.run_report.assert_called_once()
+        _, kwargs = client.run_report.call_args
+        self.assertIs(kwargs['retry'], ga4_client._GA4_RUN_REPORT_RETRY)


### PR DESCRIPTION
## なぜこの変更が必要か

- VRC技術学術Hub で観測された `grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:` に対する TASK-1833 の自動修正として作成した差分です

## 変更内容

- `app/analytics/ga4_client.py` で GA4 Data API `run_report` に明示的な `Retry` を追加しました。
- 対象例外は `DeadlineExceeded` / `InternalServerError` / `ServiceUnavailable` に限定しました。
- `fetch_page_report` と `fetch_poster_click_report` の両方に同じリトライ方針を適用しました。
- `app/analytics/tests/test_ga4_client.py` に、両取得処理が retry policy を渡すテストを追加しました。
- コミット済み: `68fff9d fix: GA4同期の一時的なgRPC失敗を再試行する`

## 意思決定

### 採用アプローチ
観測された `grpc._channel._InactiveRpcError` は GA4 Data API の gRPC 経路で発生する一時的な通信失敗と判断しました。日次同期を単発の通信断で失敗させないため、認証設定や同期 view には触れず、GA4 クライアント境界の読み取りリクエストだけを短時間リトライする方針にしました。

### トレードオフ または 却下した代替案
同期 view 側で例外を握りつぶして 200 を返す案は、実際にデータ取得できていない状態を成功扱いにするため却下しました。保護対象の settings / deploy / secret 系ファイルを変更する案も不要で、今回はアプリケーションコード側だけで一時失敗を吸収しています。

### 残課題やリスク
なし


## テスト

- `docker run ... python manage.py test analytics.tests.test_ga4_client`: 5 tests passed
- `docker run ... python manage.py test analytics.tests.test_ga4_client analytics.tests.test_sync analytics.tests.test_phase2`: 24 tests passed
- `uvx ruff check app/analytics/ga4_client.py app/analytics/tests/test_ga4_client.py`: passed
- `git diff --check`: passed

---
🤖 Generated with [Codex](https://Codex.com/Codex)
