### PR TITLE
fix(analytics): 「ポスター経由クリック」を「集会一覧からの遷移数」に改名

### DIFF
--- a/app/analytics/templates/analytics/dashboard.html
+++ b/app/analytics/templates/analytics/dashboard.html
@@ -183,25 +183,28 @@
                 </div>
             {% endif %}
 
-            {# ポスター経由クリック数（集会一覧のサムネクリック）。GA4 計測開始直後はデータが少ないので
-               total.clicks が 0 でもセクション自体は表示し、説明文で計測中の旨を伝える #}
+            {% comment %}
+                集会一覧からの遷移数（GA4 カスタムイベント poster_click 由来）。
+                GA4 計測開始直後はデータが少ないので total.clicks が 0 でもセクション自体は表示し、
+                説明文で計測中の旨を伝える。
+            {% endcomment %}
             <div class="card mb-3">
                 <div class="card-body">
                     <h2 class="fs-5 fw-bold mb-1">
-                        <i class="fa-solid fa-hand-pointer me-2"></i>ポスター経由クリック（{{ days }}日）
+                        <i class="fa-solid fa-hand-pointer me-2"></i>集会一覧からの遷移数（{{ days }}日）
                     </h2>
-                    <p class="text-muted small mb-3">集会一覧ページでサムネを押した数。GA4 計測開始から反映までタイムラグがあります。</p>
+                    <p class="text-muted small mb-3">集会一覧ページから、この集会を選んで詳細ページへ進んだ数。GA4 計測開始から反映までタイムラグがあります。</p>
                     {% with pc=poster_clicks %}
                         <div class="row g-2 mb-3">
                             <div class="col-6 col-md-3">
                                 <div class="border-start border-4 border-primary ps-2">
-                                    <div class="text-muted small">合計クリック</div>
+                                    <div class="text-muted small">合計遷移数</div>
                                     <div class="fs-4 fw-bold">{{ pc.total.clicks }}</div>
                                 </div>
                             </div>
                             <div class="col-6 col-md-3">
                                 <div class="border-start border-4 border-success ps-2">
-                                    <div class="text-muted small">ユニーククリックユーザー</div>
+                                    <div class="text-muted small">ユニークユーザー</div>
                                     <div class="fs-4 fw-bold">{{ pc.total.users }}</div>
                                 </div>
                             </div>
@@ -212,7 +215,7 @@
                                     <thead class="table-light">
                                         <tr>
                                             <th>集会</th>
-                                            <th class="text-end">クリック</th>
+                                            <th class="text-end">遷移数</th>
                                             <th class="text-end">ユーザー</th>
                                         </tr>
                                     </thead>
@@ -232,7 +235,7 @@
                                 </table>
                             </div>
                         {% else %}
-                            <p class="text-muted small mb-0">対象期間にポスタークリックのデータがありません。</p>
+                            <p class="text-muted small mb-0">対象期間に集会一覧からの遷移データがありません。</p>
                         {% endif %}
                     {% endwith %}
                 </div>


### PR DESCRIPTION
## 背景

主催者から「ポスター経由クリック」が何を計測しているか分かりづらいと指摘あり。

実装を確認したところ、計測対象（`app/community/templates/community/list.html:147-148` の onclick）は **ポスター画像 + 集会名タイトル両方を内包する `<a>` 全体** に付いており、実態は「集会一覧 → 詳細ページへの動線」を測っている。
「ポスター」だけを指すわけでも「クリック」だけでもないため、表現がミスマッチだった。

## 変更内容

ダッシュボードの該当カードの文言を **「集会一覧からの遷移数」** に統一。

| 箇所 | 変更前 | 変更後 |
|------|--------|--------|
| カード見出し | ポスター経由クリック | 集会一覧からの遷移数 |
| 説明文 | 集会一覧ページでサムネを押した数。 | 集会一覧ページから、この集会を選んで詳細ページへ進んだ数。 |
| 指標ラベル | 合計クリック / ユニーククリックユーザー | 合計遷移数 / ユニークユーザー |
| テーブル列 | クリック / ユーザー | 遷移数 / ユーザー |
| 空状態文言 | ポスタークリックのデータがありません | 集会一覧からの遷移データがありません |

ついでに HTML に漏れていた複数行 `{# ... #}` コメントを `{% comment %}` に修正（Django テンプレート規約 [django-template-comments.md](https://github.com/noricha-vr) 準拠）。

## 据え置き（変更しない）

- `PosterClick` モデル名 / `db_table='poster_click'`
- GA4 カスタムイベント名 `poster_click`
- `services.get_poster_click_stats` メソッド名
- `fetch_poster_click_report` 関数名

これらは内部名で表示に出ないため、変更すると過去 GA4 データとの整合が壊れる。

## スクリーンショット

![rename-poster-click-final-20260602-112946](https://gh-image-uploader.kaisha3.com/uploads/2026/06/b8fc02146585-rename-poster-click-final-20260602-112946.avif)

## 検証

- [x] `curl` でログイン後のダッシュボード HTML を取得 → 新文言含まれること、旧文言が残っていないことを確認
- [x] `docker compose exec vrc-ta-hub python manage.py test analytics` → 60 件全パス（main 基準、ロジック変更なし）
- [x] ヘッドレス Chrome でスクリーンショット撮影 → 見た目崩れなし、テンプレートコメント漏れもなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)