### PR TITLE
refactor(auth): logout リンクを POST フォーム化 (Django 5 対応・Issue #321 PR1)

### DIFF
--- a/app/ta_hub/templates/ta_hub/base.html
+++ b/app/ta_hub/templates/ta_hub/base.html
@@ -409,9 +409,14 @@
                                 <li><a class="dropdown-item" href="{% url 'account:settings' %}">
                                     <i class="bi bi-gear me-2"></i>アカウント設定
                                 </a></li>
-                                <li><a class="dropdown-item" href="{% url 'account:logout' %}">
-                                    <i class="bi bi-box-arrow-right me-2"></i>ログアウト
-                                </a></li>
+                                <li>
+                                    <form method="post" action="{% url 'account:logout' %}" class="m-0">
+                                        {% csrf_token %}
+                                        <button type="submit" class="dropdown-item">
+                                            <i class="bi bi-box-arrow-right me-2"></i>ログアウト
+                                        </button>
+                                    </form>
+                                </li>
                             </ul>
                         </li>
                     {% else %}

--- a/app/user_account/templates/account/discord_required.html
+++ b/app/user_account/templates/account/discord_required.html
@@ -30,9 +30,12 @@
                         </div>
                         <hr>
                         <div class="text-center mt-4">
-                            <a href="{% url 'account:logout' %}" class="text-muted">
-                                <i class="fas fa-sign-out-alt me-1"></i>ログアウト
-                            </a>
+                            <form method="post" action="{% url 'account:logout' %}" class="d-inline">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-link text-muted p-0 border-0 align-baseline">
+                                    <i class="fas fa-sign-out-alt me-1"></i>ログアウト
+                                </button>
+                            </form>
                         </div>
                     </div>
                 </div>

--- a/app/user_account/templates/account/settings.html
+++ b/app/user_account/templates/account/settings.html
@@ -157,9 +157,12 @@
 
                         <!-- ログアウトセクション -->
                         <div class="list-group list-group-flush">
-                            <a href="{% url 'account:logout' %}" class="list-group-item list-group-item-action text-danger">
-                                <i class="fa-solid fa-right-from-bracket me-2"></i>ログアウト
-                            </a>
+                            <form method="post" action="{% url 'account:logout' %}" class="m-0">
+                                {% csrf_token %}
+                                <button type="submit" class="list-group-item list-group-item-action text-danger w-100 text-start border-0">
+                                    <i class="fa-solid fa-right-from-bracket me-2"></i>ログアウト
+                                </button>
+                            </form>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## 概要

Django 4.2 → 5.2 LTS 移行（Issue #321）の **PR1 / 3** ステップ。Django 5.0 で `LogoutView` の GET メソッドが廃止されるため、`<a href="{% url 'account:logout' %}">` 形式の 3 箇所を `<form method="post">` + `{% csrf_token %}` + `<button>` に書き換える。

Django 4.2 でもそのまま動作するので、本体アップグレード前に先行マージ可能（plan: `/Users/ms25/.claude/plans/polished-sparking-rain.md`）。

## 変更点

| ファイル | 場所 |
|---|---|
| `app/ta_hub/templates/ta_hub/base.html` | ヘッダードロップダウン内 |
| `app/user_account/templates/account/settings.html` | 設定画面のログアウトセクション |
| `app/user_account/templates/account/discord_required.html` | Discord 連携必須案内ページ |

## 検証

### 自動テスト

```
docker compose exec vrc-ta-hub python manage.py test user_account
Ran 181 tests in 13.742s
OK
```

### ブラウザ実機（Playwright）

| ページ | `<form method=post action=/account/logout/>` | `<a href=/account/logout/>` |
|---|---|---|
| `/`（base.html ヘッダードロップダウン） | 1 | 0 |
| `/account/settings/`（base + body） | 2 | 0 |
| `/account/discord-required/`（base + body） | 2 | 0 |

設定画面のログアウトボタンを実際にクリック:
- POST 送信 → `/account/login/` にリダイレクト
- 再度 `/account/settings/` にアクセス → `/account/login/?next=/account/settings/` にリダイレクトされ、セッション破棄を確認

スクリーンショット: `docs/tmp/screenshots/01-04*.png`, `05-after-logout-*.png`

## 後続

- PR2: `unique_together` → `UniqueConstraint` 移行（4 ファイル、migration 含む）
- PR3: Django 5.2 本体 + 依存パッケージ一括アップグレード（canary 監視あり）

## 関連 Issue

- #321（Django 4.2 → 5.2 LTS アップグレード）