### PR TITLE
fix: 集会一覧のテンプレートコメント表示を修正

### DIFF
--- a/app/community/templates/community/list.html
+++ b/app/community/templates/community/list.html
@@ -142,8 +142,10 @@
                     <div class="col-md-4 mb-4"> <!-- mb-4 クラスを追加してカード間の縦方向の間隔を確保 -->
                         <div class="card h-100 bg-light-subtle shadow"> <!-- カードを囲む div を追加 -->
                             <div class="card-body d-flex flex-column"> <!-- カードの内容を card-body で囲む -->
-                                {# 集会一覧のポスタークリックは GA4 カスタムイベント poster_click で計測。
-                                   ダッシュボードでポスター経由クリック数を可視化する目的。 #}
+                                {% comment %}
+                                集会一覧のポスタークリックは GA4 カスタムイベント poster_click で計測。
+                                ダッシュボードでポスター経由クリック数を可視化する目的。
+                                {% endcomment %}
                                 <a href="{% url 'community:detail' community.id %}" class="text-decoration-none"
                                    onclick="if(window.gtag){gtag('event','poster_click',{community_id:{{ community.id }}});}">
                                     {% if community.poster_image %}

--- a/app/community/tests/test_views.py
+++ b/app/community/tests/test_views.py
@@ -52,6 +52,13 @@ class TestCommunityListViewPagination(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.community.name)
 
+    def test_poster_click_comment_is_not_rendered(self):
+        response = self.client.get(reverse('community:list'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, '集会一覧のポスタークリック')
+        self.assertNotContains(response, 'poster_click で計測')
+
     def test_malformed_amp_params_are_not_propagated(self):
         response = self.client.get(
             reverse('community:list'),


### PR DESCRIPTION
## なぜこの変更が必要か

集会一覧カードのポスター上部に Django テンプレートコメントがそのまま表示され、利用者に開発者向けの説明文が見えていたため修正します。

## 変更内容

- 複数行の Django コメントを `{% comment %}` / `{% endcomment %}` へ置き換え
- 一覧レスポンスにコメント文が含まれない回帰テストを追加

## 意思決定

- 計測意図のコメントは残しつつ、Django テンプレートで正しく無視される構文を採用しました。
- GA4 の `poster_click` 計測処理には触れず、表示不具合だけを最小差分で直しています。

## テスト

- [x] `docker compose exec -T vrc-ta-hub python manage.py test community.tests.test_views.TestCommunityListViewPagination`

## 本番確認

- merge 後、Cloud Run へ反映して `/community/list/` でコメント文が表示されないことを確認します。
