### PR TITLE
スタッフ削除確認の表示名をJS向けにエスケープ

### DIFF
--- a/app/community/templates/community/member_manage.html
+++ b/app/community/templates/community/member_manage.html
@@ -90,7 +90,7 @@
                 {% if not member.is_owner or members|length > 1 %}
                 {% if member.user != request.user or not member.is_owner %}
                 <form method="post" action="{% url 'community:remove_staff' community.pk member.pk %}"
-                      onsubmit="return confirm('{{ member.user.display_label }} を削除しますか？');">
+                      onsubmit="return confirm('{{ member.user.display_label|escapejs }} を削除しますか？');">
                     {% csrf_token %}
                     <button type="submit" class="btn btn-outline-danger btn-sm">
                         <i class="bi bi-trash"></i>

--- a/app/community/tests/test_member_manage.py
+++ b/app/community/tests/test_member_manage.py
@@ -2,6 +2,7 @@ from django.test import TestCase, Client, override_settings
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
+from django.utils.html import escapejs
 
 from allauth.socialaccount.models import SocialApp
 
@@ -95,6 +96,24 @@ class CommunityMemberManageViewTest(TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertIn('/login/', response.url)
+
+    def test_member_remove_confirm_escapes_display_label_for_js(self):
+        """削除確認の表示名はJS文字列としてエスケープされる"""
+        self.staff.display_name = "');alert(1);//"
+        self.staff.save(update_fields=['display_name'])
+        self.client.login(username='オーナー', password='testpass123')
+
+        response = self.client.get(
+            reverse('community:member_manage', kwargs={'pk': self.community.pk})
+        )
+
+        content = response.content.decode()
+        expected_confirm = (
+            f"confirm('{escapejs(self.staff.display_label)} を削除しますか？');"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(expected_confirm, content)
+        self.assertNotIn("confirm('');alert(1);// を削除しますか？');", content)
 
 
 class RemoveStaffViewTest(TestCase):


### PR DESCRIPTION
## 概要

- スタッフ削除確認の `confirm()` に埋め込む表示名へ `escapejs` を適用
- 引用符を含む表示名でも JavaScript 文字列を抜けられないことをテストで固定

## 背景

PR #395 で `display_name` / `display_label` が追加され、`user_name` と異なり表示名には引用符などの任意文字を含められるようになりました。
スタッフ管理画面の削除確認では `display_label` をインライン JS 文字列に直接埋め込んでいたため、保存型 XSS の可能性がありました。

## テスト

- `COMPOSE_PROJECT_NAME=vrc-ta-hub docker compose run --rm --no-deps vrc-ta-hub python manage.py test community.tests.test_member_manage`
- `COMPOSE_PROJECT_NAME=vrc-ta-hub docker compose run --rm --no-deps vrc-ta-hub python manage.py check`

`manage.py check` は既存の allauth 設定 deprecation 警告 4 件のみです。

Closes #399
