### PR TITLE
fix(analytics): 集計期間を前日基準・当日除外のちょうどN日に統一 (#369)

### DIFF
--- a/app/analytics/dashboard_views.py
+++ b/app/analytics/dashboard_views.py
@@ -45,7 +45,8 @@ def _csv_safe(value) -> str:
 
 # クエリパラメータで受け付ける days の許可リスト（任意値を許すと DoS リスク）
 ALLOWED_DAYS = [7, 30, 90]
-DEFAULT_DAYS = 30
+# 既定日数は services を単一の真実とし、二重管理による不整合を防ぐ
+DEFAULT_DAYS = services.DEFAULT_DAYS
 # 公開後 N 日積み上げチャートで遡る日数
 POST_PUBLISH_DAYS_AFTER = 14
 POST_PUBLISH_TOP_N = 5

--- a/app/analytics/services.py
+++ b/app/analytics/services.py
@@ -22,6 +22,23 @@ DEFAULT_DAYS = 30
 TOP_EVENT_DETAILS_LIMIT = 50
 
 
+def _date_range(days=DEFAULT_DAYS) -> tuple[date, date]:
+    """集計対象の日付範囲 (since, until) を返す。両端含む。
+
+    GA4 同期は午前1時に前日分までしか取得しない（views.py _parse_target_date）。
+    当日(today) のレコードはそもそも存在せず、含めると同期済み日数が1日足りない
+    期間になり集計が日々ブレるため、当日は集計に含めない。
+
+    until = today - 1（前日、含む）
+    since = today - days（含む）= until - (days - 1)
+    範囲は today-days 〜 today-1 のちょうど days 日分。
+    """
+    today = timezone.localdate()
+    until = today - timedelta(days=1)
+    since = today - timedelta(days=days)
+    return since, until
+
+
 def accessible_community_ids(user) -> list[int]:
     """ユーザーがアクセス可能な community の id リストを返す。
 
@@ -47,12 +64,16 @@ def accessible_community_ids(user) -> list[int]:
 
 
 def _base_queryset(community_ids, *, content_type=None, object_id=None, days=DEFAULT_DAYS):
-    """community_ids で必ず絞った PageAnalytics の基底クエリセットを作る。"""
-    since = timezone.localdate() - timedelta(days=days)
+    """community_ids で必ず絞った PageAnalytics の基底クエリセットを作る。
+
+    日付範囲は _date_range に従い today-days 〜 today-1（当日除外、ちょうど days 日）。
+    """
+    since, until = _date_range(days)
     # community__in による絞り込みは権限境界。絶対に外さないこと
     queryset = PageAnalytics.objects.filter(
         community_id__in=community_ids,
         date__gte=since,
+        date__lte=until,
     )
     if content_type is not None:
         queryset = queryset.filter(content_type=content_type)
@@ -123,9 +144,11 @@ def get_overall_stats(community_ids, *, days=DEFAULT_DAYS) -> dict:
             'pv_change_pct', 'users_change_pct', 'sessions_change_pct': 変化率%（float, 前期間が0なら None）
         }
     """
-    today = timezone.localdate()
-    current_start = today - timedelta(days=days)
-    prev_start = current_start - timedelta(days=days)
+    # current = today-days 〜 today-1（当日除外、N日）。prev はその直前の同じ N 日。
+    # current/prev を同じ期間長にすることで比較率が正しくなる
+    since, until = _date_range(days)
+    prev_until = since - timedelta(days=1)
+    prev_since = prev_until - timedelta(days=days - 1)
 
     # community_ids が空なら集計しても 0 件。早期 return で DB を叩かない
     if not community_ids:
@@ -133,15 +156,15 @@ def get_overall_stats(community_ids, *, days=DEFAULT_DAYS) -> dict:
 
     current = (
         PageAnalytics.objects
-        .filter(community_id__in=community_ids, date__gte=current_start)
+        .filter(community_id__in=community_ids, date__gte=since, date__lte=until)
         .aggregate(pv=Sum('pv'), users=Sum('users'), sessions=Sum('sessions'))
     )
     prev = (
         PageAnalytics.objects
         .filter(
             community_id__in=community_ids,
-            date__gte=prev_start,
-            date__lt=current_start,
+            date__gte=prev_since,
+            date__lte=prev_until,
         )
         .aggregate(pv=Sum('pv'), users=Sum('users'), sessions=Sum('sessions'))
     )
@@ -360,10 +383,12 @@ def get_global_traffic(*, days=DEFAULT_DAYS) -> dict:
             'top_paths': [{'page_path', 'pv'}, ...]（上位10件）,
         }
     """
-    since = timezone.localdate() - timedelta(days=days)
+    # GLOBAL 集計は community_id 境界を持たないため _base_queryset は使わず日付範囲だけ流用
+    since, until = _date_range(days)
     base = PageAnalytics.objects.filter(
         content_type=PageAnalytics.ContentType.GLOBAL,
         date__gte=since,
+        date__lte=until,
     )
 
     total = base.aggregate(pv=Sum('pv'), users=Sum('users'), sessions=Sum('sessions'))
@@ -497,10 +522,9 @@ def get_campaign_daily_series(
 
     top_keys = [row['campaign'] for row in top_campaigns]
 
-    # 日付ラベル: today を含めて days+1 日分。グラフは「過去 N 日」の期間表示
-    today = timezone.localdate()
-    start = today - timedelta(days=days)
-    label_dates = [start + timedelta(days=i) for i in range(days + 1)]
+    # 日付ラベル: today-days 〜 today-1 のちょうど days 日分（当日除外、_date_range と一致）
+    since, _until = _date_range(days)
+    label_dates = [since + timedelta(days=i) for i in range(days)]
     labels = [d.strftime('%m/%d') for d in label_dates]
 
     # 一括取得して dict 化（N+1 防止）
@@ -553,10 +577,12 @@ def get_poster_click_stats(community_ids, *, days=DEFAULT_DAYS) -> dict:
             'per_community': [],
         }
 
-    since = timezone.localdate() - timedelta(days=days)
+    # PosterClick は _base_queryset(PageAnalytics 用) と別モデルなので日付範囲だけ流用
+    since, until = _date_range(days)
     base = PosterClick.objects.filter(
         community_id__in=community_ids,
         date__gte=since,
+        date__lte=until,
     )
 
     total = base.aggregate(clicks=Sum('clicks'), users=Sum('users'))

--- a/app/analytics/templates/analytics/_chart_section.html
+++ b/app/analytics/templates/analytics/_chart_section.html
@@ -17,7 +17,7 @@ analytics/_chart_scripts.html を include すること。
         <h2 class="fs-4 fw-bold mb-1">
             <i class="fa-solid fa-chart-line me-2 text-primary"></i>アクセス解析
         </h2>
-        <p class="text-muted mb-4">直近30日のページアクセス状況です。</p>
+        <p class="text-muted mb-4">直近{{ days|default:30 }}日（前日まで）のページアクセス状況です。</p>
 
         {% if daily_series %}
             {# Django テンプレートの json_script で安全に JSON 化して受け渡す（XSS対策） #}

--- a/app/analytics/tests/test_dashboard.py
+++ b/app/analytics/tests/test_dashboard.py
@@ -89,16 +89,17 @@ class DashboardViewAccessTest(TestCase):
         ed_a = _create_event_detail(self.community_a, 'A theme')
         # community_b 側にも event を作って参照整合性は保つ。変数は使わない（ruff F841 回避）
         _create_event_detail(self.community_b, 'B theme')
-        today = timezone.localdate()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）。前日にデータを置く
+        yesterday = timezone.localdate() - timedelta(days=1)
         _make_analytics(self.community_a, page_path='/community/{}/'.format(self.community_a.id),
                         content_type=PageAnalytics.ContentType.COMMUNITY,
-                        object_id=self.community_a.id, date_=today, pv=10, source='source-A-only / organic')
+                        object_id=self.community_a.id, date_=yesterday, pv=10, source='source-A-only / organic')
         _make_analytics(self.community_a, page_path='/event/detail/{}/'.format(ed_a.id),
                         content_type=PageAnalytics.ContentType.EVENT_DETAIL,
-                        object_id=ed_a.id, date_=today, pv=5, source='source-A-only / referral')
+                        object_id=ed_a.id, date_=yesterday, pv=5, source='source-A-only / referral')
         _make_analytics(self.community_b, page_path='/community/{}/'.format(self.community_b.id),
                         content_type=PageAnalytics.ContentType.COMMUNITY,
-                        object_id=self.community_b.id, date_=today, pv=20, source='source-B-only / organic')
+                        object_id=self.community_b.id, date_=yesterday, pv=20, source='source-B-only / organic')
 
     def test_unauthenticated_redirects_to_login(self):
         response = self.client.get(self.url)
@@ -213,10 +214,11 @@ class DashboardCsvExportTest(TestCase):
         self.client.force_login(self.user)
 
         self.ed = _create_event_detail(self.community, 'CSV テスト記事', event_date=date(2026, 5, 1))
-        today = timezone.localdate()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）
+        yesterday = timezone.localdate() - timedelta(days=1)
         _make_analytics(self.community, page_path=f'/event/detail/{self.ed.id}/',
                         content_type=PageAnalytics.ContentType.EVENT_DETAIL,
-                        object_id=self.ed.id, date_=today, pv=42, source='google / organic')
+                        object_id=self.ed.id, date_=yesterday, pv=42, source='google / organic')
 
     def test_csv_export_returns_csv_content_type(self):
         response = self.client.get(reverse('analytics:dashboard'), {'format': 'csv'})
@@ -254,7 +256,7 @@ class DashboardCsvExportTest(TestCase):
         other_ed = _create_event_detail(other, '他人の記事X', event_date=date(2026, 5, 1))
         _make_analytics(other, page_path=f'/event/detail/{other_ed.id}/',
                         content_type=PageAnalytics.ContentType.EVENT_DETAIL,
-                        object_id=other_ed.id, date_=timezone.localdate(), pv=999)
+                        object_id=other_ed.id, date_=timezone.localdate() - timedelta(days=1), pv=999)
 
         response = self.client.get(
             reverse('analytics:dashboard'),

--- a/app/analytics/tests/test_phase2.py
+++ b/app/analytics/tests/test_phase2.py
@@ -1,4 +1,5 @@
 """Phase 2 #10 #11 のテスト（未紐付けトラフィック / ポスタークリック）。"""
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.test import Client, TestCase, override_settings
@@ -52,23 +53,24 @@ class GlobalTrafficServiceTest(TestCase):
 
     def setUp(self):
         community = _create_community('A')
-        today = timezone.localdate()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）
+        yesterday = timezone.localdate() - timedelta(days=1)
         # community 紐付き（GLOBAL ではない）
         PageAnalytics.objects.create(
-            page_path=f'/community/{community.pk}/', date=today,
+            page_path=f'/community/{community.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=community, object_id=community.pk,
             pv=100, users=80, sessions=90, source_medium='google / organic',
         )
         # GLOBAL レコード
         PageAnalytics.objects.create(
-            page_path='/', date=today,
+            page_path='/', date=yesterday,
             content_type=PageAnalytics.ContentType.GLOBAL,
             community=None, object_id=0,
             pv=500, users=400, sessions=450, source_medium='google / organic',
         )
         PageAnalytics.objects.create(
-            page_path='/community/list/', date=today,
+            page_path='/community/list/', date=yesterday,
             content_type=PageAnalytics.ContentType.GLOBAL,
             community=None, object_id=0,
             pv=200, users=180, sessions=190, source_medium='(direct) / (none)',
@@ -131,9 +133,10 @@ class PosterClickServiceTest(TestCase):
     def setUp(self):
         self.community_a = _create_community('PA')
         self.community_b = _create_community('PB')
-        today = timezone.localdate()
-        PosterClick.objects.create(community=self.community_a, date=today, clicks=20, users=15)
-        PosterClick.objects.create(community=self.community_b, date=today, clicks=99, users=80)
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）
+        yesterday = timezone.localdate() - timedelta(days=1)
+        PosterClick.objects.create(community=self.community_a, date=yesterday, clicks=20, users=15)
+        PosterClick.objects.create(community=self.community_b, date=yesterday, clicks=99, users=80)
 
     def test_filter_by_community_ids(self):
         """渡された community_ids のレコードのみ集計に含まれる。"""
@@ -162,9 +165,10 @@ class DashboardGlobalTrafficVisibilityTest(TestCase):
             community=self.community, user=self.user,
             role=CommunityMember.Role.OWNER,
         )
-        today = timezone.localdate()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）
+        yesterday = timezone.localdate() - timedelta(days=1)
         PageAnalytics.objects.create(
-            page_path='/', date=today,
+            page_path='/', date=yesterday,
             content_type=PageAnalytics.ContentType.GLOBAL,
             community=None, object_id=0,
             pv=300, users=200, sessions=250, source_medium='google / organic',

--- a/app/analytics/tests/test_services.py
+++ b/app/analytics/tests/test_services.py
@@ -1,8 +1,9 @@
-from datetime import date
+from datetime import timedelta
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
+from django.utils import timezone
 
 from community.models import Community, CommunityMember
 
@@ -85,15 +86,16 @@ class AggregationPermissionBoundaryTest(TestCase):
             community=cls.community_a, user=cls.user_a,
             role=CommunityMember.Role.OWNER,
         )
-        today = date.today()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）。前日にデータを置く
+        yesterday = timezone.localdate() - timedelta(days=1)
         PageAnalytics.objects.create(
-            page_path=f'/community/{cls.community_a.pk}/', date=today,
+            page_path=f'/community/{cls.community_a.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=cls.community_a, object_id=cls.community_a.pk,
             pv=100, users=80, sessions=90, source_medium='google / organic',
         )
         PageAnalytics.objects.create(
-            page_path=f'/community/{cls.community_b.pk}/', date=today,
+            page_path=f'/community/{cls.community_b.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=cls.community_b, object_id=cls.community_b.pk,
             pv=500, users=400, sessions=450, source_medium='twitter / referral',
@@ -124,15 +126,16 @@ class AggregationPermissionBoundaryTest(TestCase):
         # object_id だけで絞ると両方混入するが、community 境界が効いていれば
         # アクセス可能な community_a の分だけが返ることを検証する。
         shared_object_id = 7777
-        today = date.today()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）。前日にデータを置く
+        yesterday = timezone.localdate() - timedelta(days=1)
         PageAnalytics.objects.create(
-            page_path='/community/a-shared/', date=today,
+            page_path='/community/a-shared/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=self.community_a, object_id=shared_object_id,
             pv=11, users=10, sessions=10, source_medium='a / src',
         )
         PageAnalytics.objects.create(
-            page_path='/community/b-shared/', date=today,
+            page_path='/community/b-shared/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=self.community_b, object_id=shared_object_id,
             pv=22, users=20, sessions=20, source_medium='b / src',

--- a/app/analytics/tests/test_services_campaign.py
+++ b/app/analytics/tests/test_services_campaign.py
@@ -29,13 +29,14 @@ class CampaignBreakdownTest(TestCase):
             community=cls.community_a, user=cls.user_a,
             role=CommunityMember.Role.OWNER,
         )
-        today = timezone.localdate()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）。前日を起点に置く
+        yesterday = timezone.localdate() - timedelta(days=1)
 
-        # 集会A: flyer キャンペーン × 2日分
+        # 集会A: flyer キャンペーン × 2日分（前日・前々日）
         for offset in (0, 1):
             PageAnalytics.objects.create(
                 page_path=f'/community/{cls.community_a.pk}/',
-                date=today - timedelta(days=offset),
+                date=yesterday - timedelta(days=offset),
                 content_type=PageAnalytics.ContentType.COMMUNITY,
                 community=cls.community_a, object_id=cls.community_a.pk,
                 pv=5, users=4, sessions=5,
@@ -44,7 +45,7 @@ class CampaignBreakdownTest(TestCase):
             )
         # 集会A: (not set) 流入
         PageAnalytics.objects.create(
-            page_path=f'/community/{cls.community_a.pk}/', date=today,
+            page_path=f'/community/{cls.community_a.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=cls.community_a, object_id=cls.community_a.pk,
             pv=100, users=90, sessions=95,
@@ -53,7 +54,7 @@ class CampaignBreakdownTest(TestCase):
         )
         # 集会B: 別キャンペーン（user_a は見えてはいけない）
         PageAnalytics.objects.create(
-            page_path=f'/community/{cls.community_b.pk}/', date=today,
+            page_path=f'/community/{cls.community_b.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=cls.community_b, object_id=cls.community_b.pk,
             pv=999, users=999, sessions=999,
@@ -144,17 +145,18 @@ class CampaignBreakdownAcrossCommunitiesTest(TestCase):
             community=cls.community_b, user=cls.user,
             role=CommunityMember.Role.OWNER,
         )
-        today = timezone.localdate()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）
+        yesterday = timezone.localdate() - timedelta(days=1)
         # 同じ utm_campaign を別 community が使うケース
         PageAnalytics.objects.create(
-            page_path=f'/community/{cls.community_a.pk}/', date=today,
+            page_path=f'/community/{cls.community_a.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=cls.community_a, object_id=cls.community_a.pk,
             pv=10, users=8, sessions=9,
             source_medium='(direct) / (none)', campaign='shared-key',
         )
         PageAnalytics.objects.create(
-            page_path=f'/community/{cls.community_b.pk}/', date=today,
+            page_path=f'/community/{cls.community_b.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=cls.community_b, object_id=cls.community_b.pk,
             pv=20, users=18, sessions=19,
@@ -205,9 +207,10 @@ class CampaignBreakdownIncludesRootLandingTest(TestCase):
             utm_source='flyer', utm_medium='qr',
             utm_campaign='20260510-flyer-top', landing_path='/',
         )
-        # sync_analytics の解決後に保存される想定レコード（page_path='/' で CAMPAIGN）
+        # sync_analytics の解決後に保存される想定レコード（page_path='/' で CAMPAIGN）。
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）なので前日に置く
         PageAnalytics.objects.create(
-            page_path='/', date=timezone.localdate(),
+            page_path='/', date=timezone.localdate() - timedelta(days=1),
             content_type=PageAnalytics.ContentType.CAMPAIGN,
             community=cls.community, object_id=cls.campaign.pk,
             pv=42, users=38, sessions=40,

--- a/app/analytics/tests/test_services_date_boundary.py
+++ b/app/analytics/tests/test_services_date_boundary.py
@@ -1,0 +1,233 @@
+"""集計期間の境界値テスト（前日基準・当日除外）。
+
+GA4 同期は午前1時に前日分までしか取得しないため、集計対象は
+「前日(today-1) から遡った N 日間」= today-N 〜 today-1 のちょうど N 日。
+当日(today) は集計に含めない。timezone.localdate() を固定して境界を厳密に検証する。
+
+このファイルは「当日除外・N日ぴったり」仕様の正本テスト。他アプリの集計テストは
+前日にデータを置く前提に揃えてあり当日除外そのものは検証しないため、本ファイルを
+削除・縮小すると当日除外の回帰保証が失われる点に注意。
+"""
+from datetime import date, timedelta
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from community.models import Community, CommunityMember
+
+from analytics import services
+from analytics.models import Campaign, PageAnalytics, PosterClick
+
+User = get_user_model()
+
+# localdate を固定して境界を再現可能にする（Date.now 系は使えないため定数で渡す）
+FIXED_TODAY = date(2026, 6, 6)
+
+
+def _patch_today():
+    """services 内で参照される timezone.localdate のみ FIXED_TODAY に固定する。"""
+    return mock.patch.object(
+        services.timezone, 'localdate', return_value=FIXED_TODAY,
+    )
+
+
+class DateRangeHelperTest(TestCase):
+    """_date_range が「前日まで・ちょうど N 日」を返すことを検証。"""
+
+    def test_range_is_exactly_n_days_ending_yesterday(self):
+        for days in (7, 30):
+            with self.subTest(days=days), _patch_today():
+                since, until = services._date_range(days)
+                self.assertEqual(until, FIXED_TODAY - timedelta(days=1))
+                self.assertEqual(since, FIXED_TODAY - timedelta(days=days))
+                # 両端含めて ちょうど days 日
+                self.assertEqual((until - since).days, days - 1)
+
+
+class DailySeriesBoundaryTest(TestCase):
+    """get_daily_series / get_overall_stats / get_campaign_breakdown の境界を検証。"""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            user_name='owner', email='owner@example.com', password='pass',
+        )
+        cls.community = Community.objects.create(
+            name='集会', frequency='毎週', organizers='主催',
+        )
+        CommunityMember.objects.create(
+            community=cls.community, user=cls.user,
+            role=CommunityMember.Role.OWNER,
+        )
+
+    def _make(self, target_date, *, pv=1, campaign='cmp-a'):
+        PageAnalytics.objects.create(
+            page_path=f'/community/{self.community.pk}/',
+            date=target_date,
+            content_type=PageAnalytics.ContentType.COMMUNITY,
+            community=self.community, object_id=self.community.pk,
+            pv=pv, users=pv, sessions=pv,
+            source_medium='google / organic', campaign=campaign,
+        )
+
+    def test_today_record_is_excluded(self):
+        """当日(today) のレコードは集計に含まれない（防御的: 手動同期等で入っても表示がブレない）。"""
+        self._make(FIXED_TODAY, pv=100)  # 当日 → 除外されるべき
+        ids = services.accessible_community_ids(self.user)
+        with _patch_today():
+            series = services.get_daily_series(ids, days=30)
+            stats = services.get_overall_stats(ids, days=30)
+        self.assertEqual(sum(r['pv'] for r in series), 0)
+        self.assertEqual(stats['pv'], 0)
+
+    def test_yesterday_record_is_included(self):
+        """前日(today-1) は集計に含まれる。"""
+        self._make(FIXED_TODAY - timedelta(days=1), pv=42)
+        ids = services.accessible_community_ids(self.user)
+        with _patch_today():
+            series = services.get_daily_series(ids, days=30)
+        self.assertEqual(sum(r['pv'] for r in series), 42)
+
+    def test_lower_boundary_is_exactly_n_days(self):
+        """下端 today-N は含み、today-N-1 は含まない（N日ぴったり）。"""
+        for days in (7, 30):
+            with self.subTest(days=days):
+                PageAnalytics.objects.all().delete()
+                self._make(FIXED_TODAY - timedelta(days=days), pv=7)       # 下端: 含む
+                self._make(FIXED_TODAY - timedelta(days=days + 1), pv=99)  # 範囲外: 含まない
+                ids = services.accessible_community_ids(self.user)
+                with _patch_today():
+                    series = services.get_daily_series(ids, days=days)
+                self.assertEqual(sum(r['pv'] for r in series), 7)
+
+    def test_current_and_prev_periods_are_symmetric(self):
+        """current(today-N〜today-1) と prev(today-2N〜today-N-1) が同じ期間長で集計される。"""
+        days = 30
+        # current 期間の中央付近と prev 期間の中央付近に同じ pv を1件ずつ
+        self._make(FIXED_TODAY - timedelta(days=10), pv=50)   # current 内
+        self._make(FIXED_TODAY - timedelta(days=40), pv=50)   # prev 内（today-40 ∈ [today-60, today-31]）
+        ids = services.accessible_community_ids(self.user)
+        with _patch_today():
+            stats = services.get_overall_stats(ids, days=days)
+        self.assertEqual(stats['pv'], 50)
+        self.assertEqual(stats['pv_prev'], 50)
+        # 期間長が等しいので比較率は 0%
+        self.assertEqual(stats['pv_change_pct'], 0.0)
+
+    def test_prev_boundary_does_not_leak_into_current(self):
+        """prev 上端 today-N-1 は current に入らない（境界の取り違え防止）。"""
+        days = 30
+        self._make(FIXED_TODAY - timedelta(days=days + 1), pv=11)  # = today-31 → prev 側
+        ids = services.accessible_community_ids(self.user)
+        with _patch_today():
+            stats = services.get_overall_stats(ids, days=days)
+        self.assertEqual(stats['pv'], 0)
+        self.assertEqual(stats['pv_prev'], 11)
+
+    def test_campaign_breakdown_excludes_today(self):
+        """get_campaign_breakdown も当日を除外する。"""
+        self._make(FIXED_TODAY, pv=100, campaign='cmp-today')
+        self._make(FIXED_TODAY - timedelta(days=1), pv=5, campaign='cmp-yesterday')
+        ids = services.accessible_community_ids(self.user)
+        with _patch_today():
+            rows = services.get_campaign_breakdown(ids, days=30)
+        keys = {r['campaign'] for r in rows}
+        self.assertIn('cmp-yesterday', keys)
+        self.assertNotIn('cmp-today', keys)
+
+
+class CampaignDailySeriesBoundaryTest(TestCase):
+    """get_campaign_daily_series のラベルが「前日まで・N個」であることを検証。"""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            user_name='owner2', email='owner2@example.com', password='pass',
+        )
+        cls.community = Community.objects.create(
+            name='集会2', frequency='毎週', organizers='主催',
+        )
+        CommunityMember.objects.create(
+            community=cls.community, user=cls.user,
+            role=CommunityMember.Role.OWNER,
+        )
+        Campaign.objects.create(
+            community=cls.community, name='キャンペーン',
+            utm_source='flyer', utm_medium='qr', utm_campaign='cmp-a',
+        )
+
+    def test_labels_count_and_endpoints(self):
+        # 前日に1件入れて dataset が出る状態にする
+        PageAnalytics.objects.create(
+            page_path=f'/community/{self.community.pk}/',
+            date=FIXED_TODAY - timedelta(days=1),
+            content_type=PageAnalytics.ContentType.COMMUNITY,
+            community=self.community, object_id=self.community.pk,
+            pv=5, users=4, sessions=5,
+            source_medium='flyer / qr', campaign='cmp-a',
+        )
+        ids = services.accessible_community_ids(self.user)
+        for days in (7, 30):
+            with self.subTest(days=days), _patch_today():
+                result = services.get_campaign_daily_series(ids, days=days)
+                labels = result['labels']
+                self.assertEqual(len(labels), days)
+                for ds in result['datasets']:
+                    self.assertEqual(len(ds['data']), days)
+                # 先頭=today-N, 末尾=today-1, 当日は含まない
+                self.assertEqual(
+                    labels[0],
+                    (FIXED_TODAY - timedelta(days=days)).strftime('%m/%d'),
+                )
+                self.assertEqual(
+                    labels[-1],
+                    (FIXED_TODAY - timedelta(days=1)).strftime('%m/%d'),
+                )
+                self.assertNotIn(FIXED_TODAY.strftime('%m/%d'), labels)
+
+
+class GlobalTrafficBoundaryTest(TestCase):
+    """get_global_traffic（superuser 用）の当日除外を検証。"""
+
+    def test_today_excluded_yesterday_included(self):
+        PageAnalytics.objects.create(
+            page_path='/', date=FIXED_TODAY,
+            content_type=PageAnalytics.ContentType.GLOBAL,
+            community=None, object_id=0,
+            pv=100, users=80, sessions=90, source_medium='google / organic',
+        )
+        PageAnalytics.objects.create(
+            page_path='/community/list/', date=FIXED_TODAY - timedelta(days=1),
+            content_type=PageAnalytics.ContentType.GLOBAL,
+            community=None, object_id=0,
+            pv=200, users=180, sessions=190, source_medium='(direct) / (none)',
+        )
+        with _patch_today():
+            result = services.get_global_traffic(days=30)
+        self.assertEqual(result['total']['pv'], 200)
+        paths = {r['page_path'] for r in result['top_paths']}
+        self.assertIn('/community/list/', paths)
+        self.assertNotIn('/', paths)
+
+
+class PosterClickBoundaryTest(TestCase):
+    """get_poster_click_stats の当日除外を検証。"""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.community = Community.objects.create(
+            name='集会P', frequency='毎週', organizers='主催',
+        )
+
+    def test_today_excluded_yesterday_included(self):
+        PosterClick.objects.create(
+            community=self.community, date=FIXED_TODAY, clicks=100, users=90,
+        )
+        PosterClick.objects.create(
+            community=self.community, date=FIXED_TODAY - timedelta(days=1),
+            clicks=20, users=15,
+        )
+        with _patch_today():
+            result = services.get_poster_click_stats([self.community.pk], days=30)
+        self.assertEqual(result['total']['clicks'], 20)

--- a/app/community/tests/test_analytics_section.py
+++ b/app/community/tests/test_analytics_section.py
@@ -45,17 +45,18 @@ class CommunityDetailAnalyticsTests(TestCase):
             role=CommunityMember.Role.OWNER,
         )
 
-        today = timezone.localdate()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）。前日にデータを置く
+        yesterday = timezone.localdate() - timedelta(days=1)
         # 集会A のアクセスデータ（識別しやすい source_medium で他人混入を検出）
         PageAnalytics.objects.create(
-            page_path=f'/community/{cls.community_a.pk}/', date=today,
+            page_path=f'/community/{cls.community_a.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=cls.community_a, object_id=cls.community_a.pk,
             pv=100, users=80, sessions=90, source_medium='source-A-only / organic',
         )
         # 集会B のアクセスデータ
         PageAnalytics.objects.create(
-            page_path=f'/community/{cls.community_b.pk}/', date=today,
+            page_path=f'/community/{cls.community_b.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=cls.community_b, object_id=cls.community_b.pk,
             pv=500, users=400, sessions=450, source_medium='source-B-only / referral',

--- a/app/event/tests/test_event_detail_analytics.py
+++ b/app/event/tests/test_event_detail_analytics.py
@@ -3,7 +3,7 @@
 can_manage_event_detail の真偽で集計 context の有無が切り替わること、
 別集会のオーナーには当該 event_detail の集計が出ないことを検証する。
 """
-from datetime import date, time
+from datetime import date, time, timedelta
 
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
@@ -69,9 +69,10 @@ class EventDetailAnalyticsTests(TestCase):
             applicant=cls.applicant,
         )
 
-        today = timezone.localdate()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）。前日にデータを置く
+        yesterday = timezone.localdate() - timedelta(days=1)
         PageAnalytics.objects.create(
-            page_path=f'/event/detail/{cls.event_detail.pk}/', date=today,
+            page_path=f'/event/detail/{cls.event_detail.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.EVENT_DETAIL,
             community=cls.community, object_id=cls.event_detail.pk,
             pv=42, users=30, sessions=35, source_medium='event-source-only / organic',

--- a/app/user_account/tests/test_settings_analytics.py
+++ b/app/user_account/tests/test_settings_analytics.py
@@ -3,6 +3,8 @@
 ログインオーナーには自分の community の集計のみが出て、他人の community の
 名前・数値が一切出ないこと、未ログインは login へリダイレクトされることを検証する。
 """
+from datetime import timedelta
+
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -41,15 +43,16 @@ class SettingsAnalyticsTests(TestCase):
             role=CommunityMember.Role.OWNER,
         )
 
-        today = timezone.localdate()
+        # 集計対象は前日まで（当日は GA4 未同期で集計外）。前日にデータを置く
+        yesterday = timezone.localdate() - timedelta(days=1)
         PageAnalytics.objects.create(
-            page_path=f'/community/{cls.my_community.pk}/', date=today,
+            page_path=f'/community/{cls.my_community.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=cls.my_community, object_id=cls.my_community.pk,
             pv=77, users=60, sessions=70, source_medium='mine-source-only / organic',
         )
         PageAnalytics.objects.create(
-            page_path=f'/community/{cls.other_community.pk}/', date=today,
+            page_path=f'/community/{cls.other_community.pk}/', date=yesterday,
             content_type=PageAnalytics.ContentType.COMMUNITY,
             community=cls.other_community, object_id=cls.other_community.pk,
             pv=999, users=900, sessions=950, source_medium='other-source-only / referral',


### PR DESCRIPTION
## 概要

GA4 ページ別アクセス解析の集計期間 off-by-one（Issue #369）を修正する。

「直近30日」の境界が曖昧で最大31日分が対象になり得る問題に加え、調査で判明した運用事実を反映する:

- **GA4 同期は午前1時に実行され、前日分までしか取得しない**（`views.py` の `_parse_target_date()` がデフォルト `today-1` を返し、`ga4_client.py` が同日のみリクエスト）
- よって `PageAnalytics` に当日(today)レコードはそもそも存在せず、当日を集計に含めるのは分析として誤り

集計対象を **「前日から遡ったN日間」= `today-N` 〜 `today-1` のちょうどN日**（当日除外）に統一した。

## 変更内容

### コア
- **`services.py`**: `_date_range(days)` ヘルパーを新設し `(since, until)=(today-days, today-1)` を単一の真実に。`_base_queryset` / `get_overall_stats` / `get_campaign_daily_series` / `get_global_traffic` / `get_poster_click_stats` を `date__gte=since, date__lte=until` の**両境界**で絞るよう修正。上限なし（`date__gte` のみ）による off-by-one を撲滅
- `get_overall_stats`: current/prev を両方ちょうどN日に揃え、前期比較を対称化（旧: current だけ実質N+1日）
- `get_campaign_daily_series`: ラベルを `range(days)` に修正（旧 `days+1` 個 → N個、当日ラベル除外）
- `get_post_publish_series` は publish_date 起点で正確なため**変更なし**
- **`dashboard_views.py`**: `DEFAULT_DAYS` を `services.DEFAULT_DAYS` 参照に統一（二重管理解消・DRY）
- **`_chart_section.html`**: 「直近30日」→「直近{{ days|default:30 }}日（前日まで）」に動的化。4箇所から include され dashboard 以外3画面は `days` を渡さないため `|default:30` 必須

### テスト
- **新規** `test_services_date_boundary.py`（当日除外・N日ぴったりの正本テスト、境界10ケース）
- 既存テスト6ファイルの「当日にデータを置く」フィクスチャを前日(today-1)基準に修正（当日除外で集計が空になり壊れるため）

## 検証

全テストパス済み:

- `analytics`: **107件** OK（新規境界テスト10件含む）
- `user_account`: **186件** OK
- `community` / `event`: **671件** OK

```
docker compose exec vrc-ta-hub python manage.py test analytics community event user_account
```

## 設計判断・トレードオフ

- **「今日を含むN日」ではなく「前日まで」を採用**: GA4 同期が前日までしか入れないため当日を含めても1日分が常に欠け、集計が日々ブレる。前日基準にすることで表示が安定する
- **`get_overall_stats` の current が1日分減る**: 旧実装の非対称（current=実質31日 / prev=30日）を解消し、前後N日で対称な比較にした
- **当日除外の防御的テスト**: 手動同期や将来の仕様変更で当日データが入っても集計に出ないことをテストで担保

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)