### PR TITLE
chore(django): Django 5.x 削除予定 API の使用箇所を修正 (Issue #387)

### DIFF
--- a/app/user_account/tests/test_middleware.py
+++ b/app/user_account/tests/test_middleware.py
@@ -64,7 +64,8 @@ class DiscordAuthRequiredMiddlewareTests(TestCase):
     def test_exempt_path_logout_not_redirected(self):
         """除外パス /account/logout/ はリダイレクトされないこと."""
         self.client.login(username='test_no_discord', password='testpass123')
-        response = self.client.get(reverse('account:logout'))
+        # Django 5.0 で GET ログアウトは削除されたため POST を使う (Issue #387)
+        response = self.client.post(reverse('account:logout'))
         # logout後のリダイレクト（discord_requiredではない）
         self.assertEqual(response.status_code, 302)
         self.assertNotIn('discord-required', response.url)


### PR DESCRIPTION
## なぜこの変更が必要か

Django 4.2 → 5.2 LTS 移行 (Issue #321) の準備タスク (Issue #387)。Django 4.2 のうちに `python -Wd manage.py test` で Django 5.0/5.1/5.2 で削除される API の使用箇所を洗い出し、プロジェクトコード由来のものを潰しておく。

PR #385 で本番ログアウト導線は POST 化済みだが、テストコード側に GET ログアウトの取り残しが 1 箇所あったため、それを修正する。

## 変更内容

- `app/user_account/tests/test_middleware.py:67`: `self.client.get(reverse('account:logout'))` → `self.client.post(...)`
  - 警告: `RemovedInDjango50Warning: Log out via GET requests is deprecated and will be removed in Django 5.0. Use POST requests for logging out.`
  - PR #385 で `<form method="post" action="/account/logout/">` 化したので、テストもそれに合わせる

## 調査結果サマリ

| カテゴリ | 件数 | 対応 |
|---|---|---|
| A. プロジェクトコード由来 | 1 件 (logout GET) | 本 PR で修正 |
| B. サードパーティ由来 | 1 件 (`botocore` の `datetime.utcnow()` Python 3.12 警告) | PR3 (Issue #388) の依存パッケージ更新で吸収予定 |
| C. Django 内部 | 0 件 | — |

`force_text` / `ugettext` / `url()` / `is_ajax` 等の古典的な削除予定 API は既にプロジェクトコードから除去されており、Django 5.2 アップグレード (PR3) は安全に着手できる状態。

## 意思決定

### 採用アプローチ
- `client.post()` への変更を採用。理由: PR #385 でログアウト URL は POST 必須化済み、テストもそれに揃える方が一貫性がある。Django 4.2 / 5.x 両対応

### 却下した代替案
- `client.get()` のままで Warning を `@ignore_warnings` でサプレス → 却下: 警告隠蔽は技術的負債、Django 5.0 で 405 を返すようになる

### トレードオフ
- テスト 1 行修正 vs Django 5 アップグレード前の互換性確保: 後者を優先

## テスト

- [x] `docker compose exec vrc-ta-hub python -Wd manage.py test 2>&1 | grep RemovedInDjango50Warning` → 修正前 1 件 → 修正後 **0 件**
- [x] `docker compose exec vrc-ta-hub python manage.py check` → System check identified no issues (0 silenced)
- [x] `docker compose exec vrc-ta-hub python manage.py test` → 1549 tests 通過（既存3エラーは `cloudbuild.yaml` の絶対パスマウントが worktree 環境で外れた既存問題で本 PR とは無関係）

Closes #387

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)