### PR TITLE
fix: スタッフ削除確認の表示名をJS用にエスケープ

### DIFF
--- a/app/community/templates/community/member_manage.html
+++ b/app/community/templates/community/member_manage.html
@@ -90,7 +90,7 @@
                 {% if not member.is_owner or members|length > 1 %}
                 {% if member.user != request.user or not member.is_owner %}
                 <form method="post" action="{% url 'community:remove_staff' community.pk member.pk %}"
-                      onsubmit="return confirm('{{ member.user.display_label }} を削除しますか？');">
+                      onsubmit="return confirm('{{ member.user.display_label|escapejs }} を削除しますか？');">
                     {% csrf_token %}
                     <button type="submit" class="btn btn-outline-danger btn-sm">
                         <i class="bi bi-trash"></i>

--- a/app/community/tests/test_member_manage.py
+++ b/app/community/tests/test_member_manage.py
@@ -2,6 +2,7 @@ from django.test import TestCase, Client, override_settings
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
+from django.utils.html import escapejs
 
 from allauth.socialaccount.models import SocialApp
 
@@ -95,6 +96,30 @@ class CommunityMemberManageViewTest(TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertIn('/login/', response.url)
+
+    def test_remove_staff_confirm_escapes_display_label_for_javascript(self):
+        """削除確認の表示名はJavaScript文字列用にエスケープされる"""
+        display_name = "');alert(1);//"
+        self.staff.display_name = display_name
+        self.staff.save(update_fields=['display_name'])
+
+        self.client.login(username='オーナー', password='testpass123')
+        response = self.client.get(
+            reverse('community:member_manage', kwargs={'pk': self.community.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        escaped_display_name = escapejs(display_name)
+        self.assertIn('&#x27;);alert(1);//', content)
+        self.assertIn(
+            f"return confirm('{escaped_display_name} を削除しますか？');",
+            content,
+        )
+        self.assertNotIn(
+            "return confirm('');alert(1);// を削除しますか？');",
+            content,
+        )
 
 
 class RemoveStaffViewTest(TestCase):

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -4,6 +4,7 @@
 
 ## レポート一覧
 
+- [Issue #399 スタッフ削除確認の表示名エスケープ](issue-399-member-delete-confirm-xss.md) — `display_name` を JavaScript 文字列コンテキストで安全に扱うための調査と検証方針
 - [Issue #356 OpenRouter HTTP-Referer 調査](issue-356-openrouter-http-referer.md) — preview/staging URL が OpenRouter の `HTTP-Referer` に漏れないようにする調査と検証方針
 - [Issue #343 LT申請「追加情報」テンプレート初期値化](issue-343-lt-application-additional-info-initial.md) — LT申請フォームのテンプレート表示を placeholder から initial に変更する調査と検証方針
 - [リファクタリング計画 (2026-05-25)](refactor-plan.html) — `app/` 配下のPythonコードを構造/品質/設計の3軸で機械的にスキャンし、優先度付き改善ロードマップを提示

--- a/docs/research/issue-399-member-delete-confirm-xss.md
+++ b/docs/research/issue-399-member-delete-confirm-xss.md
@@ -1,0 +1,26 @@
+# Issue 399: スタッフ削除確認の表示名エスケープ
+
+## 調査対象
+
+- `app/community/templates/community/member_manage.html` のスタッフ削除フォームは、`display_label` を `confirm('...')` の JavaScript 文字列リテラルへ埋め込んでいた。
+- `app/user_account/models.py` の `CustomUser.display_name` は `blank=True` の任意表示名で、`display_label` は `display_name` があれば優先し、未設定時だけ `user_name` にフォールバックする。
+- `app/user_account/forms.py` のプロフィール編集フォームは `display_name` に専用の文字種制限を設けていない。
+- 同じ `display_label` と `confirm` の組み合わせをテンプレート群で検索したところ、未エスケープの該当箇所はスタッフ削除確認だけだった。Vket の発表削除確認は既に `escapejs` を使っている。
+
+## 原因候補と改善案
+
+`display_name` は引用符、改行、バックスラッシュなどを含められる人間向けプロフィール項目であるため、HTML表示では問題なくても JavaScript 文字列コンテキストでは別途エスケープが必要になる。
+
+改善案は、テンプレート上で `escapejs` を適用する案と、表示名を `data-*` 属性へ移して外部 JavaScript で確認文を組み立てる案を比較した。
+
+## 採用判断
+
+既存テンプレートでは同種の削除確認に `escapejs` を使う実装があり、今回の問題は単一の JavaScript 文字列コンテキストに限定されているため、`member.user.display_label|escapejs` を採用した。
+
+この変更により、表示名 `');alert(1);//` は `\u0027)\u003Balert(1)\u003B//` のような文字列として描画され、`confirm` の文字列リテラルを閉じられない。
+
+## 検証手順
+
+- スタッフ管理ページのレスポンスに、攻撃例の表示名が画面表示用テキストとして HTML エスケープされていることを確認する。
+- 同じ表示名が `onsubmit` 内では JavaScript 文字列用にエスケープされ、raw な `confirm('');alert(1);// を削除しますか？')` 形式にならないことを確認する。
+- 影響範囲として `app.community` と `app.user_account` の Django テストを実行する。


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: [#399](https://github.com/noricha-vr/vrc-ta-hub/issues/399)「スタッフ削除確認の表示名をJS文字列用にエスケープする」
- 必要性: この Issue で報告された問題・要望により、VRC技術学術Hub が期待動作や要件を満たせないため、修正・対応が必要です。
- 対応意図: `display_name` は任意文字を含められる表示用フィールドなので、HTML表示とは別に JavaScript 文字列コンテキスト用のエスケープが必要でした。既存の Vket 削除確認でも使われている Django 標準の `escapejs` を採用し、問題箇所に限定した最小修正にしました。

## 変更内容

- `app/community/templates/community/member_manage.html` のスタッフ削除確認で `display_label|escapejs` を適用しました。
- `app/community/tests/test_member_manage.py` に `');alert(1);//` を表示名にした回帰テストを追加しました。
- `docs/research/issue-399-member-delete-confirm-xss.md` に原因、調査結果、採用判断、検証方針を記録しました。
- `docs/research/index.md` から Issue #399 の調査メモへリンクを追加しました。
- コミット済み: `cacb503a9e8d48b52fb4819f3b30b2f2d71edf42`

## 意思決定

### 採用アプローチ
`display_name` は任意文字を含められる表示用フィールドなので、HTML表示とは別に JavaScript 文字列コンテキスト用のエスケープが必要でした。既存の Vket 削除確認でも使われている Django 標準の `escapejs` を採用し、問題箇所に限定した最小修正にしました。

### トレードオフ または 却下した代替案
`data-*` 属性や外部 JavaScript に移す案も検討しましたが、今回の危険箇所は単一の `confirm('...')` 文字列に限定されていました。テンプレート構造を広く変更するより、既存パターンに合わせた `escapejs` の方が影響範囲が小さく、レビューしやすいと判断しました。

### 残課題やリスク
影響範囲全体の `community user_account` は既存失敗が残っています。今回追加したスタッフ削除確認の回帰テストは pass しており、保護対象ファイルは変更していません。


## テスト

- `docker compose -f docker-compose.yaml -f docker-compose.test.yml run --rm test python manage.py test community.tests.test_member_manage`: 17 tests pass
- `uvx ruff check app/community/tests/test_member_manage.py`: pass
- `docker compose -f docker-compose.yaml -f docker-compose.test.yml run --rm --build test python manage.py test community user_account`: 478 tests 実行、failures=2 / errors=8。`storage:9000` 解決失敗など、今回変更とは別の既存環境・既存テスト失敗で完走失敗。
- `docker compose -f docker-compose.yaml -f docker-compose.test.yml run --rm --build test python manage.py test user_account`: 186 tests 実行、failures=2。

---
🤖 Generated with [Codex](https://Codex.com/Codex)
