### PR TITLE
feat: アクセス解析カードを主催者連絡先の上へ移動

### DIFF
--- a/app/community/templates/community/detail.html
+++ b/app/community/templates/community/detail.html
@@ -439,6 +439,13 @@
         </div>
     {% endif %}
 
+    {# アクセス解析（集会管理者 / superuser のみ。集計データは view 側で出し分け済み） #}
+    {% if can_view_analytics %}
+    <div class="container">
+        {% include 'analytics/_chart_section.html' %}
+    </div>
+    {% endif %}
+
     <!-- Superuserの場合はコミュニティーのユーザーの連絡先を表示 -->
     {% if request.user.is_superuser %}
     <div class="container my-4">
@@ -502,13 +509,6 @@
                 </div>
             </div>
         </div>
-    </div>
-    {% endif %}
-
-    {# アクセス解析（集会管理者 / superuser のみ。集計データは view 側で出し分け済み） #}
-    {% if can_view_analytics %}
-    <div class="container">
-        {% include 'analytics/_chart_section.html' %}
     </div>
     {% endif %}
 

--- a/app/community/tests/test_analytics_section.py
+++ b/app/community/tests/test_analytics_section.py
@@ -100,6 +100,15 @@ class CommunityDetailAnalyticsTests(TestCase):
         self.assertIn('daily_series', response_b.context)
         self.assertContains(response_b, 'source-B-only / referral')
 
+    def test_superuser_sees_analytics_before_owner_contact_card(self):
+        """superuser 画面ではアクセス解析が集会主催者の連絡先より先に出る."""
+        self.client.force_login(self.superuser)
+        response = self.client.get(self._url(self.community_a))
+        html = response.content.decode()
+        analytics_index = html.index('id="analytics-section"')
+        owner_contact_index = html.index('集会主催者の連絡先')
+        self.assertLess(analytics_index, owner_contact_index)
+
     def test_anonymous_has_no_analytics(self):
         """匿名ユーザーには集計 context もグラフセクションも無い."""
         response = self.client.get(self._url(self.community_a))

--- a/docs/research/issue-377-community-analytics-order.md
+++ b/docs/research/issue-377-community-analytics-order.md
@@ -1,0 +1,35 @@
+# Issue 377: 集会詳細ページのアクセス解析カード表示順
+
+## 調査対象
+
+- `app/community/templates/community/detail.html`
+- `app/community/views/public.py`
+- `app/community/tests/test_analytics_section.py`
+- `CLAUDE.md`
+
+## 観測結果
+
+- 集会詳細ページのアクセス解析カードは、テンプレート末尾で `can_view_analytics` により表示されていた。
+- `can_view_analytics` は view 側で `user.is_superuser or community.is_manager(user)` として算出され、owner/staff/superuser のみが対象になる。
+- 権限がない場合は `daily_series` と `source_breakdown` が context に入らないため、テンプレート表示条件だけに依存しない権限境界になっている。
+- Chart.js の読み込みは `{% block extra_js %}` 側で `can_view_analytics` により制御されており、HTML セクションの移動とは独立している。
+
+## 原因候補
+
+アクセス解析カードの include 位置が superuser 向けの「集会主催者の連絡先」カードより後ろにあり、管理者向け情報の中でも下部へ押し出されていた。
+
+## 改善案
+
+Issue で推奨されていた案Aを採用し、アクセス解析カードを「集会主催者の連絡先」カードの直前へ移動する。
+
+この方針は、既存の管理者向けカード群の並び順だけを変えるため、一般ユーザー向けのメイン情報や権限判定には影響しない。
+
+## 却下した代替案
+
+案Bとしてページ最上部への移動も考えられるが、集会の基本情報より上に管理者専用カードを置くと、詳細ページ全体の主情報より管理機能が先に表示される。今回の要望は「主催者カードより上」への移動であり、管理者向け情報の先頭へ移す案Aの方が変更範囲が小さい。
+
+## 検証手順
+
+- `docker compose exec vrc-ta-hub python manage.py test community.tests.test_analytics_section`
+- superuser HTML で `id="analytics-section"` が「集会主催者の連絡先」より前に現れることをテストで確認する。
+- 匿名ユーザー、他集会の owner/staff にはアクセス解析セクションが表示されない既存テストを継続して確認する。


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: [#377](https://github.com/noricha-vr/vrc-ta-hub/issues/377)「集会詳細ページのアクセス解析カードを主催者カードの上に表示する」
- 必要性: この Issue で報告された問題・要望により、VRC技術学術Hub が期待動作や要件を満たせないため、修正・対応が必要です。
- 対応意図: アクセス解析の権限境界は view 側の `can_view_analytics` で既に担保されていたため、権限ロジックには触れず HTML の include 位置だけを変更しました。 Issue 推奨の案Aを採用し、管理者向け情報の先頭として「集会主催者の連絡先」カード直前に配置しました。

## 変更内容

- `app/community/templates/community/detail.html` でアクセス解析カードを「集会主催者の連絡先」カード直前へ移動
- `can_view_analytics` と Chart.js 読み込み条件は既存のまま維持
- `app/community/tests/test_analytics_section.py` に superuser 表示順の回帰テストを追加
- `docs/research/issue-377-community-analytics-order.md` に調査結果、判断根拠、検証手順を記録
- コミット作成済み: `3dcfa7b feat(community-detail): アクセス解析カードを主催者連絡先の上へ移動`

## 意思決定

### 採用アプローチ
アクセス解析の権限境界は view 側の `can_view_analytics` で既に担保されていたため、権限ロジックには触れず HTML の include 位置だけを変更しました。  
Issue 推奨の案Aを採用し、管理者向け情報の先頭として「集会主催者の連絡先」カード直前に配置しました。

### トレードオフ または 却下した代替案
案Bのページ最上部配置は、集会の基本情報より管理者専用カードが先に表示されるため却下しました。  
今回の要望は主催者カードより上への移動なので、管理者向けカード群の中で順序だけを変える案Aの方が影響範囲が小さいです。

### 残課題やリスク
superuser / is_manager のブラウザログインスクリーンショットは未実施です。HTML上の権限表示と並び順は Django テストで確認済みです。  
匿名ブラウザ確認時に既存データ由来のポスター画像 URL 解決エラーが1件ありましたが、今回の変更とは無関係です。


## テスト

- `docker run ... python manage.py test community.tests.test_analytics_section`: 10 tests / OK
- `docker run ... ruff check app/community/tests/test_analytics_section.py`: All checks passed
- Playwright: 匿名 `/community/19/` を desktop/mobile 幅で確認し、アクセス解析非表示、横スクロールなし
- 保護対象ファイル検査: 該当変更なし

---
🤖 Generated with [Codex](https://Codex.com/Codex)
