### PR TITLE
表示名とログインユーザー名の説明を明確化

### DIFF
--- a/app/user_account/forms.py
+++ b/app/user_account/forms.py
@@ -311,8 +311,8 @@ class CustomUserChangeForm(forms.ModelForm):
             'user_name': 'ログインユーザー名',
         }
         help_texts = {
-            'display_name': 'VRChat等で使う表示名です。同じ表示名を複数ユーザーが使用できます。',
-            'user_name': 'ログインに使用する一意のユーザー名です。',
+            'display_name': 'VRChat内の名前や発表者名として表示されます。同じ表示名を複数ユーザーが使用できます。',
+            'user_name': 'ログインと内部識別に使用する一意のユーザー名です。通常は変更不要です。',
         }
 
     def clean_x_account(self):

--- a/app/user_account/templates/account/user_update.html
+++ b/app/user_account/templates/account/user_update.html
@@ -9,6 +9,10 @@
                         <h4 class="mb-0">ユーザー情報の更新</h4>
                     </div>
                     <div class="card-body">
+                        <div class="alert alert-info small" role="alert">
+                            <div><strong>表示名:</strong> VRChat内の名前や発表者名として表示されます。同じ名前を複数ユーザーが使えます。</div>
+                            <div><strong>ログインユーザー名:</strong> ログインと内部識別に使用します。一意のため、通常は変更不要です。</div>
+                        </div>
                         <form method="post" enctype="multipart/form-data">
                             {% csrf_token %}
                             <div class="mb-3">

--- a/app/user_account/tests/test_forms.py
+++ b/app/user_account/tests/test_forms.py
@@ -270,6 +270,22 @@ class CustomUserChangeFormTests(TestCase):
         form = CustomUserChangeForm(instance=self.test_user)
         self.assertEqual(form.fields['display_name'].label, '表示名')
 
+    def test_display_name_help_text_explains_public_display(self):
+        """display_nameの説明が公開表示と重複許可を伝えること."""
+        form = CustomUserChangeForm(instance=self.test_user)
+        self.assertEqual(
+            form.fields['display_name'].help_text,
+            'VRChat内の名前や発表者名として表示されます。同じ表示名を複数ユーザーが使用できます。',
+        )
+
+    def test_user_name_help_text_explains_login_identifier(self):
+        """user_nameの説明がログイン用の一意な識別子であることを伝えること."""
+        form = CustomUserChangeForm(instance=self.test_user)
+        self.assertEqual(
+            form.fields['user_name'].help_text,
+            'ログインと内部識別に使用する一意のユーザー名です。通常は変更不要です。',
+        )
+
     def test_form_has_bootstrap_class(self):
         """フォームフィールドにBootstrapのform-controlクラスが適用されていること."""
         form = CustomUserChangeForm(instance=self.test_user)

--- a/app/user_account/tests/test_views.py
+++ b/app/user_account/tests/test_views.py
@@ -440,6 +440,15 @@ class UserUpdateViewTests(TestCase):
         self.assertContains(response, 'fa-lock')
         self.assertContains(response, 'form-text')
 
+    def test_user_update_view_explains_display_name_and_login_user_name(self):
+        """表示名とログインユーザー名の使い分けが画面で伝わること."""
+        self.client.login(username='test_update_user', password='testpass123')
+        response = self.client.get(self.update_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'name="display_name"')
+        self.assertContains(response, 'VRChat内の名前や発表者名として表示されます')
+        self.assertContains(response, 'ログインと内部識別に使用します')
+
 
 @override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS_WITH_APPS)
 class RegisterViewTests(TestCase):


### PR DESCRIPTION
## 概要
- アカウント更新画面に、表示名とログインユーザー名の使い分けを説明する注釈を追加
- `display_name` / `user_name` の help_text を、公開表示用とログイン・内部識別用の違いが伝わる文言に更新
- フォーム定義と画面表示のテストを追加

## なぜこの変更が必要か
`CustomUser.user_name` はログイン・内部識別子として一意制約を維持し、`display_name` はVRChat内の名前や発表者名として重複可能に分離した。ユーザーがアカウント編集画面で両者の役割を誤解しないよう、画面上の説明を明確にする。

## テスト
- `COMPOSE_PROJECT_NAME=vrc-ta-hub-help APP_PORT=8025 DB_PORT=3315 STORAGE_PORT=9015 STORAGE_CONSOLE_PORT=9016 docker compose run --rm vrc-ta-hub python manage.py test user_account.tests.test_forms.CustomUserChangeFormTests user_account.tests.test_views.UserUpdateViewTests --verbosity=2`
- `git diff --check`
- `COMPOSE_PROJECT_NAME=vrc-ta-hub-help APP_PORT=8025 DB_PORT=3315 STORAGE_PORT=9015 STORAGE_CONSOLE_PORT=9016 docker compose run --rm vrc-ta-hub python manage.py makemigrations user_account --check --dry-run`
