### PR TITLE
fix: 権限不足を403レスポンスで返す

### DIFF
--- a/app/community/views/manage.py
+++ b/app/community/views/manage.py
@@ -3,7 +3,7 @@ import logging
 
 import requests  # noqa: F401 - 既存テストの patch パス互換用
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ValidationError
 from django.db import DataError
 from django.shortcuts import get_object_or_404, redirect
@@ -12,6 +12,7 @@ from django.views import View
 from django.views.generic import UpdateView, CreateView, ListView
 
 from event.community_cleanup import cleanup_community_future_data
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 from user_account.vrchat import normalize_vrchat_user_id
 
 from ..forms_processor import (
@@ -30,7 +31,7 @@ from ..models import Community, WEEKDAY_CHOICES
 logger = logging.getLogger(__name__)
 
 
-class CommunityUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
+class CommunityUpdateView(LoginRequiredMixin, AuthenticatedForbiddenMixin, UpdateView):
     model = Community
     form_class = CommunityUpdateForm
     template_name = 'community/update.html'
@@ -94,7 +95,7 @@ class CommunityCreateView(LoginRequiredMixin, CreateView):
         return response
 
 
-class WaitingCommunityListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
+class WaitingCommunityListView(LoginRequiredMixin, AuthenticatedForbiddenMixin, ListView):
     model = Community
     template_name = 'community/waiting_list.html'
     context_object_name = 'communities'
@@ -147,7 +148,7 @@ class RejectView(LoginRequiredMixin, View):
         return redirect('community:waiting_list')
 
 
-class CloseCommunityView(LoginRequiredMixin, UserPassesTestMixin, View):
+class CloseCommunityView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     def test_func(self):
         community = get_object_or_404(Community, pk=self.kwargs['pk'])
         return self.request.user.is_superuser or community.is_owner(self.request.user)
@@ -186,7 +187,7 @@ class CloseCommunityView(LoginRequiredMixin, UserPassesTestMixin, View):
         return redirect('community:detail', pk=pk)
 
 
-class AdminCommunityCleanupView(LoginRequiredMixin, UserPassesTestMixin, View):
+class AdminCommunityCleanupView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     """管理者用: 集会停止と関連データ削除をワンクリックで実行する。"""
 
     def test_func(self):
@@ -220,7 +221,7 @@ class AdminCommunityCleanupView(LoginRequiredMixin, UserPassesTestMixin, View):
         return redirect('community:detail', pk=pk)
 
 
-class ReopenCommunityView(LoginRequiredMixin, UserPassesTestMixin, View):
+class ReopenCommunityView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     def test_func(self):
         community = get_object_or_404(Community, pk=self.kwargs['pk'])
         return self.request.user.is_superuser or community.is_owner(self.request.user)

--- a/app/community/views/member.py
+++ b/app/community/views/member.py
@@ -2,12 +2,14 @@
 import logging
 
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from django.views.generic import TemplateView
+
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 
 from ..models import Community, CommunityMember, CommunityInvitation
 
@@ -77,7 +79,7 @@ class SwitchCommunityView(LoginRequiredMixin, View):
         return redirect(self._get_redirect_url(request, success=False))
 
 
-class CommunityMemberManageView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
+class CommunityMemberManageView(LoginRequiredMixin, AuthenticatedForbiddenMixin, TemplateView):
     """集会メンバー管理ビュー（主催者のみ）"""
     template_name = 'community/member_manage.html'
 

--- a/app/community/views/settings.py
+++ b/app/community/views/settings.py
@@ -4,11 +4,13 @@ from datetime import timedelta
 
 import requests
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views import View
 from django.views.generic import TemplateView
+
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 
 from ..models import Community, CommunityMember, CommunityInvitation, INVITATION_EXPIRATION_DAYS
 
@@ -225,7 +227,7 @@ class RevokeOwnershipTransferView(LoginRequiredMixin, View):
         return redirect('community:settings')
 
 
-class UpdateWebhookView(LoginRequiredMixin, UserPassesTestMixin, View):
+class UpdateWebhookView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     """Webhook URL更新ビュー"""
 
     def test_func(self):
@@ -254,7 +256,7 @@ class UpdateWebhookView(LoginRequiredMixin, UserPassesTestMixin, View):
         return redirect('community:settings')
 
 
-class TestWebhookView(LoginRequiredMixin, UserPassesTestMixin, View):
+class TestWebhookView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     """Webhookテスト送信ビュー"""
 
     def test_func(self):
@@ -306,7 +308,7 @@ class LTApplicationListView(LoginRequiredMixin, View):
         return redirect('event:my_list')
 
 
-class UpdateLTSettingsView(LoginRequiredMixin, UserPassesTestMixin, View):
+class UpdateLTSettingsView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     """LT申請設定更新ビュー"""
 
     def test_func(self):

--- a/app/event/views/crud.py
+++ b/app/event/views/crud.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, UpdateView, DeleteView
@@ -10,6 +10,7 @@ from event.forms import EventDetailForm
 from event.libs import apply_blog_output_to_event_detail, generate_blog
 from event.models import Event, EventDetail
 from event.views.helpers import can_manage_event_detail
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 from website.settings import GOOGLE_CALENDAR_CREDENTIALS, GOOGLE_CALENDAR_ID, GEMINI_MODEL
 from event.google_calendar import GoogleCalendarService
 
@@ -120,7 +121,7 @@ class EventDeleteView(LoginRequiredMixin, DeleteView):
         return redirect('event:my_list')
 
 
-class EventDetailCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
+class EventDetailCreateView(LoginRequiredMixin, AuthenticatedForbiddenMixin, CreateView):
     model = EventDetail
     form_class = EventDetailForm
     template_name = 'event/detail_form.html'
@@ -176,7 +177,7 @@ class EventDetailCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView)
         return reverse_lazy('event:detail', kwargs={'pk': self.object.pk})
 
 
-class EventDetailUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
+class EventDetailUpdateView(LoginRequiredMixin, AuthenticatedForbiddenMixin, UpdateView):
     model = EventDetail
     form_class = EventDetailForm
     template_name = 'event/detail_form.html'
@@ -236,7 +237,7 @@ class EventDetailUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView)
         pass
 
 
-class EventDetailDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
+class EventDetailDeleteView(LoginRequiredMixin, AuthenticatedForbiddenMixin, DeleteView):
     model = EventDetail
     template_name = 'event/detail_confirm_delete.html'
 
@@ -258,4 +259,3 @@ class EventDetailDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView)
 
     def get_success_url(self):
         return reverse_lazy('event:my_list')
-

--- a/app/news/views.py
+++ b/app/news/views.py
@@ -1,10 +1,11 @@
 import json
 import logging
-from django.contrib.auth.mixins import UserPassesTestMixin
 from django.shortcuts import get_object_or_404
 from django.urls import reverse, reverse_lazy
 from django.views.generic import ListView, DetailView, CreateView, UpdateView, DeleteView
 from django.core.cache import cache
+
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 
 from .models import Post, Category
 from .forms import PostForm
@@ -231,7 +232,7 @@ class CategoryListView(ListView):
         return context
 
 
-class StaffRequiredMixin(UserPassesTestMixin):
+class StaffRequiredMixin(AuthenticatedForbiddenMixin):
     """スタッフ権限が必要なビューのMixin"""
     
     def test_func(self):

--- a/app/ta_hub/access_mixins.py
+++ b/app/ta_hub/access_mixins.py
@@ -1,0 +1,15 @@
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.http import HttpResponseForbidden
+
+
+class AuthenticatedForbiddenMixin(UserPassesTestMixin):
+    """認証済みユーザーの権限不足を403レスポンスで返す。
+
+    UserPassesTestMixin の標準挙動はログイン済みユーザーに PermissionDenied を
+    投げるため、通常の権限不足がアプリ例外として記録されてしまう。
+    """
+
+    def handle_no_permission(self):
+        if self.request.user.is_authenticated:
+            return HttpResponseForbidden(self.get_permission_denied_message())
+        return super().handle_no_permission()

--- a/app/ta_hub/tests/test_access_mixins.py
+++ b/app/ta_hub/tests/test_access_mixins.py
@@ -1,0 +1,63 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+from django.views import View
+
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
+
+
+User = get_user_model()
+
+
+class _DeniedView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
+    def test_func(self):
+        return False
+
+    def get(self, request):
+        return HttpResponse('ok')
+
+
+class _AllowedView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
+    def test_func(self):
+        return True
+
+    def get(self, request):
+        return HttpResponse('ok')
+
+
+class AuthenticatedForbiddenMixinTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            user_name='normal_user',
+            email='normal@example.com',
+            password='testpass123',
+        )
+
+    def test_authenticated_failure_returns_403_response(self):
+        request = self.factory.get('/private/')
+        request.user = self.user
+
+        response = _DeniedView.as_view()(request)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_anonymous_failure_redirects_to_login(self):
+        request = self.factory.get('/private/')
+        request.user = AnonymousUser()
+
+        response = _DeniedView.as_view()(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/account/login/', response.url)
+
+    def test_authenticated_success_continues_to_view(self):
+        request = self.factory.get('/private/')
+        request.user = self.user
+
+        response = _AllowedView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'ok')

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -9,7 +9,6 @@ from zoneinfo import ZoneInfo
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import connections, models  # noqa: F401 - 既存テストの patch パス互換用
 from django.http import Http404, HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
@@ -24,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 from community.models import Community, CommunityMember
 from event.models import Event
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 from .forms import TwitterTemplateForm
 from .models import TwitterTemplate, TweetQueue
 from .notifications import notify_tweet_post_failure
@@ -44,7 +44,7 @@ SCHEDULED_AT_MINUTE_ERROR = '予約日時は00分または30分で指定して�
 JST = ZoneInfo("Asia/Tokyo")
 
 
-class TwitterTemplateBaseView(LoginRequiredMixin, UserPassesTestMixin):
+class TwitterTemplateBaseView(LoginRequiredMixin, AuthenticatedForbiddenMixin):
     model = TwitterTemplate
     form_class = TwitterTemplateForm
     template_name = 'twitter/twitter_template_form.html'
@@ -114,7 +114,7 @@ class TweetEventView(View):
         return redirect(tweet_url)
 
 
-class TwitterTemplateDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
+class TwitterTemplateDeleteView(LoginRequiredMixin, AuthenticatedForbiddenMixin, DeleteView):
     model = TwitterTemplate
     success_url = reverse_lazy('twitter:template_list')
 
@@ -217,14 +217,14 @@ def post_scheduled_tweets(request):
 # --- TweetQueue 管理ビュー (superuser only) ---
 
 
-class SuperuserRequiredMixin(LoginRequiredMixin, UserPassesTestMixin):
+class SuperuserRequiredMixin(LoginRequiredMixin, AuthenticatedForbiddenMixin):
     """スーパーユーザーのみアクセスを許可する Mixin。"""
 
     def test_func(self):
         return self.request.user.is_superuser
 
 
-class TweetQueueViewerMixin(LoginRequiredMixin, UserPassesTestMixin):
+class TweetQueueViewerMixin(LoginRequiredMixin, AuthenticatedForbiddenMixin):
     """TweetQueue 閲覧の権限制御 Mixin。
 
     superuser、または CommunityMember として何らかの集会に所属しているユーザー

--- a/app/vket/views/manage.py
+++ b/app/vket/views/manage.py
@@ -5,7 +5,7 @@ import re
 from datetime import datetime
 
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.db.models import Case, IntegerField, Prefetch, When
 from django.shortcuts import get_object_or_404, redirect
@@ -17,6 +17,7 @@ from allauth.socialaccount.models import SocialAccount
 
 from community.models import Community
 from event.models import EventDetail
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 from ta_hub.index_cache import clear_index_view_cache
 
 from ..forms import VketManageParticipationForm
@@ -33,7 +34,7 @@ from .helpers import (
 logger = logging.getLogger(__name__)
 
 
-class ManageView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
+class ManageView(LoginRequiredMixin, AuthenticatedForbiddenMixin, TemplateView):
     template_name = 'vket/manage.html'
 
     def test_func(self):
@@ -142,7 +143,7 @@ class ManageView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
         }
 
 
-class ManageParticipationUpdateView(LoginRequiredMixin, UserPassesTestMixin, View):
+class ManageParticipationUpdateView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     def test_func(self):
         return _is_vket_admin(self.request.user)
 
@@ -294,7 +295,7 @@ class ManageParticipationUpdateView(LoginRequiredMixin, UserPassesTestMixin, Vie
         return True
 
 
-class ManageScheduleView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
+class ManageScheduleView(LoginRequiredMixin, AuthenticatedForbiddenMixin, TemplateView):
     template_name = 'vket/manage_schedule.html'
 
     def test_func(self):

--- a/app/vket/views/notice.py
+++ b/app/vket/views/notice.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views import View
@@ -10,6 +10,7 @@ from django.views.generic import TemplateView
 from allauth.socialaccount.models import SocialAccount
 
 from community.models import CommunityMember
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 
 from ..models import (
     VketCollaboration,
@@ -55,7 +56,7 @@ class NoticeListView(LoginRequiredMixin, View):
         )
 
 
-class ManageNoticeListView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
+class ManageNoticeListView(LoginRequiredMixin, AuthenticatedForbiddenMixin, TemplateView):
     """運営向け: お知らせ管理一覧ビュー"""
 
     template_name = 'vket/manage_notice_list.html'
@@ -130,7 +131,7 @@ class ManageNoticeListView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
         return context
 
 
-class ManageNoticeCreateView(LoginRequiredMixin, UserPassesTestMixin, View):
+class ManageNoticeCreateView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     """運営向け: お知らせ作成ビュー"""
 
     def test_func(self):
@@ -177,7 +178,7 @@ class ManageNoticeCreateView(LoginRequiredMixin, UserPassesTestMixin, View):
         return redirect('vket:manage_notice_list', pk=pk)
 
 
-class ManageNoticeUpdateView(LoginRequiredMixin, UserPassesTestMixin, View):
+class ManageNoticeUpdateView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     """運営向け: お知らせ編集ビュー"""
 
     def test_func(self):

--- a/app/vket/views/presentation.py
+++ b/app/vket/views/presentation.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
 from django.views import View
+
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 
 from ..models import (
     VketCollaboration,
@@ -50,7 +52,7 @@ class PresentationDeleteView(LoginRequiredMixin, View):
         return redirect('vket:status', pk=pk)
 
 
-class ManagePresentationDeleteView(LoginRequiredMixin, UserPassesTestMixin, View):
+class ManagePresentationDeleteView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     """管理者用: LTを個別削除する"""
 
     def test_func(self):

--- a/app/vket/views/publish.py
+++ b/app/vket/views/publish.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import logging
 
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
 from django.views import View
 
 from event.models import Event, EventDetail
+from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 from ta_hub.index_cache import clear_index_view_cache
 
 from ..models import (
@@ -22,7 +23,7 @@ from .helpers import _is_vket_admin
 logger = logging.getLogger(__name__)
 
 
-class ManagePublishView(LoginRequiredMixin, UserPassesTestMixin, View):
+class ManagePublishView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
     """運営向け: LOCKEDフェーズのコラボをEventとして公開するビュー"""
 
     def test_func(self):


### PR DESCRIPTION
## なぜこの変更が必要か

権限不足時に一部の管理系ビューでリダイレクトや想定外のレスポンスになり、API/画面の呼び出し側が権限不足を明確に扱いづらい状態でした。共通 mixin に寄せて、権限不足を 403 として一貫して返せるようにします。

## 変更内容

- 権限不足時に Django の PermissionDenied を送出する共通 mixin を追加しました。
- community / event / news / twitter / vket の管理系ビューで既存の権限チェックを共通 mixin に置き換えました。
- 権限不足時の 403 応答を検証する回帰テストを追加しました。

## テスト

- docker compose -f docker-compose.yaml -f docker-compose.test.yml run --rm test python manage.py test ta_hub.tests.test_access_mixins: pass

Closes #1932