### PR TITLE
fix: LT告知に登壇者のXアカウントを含める

### DIFF
--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -2306,6 +2306,88 @@ class TweetGeneratorTest(TestCase):
 
     @patch("twitter.signals.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
+    def test_generate_lt_tweet_includes_applicant_x_account(self, mock_llm, _mock_thread):
+        """LT 告知のプロンプトに申請者の X アカウントを含める"""
+        mock_llm.return_value = "LT告知テスト"
+        applicant = CustomUser.objects.create_user(
+            user_name="lt_speaker",
+            email="lt_speaker@example.com",
+            password="testpassword",
+            x_account="speaker_vr",
+        )
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type="LT",
+            status="approved",
+            speaker="テスト太郎",
+            theme="Pythonのテスト技法",
+            start_time=datetime.time(22, 15),
+            applicant=applicant,
+        )
+
+        from twitter.tweet_generator import generate_lt_tweet
+        generate_lt_tweet(detail)
+
+        _, user_prompt = mock_llm.call_args[0]
+        self.assertIn("発表者: テスト太郎さん（@speaker_vr）", user_prompt)
+        self.assertIn("発表者（「テスト太郎さん（@speaker_vr）」をそのまま記載）", user_prompt)
+
+    @patch("twitter.signals.threading.Thread")
+    @patch("twitter.tweet_generator._call_llm")
+    def test_generate_lt_tweet_uses_name_only_without_applicant_x_account(self, mock_llm, _mock_thread):
+        """申請者や X アカウントがない LT 告知は従来どおり名前だけを使う"""
+        mock_llm.return_value = "LT告知テスト"
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type="LT",
+            status="approved",
+            speaker="テスト太郎",
+            theme="Pythonのテスト技法",
+            start_time=datetime.time(22, 15),
+        )
+
+        from twitter.tweet_generator import generate_lt_tweet
+        generate_lt_tweet(detail)
+
+        _, user_prompt = mock_llm.call_args[0]
+        self.assertIn("発表者: テスト太郎さん", user_prompt)
+        self.assertNotIn("@", user_prompt)
+
+    @patch("twitter.signals.threading.Thread")
+    @patch("twitter.tweet_generator._call_llm")
+    def test_lt_generator_fallback_includes_applicant_x_account(self, mock_llm, _mock_thread):
+        """LLM 生成失敗時の LT fallback に申請者の X アカウントを含める"""
+        mock_llm.return_value = "\n".join(["長い本文"] * 20)
+        applicant = CustomUser.objects.create_user(
+            user_name="fallback_speaker",
+            email="fallback_speaker@example.com",
+            password="testpassword",
+            x_account="fallback_vr",
+        )
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type="LT",
+            status="approved",
+            speaker="テスト太郎",
+            theme="Pythonのテスト技法",
+            start_time=datetime.time(22, 15),
+            applicant=applicant,
+        )
+        queue = TweetQueue.objects.create(
+            tweet_type="lt",
+            community=self.community,
+            event=self.event,
+            event_detail=detail,
+            status="generating",
+        )
+
+        from twitter.tweet_generator import get_generator
+        result = get_generator("lt")(queue)
+
+        self.assertIn("テスト太郎さん（@fallback_vr）", result)
+
+    @patch("twitter.signals.threading.Thread")
+    @patch("twitter.tweet_generator._call_llm")
     def test_lt_generator_fallback_fits_long_theme_under_weighted_limit(self, mock_llm, _mock_thread):
         """LLM が長い本文を返し続けても LT 告知を決定的に280以内へ収める"""
         mock_llm.return_value = (
@@ -2406,6 +2488,39 @@ class TweetGeneratorTest(TestCase):
         self.assertIn("今日の見どころ", user_prompt)
         self.assertIn("リマインダーポスト", user_prompt)
         self.assertNotIn("リマインダーツイート", user_prompt)
+
+    @patch("twitter.signals.threading.Thread")
+    @patch("twitter.tweet_generator._call_llm")
+    def test_generate_daily_reminder_tweet_includes_applicant_x_account(self, mock_llm, _mock_thread):
+        """当日リマインドの発表一覧に申請者の X アカウントを含める"""
+        mock_llm.return_value = "今日開催のリマインド"
+        applicant = CustomUser.objects.create_user(
+            user_name="reminder_speaker",
+            email="reminder_speaker@example.com",
+            password="testpassword",
+            x_account="reminder_vr",
+        )
+        today_event = Event.objects.create(
+            community=self.community,
+            date=timezone.localdate(),
+            start_time=datetime.time(20, 0),
+            duration=60,
+        )
+        EventDetail.objects.create(
+            event=today_event,
+            detail_type="LT",
+            status="approved",
+            speaker="リマインド太郎",
+            theme="今日の見どころ",
+            start_time=datetime.time(20, 15),
+            applicant=applicant,
+        )
+
+        from twitter.tweet_generator import generate_daily_reminder_tweet
+        generate_daily_reminder_tweet(today_event)
+
+        _, user_prompt = mock_llm.call_args[0]
+        self.assertIn("- 発表: リマインド太郎さん（@reminder_vr）「今日の見どころ」", user_prompt)
 
     @patch("twitter.signals.threading.Thread")
     def test_generate_daily_reminder_tweet_returns_none_without_approved_details(self, _mock_thread):

--- a/app/twitter/tweet_generator.py
+++ b/app/twitter/tweet_generator.py
@@ -186,9 +186,10 @@ def _fallback_presentation_tweet(event_detail, *, special: bool = False) -> str 
     community = event.community
     weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
     label = " 特別回" if special else ""
+    speaker_display = _format_speaker_display(event_detail)
     body_lines = [
         f"{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~ {_sanitize_for_prompt(community.name)}{label}",
-        f"{_sanitize_for_prompt(event_detail.speaker)}さん「{_sanitize_for_prompt(event_detail.theme)}」",
+        f"{speaker_display}「{_sanitize_for_prompt(event_detail.theme)}」",
     ]
     url = f"詳細はこちら {build_site_url(f'/community/{community.pk}/')}"
     return _fit_candidate(body_lines, url, _build_hashtag_suffix(community), [1, 0])
@@ -233,7 +234,7 @@ def _fallback_daily_reminder_tweet(event) -> str | None:
         body_lines = [f"今夜 {event.start_time.strftime('%H:%M')}〜 {name}"]
         for detail in details[:count]:
             body_lines.append(
-                f"{_sanitize_for_prompt(detail.speaker)}さん"
+                f"{_format_speaker_display(detail)}"
                 f"「{_sanitize_for_prompt(detail.theme)}」"
             )
         fitted = _fit_candidate(
@@ -356,6 +357,17 @@ def _sanitize_for_prompt(text: str, max_length: int = SANITIZE_MAX_LENGTH) -> st
         return ""
     text = " ".join(text.split())
     return text[:max_length]
+
+
+def _format_speaker_display(event_detail) -> str:
+    """登壇者名を告知本文用の敬称付き表記で返す。"""
+    speaker = _sanitize_for_prompt(event_detail.speaker)
+    display_name = f"{speaker}さん"
+    applicant = getattr(event_detail, "applicant", None)
+    x_account = _sanitize_for_prompt(getattr(applicant, "x_account", ""))
+    if x_account:
+        return f"{display_name}（@{x_account}）"
+    return display_name
 
 
 def _call_llm(system_prompt: str, user_prompt: str) -> str | None:
@@ -500,14 +512,14 @@ def generate_lt_tweet(event_detail, target_chars=140, validation_feedback="") ->
     weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
 
     name = _sanitize_for_prompt(community.name)
-    speaker = _sanitize_for_prompt(event_detail.speaker)
+    speaker_display = _format_speaker_display(event_detail)
     theme = _sanitize_for_prompt(event_detail.theme)
 
     user_prompt = f"""以下の発表の告知ポストを作成してください。
 
 集会名: {name}
 日時: {event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~
-発表者: {speaker}
+発表者: {speaker_display}
 テーマ: {theme}
 {validation_feedback}
 
@@ -515,14 +527,14 @@ def generate_lt_tweet(event_detail, target_chars=140, validation_feedback="") ->
 1. 集会名（「{name}」）
 2. 開催日時（「{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~」の形式で）
 3. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
-4. 発表者名（敬称は「さん」を付ける）
+4. 発表者（「{speaker_display}」をそのまま記載）
 5. テーマの補足説明と次のアクション（聞きに来る・詳細を見る等）への誘導を**1行にまとめる**（本文3行制約のため別行にしない）
 
 ## 出力フォーマット（本文は3行以内）
 
 {{日時}} {{集会名}}
 
-{{発表者}}さん「{{テーマ}}」
+{{発表者}}「{{テーマ}}」
 {{テーマ補足 + 参加誘導を1行に統合}}
 
 詳細はこちら {{URL}}
@@ -634,9 +646,9 @@ def generate_daily_reminder_tweet(event, target_chars=140, validation_feedback="
     presentations = []
     for detail in approved_details[:3]:
         label = "発表" if detail.detail_type == "LT" else "特別回"
-        speaker = _sanitize_for_prompt(detail.speaker)
+        speaker_display = _format_speaker_display(detail)
         theme = _sanitize_for_prompt(detail.theme)
-        presentations.append(f"- {label}: {speaker}さん「{theme}」")
+        presentations.append(f"- {label}: {speaker_display}「{theme}」")
 
     more_count = len(approved_details) - len(presentations)
     extra_line = f"\n- ほか {more_count} 件" if more_count > 0 else ""
@@ -662,7 +674,7 @@ def generate_daily_reminder_tweet(event, target_chars=140, validation_feedback="
 ### 発表が1件の場合
 今夜 {{時刻}}〜 {{集会名}}
 
-{{登壇者1}}さん「{{テーマ1}}」
+{{登壇者表記1}}「{{テーマ1}}」
 {{テーマ1の補足 + 参加誘導を1行に統合}}
 
 詳細はこちら {{URL}}
@@ -671,16 +683,16 @@ def generate_daily_reminder_tweet(event, target_chars=140, validation_feedback="
 ### 発表が2件の場合
 今夜 {{時刻}}〜 {{集会名}}
 
-{{登壇者1}}さん「{{テーマ1}}」
-{{登壇者2}}さん「{{テーマ2}}」
+{{登壇者表記1}}「{{テーマ1}}」
+{{登壇者表記2}}「{{テーマ2}}」
 
 詳細はこちら {{URL}}
 {{ハッシュタグ}}
 
 ### 発表が3件以上の場合（4件以上なら上位3件＋「ほかN件」）
 今夜 {{時刻}}〜 {{集会名}}
-{{登壇者1}}さん「{{テーマ1}}」
-{{登壇者2}}さん「{{テーマ2}}」／{{登壇者3}}さん「{{テーマ3}}」
+{{登壇者表記1}}「{{テーマ1}}」
+{{登壇者表記2}}「{{テーマ2}}」／{{登壇者表記3}}「{{テーマ3}}」
 
 詳細はこちら {{URL}}
 {{ハッシュタグ}}
@@ -689,9 +701,9 @@ def generate_daily_reminder_tweet(event, target_chars=140, validation_feedback="
 - {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
 {BODY_LINE_CONSTRAINT}
 - 1行目は「今夜 {event.start_time.strftime('%H:%M')}〜 {name}」の形式で、今日の開催であることと時刻が一目で伝わるようにする（日付表記は禁止）
-- 各発表は「○○さん「テーマ名」」の形式で記載する
+- 各発表は発表一覧の登壇者表記をそのまま使い、「○○さん「テーマ名」」または「○○さん（@handle）「テーマ名」」の形式で記載する
   - テーマ名は発表一覧のものをそのまま使う（言い換え・要約・省略禁止）
-  - 登壇者名には「さん」を付ける
+  - Xアカウントがある登壇者は「（@handle）」も含める
 - **発表数の言及禁止**: 「発表は1件」「全○件」「○本立て」「N件の発表」など、発表の本数を伝える表現は本文に一切書かない（通常1件なので情報価値がない）
 - 発表が1件の場合は、発表行の直後に「テーマの補足 + 参加誘導」を**1行に統合**して入れる
   - 補足と誘導は別行に分けず、1文にまとめる（本文3行制約のため必須）

--- a/docs/research/issue-407-lt-tweet-speaker-x-account.md
+++ b/docs/research/issue-407-lt-tweet-speaker-x-account.md
@@ -1,0 +1,40 @@
+# Issue 407: LT 告知ポストの登壇者 X アカウント表示
+
+## 調査対象
+
+- `app/twitter/tweet_generator.py`
+  - `generate_lt_tweet()` は LT 告知ポストの LLM prompt を組み立てる。
+  - `_fallback_presentation_tweet()` は LLM 出力が X 投稿制約を満たせない場合の決定的 fallback を作る。
+  - `generate_daily_reminder_tweet()` は当日リマインダーの発表一覧を prompt に渡す。
+- `app/event/models.py`
+  - `EventDetail.applicant` は LT 申請者の `CustomUser` を参照する。
+- `app/user_account/models.py`
+  - `CustomUser.x_account` は `@` なしの X ハンドルを保持する。
+- `app/event/views/lt_application.py`
+  - LT 申込時に `speaker` と `x_account` は申請者ユーザーへ同期保存される。
+
+## 原因候補と観測結果
+
+- 既存の LT 告知 prompt は `EventDetail.speaker` のみを発表者として渡しており、`EventDetail.applicant.x_account` を参照していなかった。
+- 当日リマインダーの発表一覧も `detail.speaker` のみで構成されていた。
+- fallback 生成も `event_detail.speaker` のみを本文に入れていたため、LLM が失敗した場合も X アカウントは出力されなかった。
+- `x_account` はモデルバリデーション上 `@` なしで保存されるため、投稿本文・prompt では表示時だけ `@` を付けるのが既存データ構造に合う。
+
+## 採用した改善案
+
+- `EventDetail` から告知本文用の登壇者表記を作る helper を `tweet_generator.py` に追加した。
+- helper は `speaker` に敬称を付け、`applicant.x_account` がある場合だけ `（@handle）` を後置する。
+- LT 告知 prompt、当日リマインダーの発表一覧、LT/SPECIAL 共通 fallback で同じ helper を使い、表記ゆれを避ける。
+
+## 却下した代替案
+
+- `EventDetail` に X アカウント専用フィールドを追加する案は、既存の `EventDetail.applicant -> CustomUser.x_account` で要件を満たせるため採用しない。
+- LLM 出力後に文字列置換で `@handle` を追記する案は、本文行数と weighted length の制約を壊しやすいため採用しない。
+
+## 検証手順
+
+- `generate_lt_tweet()` の prompt に、X アカウントありの申請者で `テスト太郎さん（@speaker_vr）` が含まれることをテストする。
+- applicant なしの場合は `テスト太郎さん` のみになり、X アカウント表記が混入しないことをテストする。
+- 当日リマインダーの発表一覧に X アカウントが含まれることをテストする。
+- LLM が X 投稿制約違反の本文を返し続けた場合の fallback にも X アカウントが含まれることをテストする。
+- 既存の weighted length 制限テストを含む `twitter.tests.test_auto_tweet` を実行する。


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: [#407](https://github.com/noricha-vr/vrc-ta-hub/issues/407)「LT告知ポストに登壇者のXアカウントを含める」
- 必要性: この Issue で報告された問題・要望により、VRC技術学術Hub が期待動作や要件を満たせないため、修正・対応が必要です。
- 対応意図: 既存の `EventDetail.applicant -> CustomUser.x_account` を使い、DB に保存済みの `@` なしハンドルへ表示時だけ `@` を付ける方針にしました。 LT 告知、当日リマインダー、fallback が別々に登壇者表記を組み立てると表記ゆれが出るため、helper に集約しました。

## 変更内容

- `app/twitter/tweet_generator.py` に登壇者表示 helper を追加し、`speakerさん（@handle）` を表示時だけ生成するようにしました。
- `generate_lt_tweet()` の prompt に X アカウント付き登壇者表記を渡すよう変更しました。
- 当日リマインダーと fallback 生成でも同じ helper を使い、LLM 失敗時も X アカウントが残るようにしました。
- `app/twitter/tests/test_auto_tweet.py` に prompt / applicant なし / daily reminder / fallback のテストを追加しました。
- `docs/research/issue-407-lt-tweet-speaker-x-account.md` に調査結果、判断根拠、検証手順を記録しました。
- コミット: `5c825b7 fix: LT告知に登壇者のXアカウントを含める`

## 意思決定

### 採用アプローチ
既存の `EventDetail.applicant -> CustomUser.x_account` を使い、DB に保存済みの `@` なしハンドルへ表示時だけ `@` を付ける方針にしました。  
LT 告知、当日リマインダー、fallback が別々に登壇者表記を組み立てると表記ゆれが出るため、helper に集約しました。

### トレードオフ または 却下した代替案
`EventDetail` に X アカウント専用フィールドを追加する案は、既存の申請者ユーザー情報で要件を満たせるため却下しました。  
LLM 出力後に文字列追記する案は、X の weighted length と本文行数制約を壊しやすいため採用しませんでした。

### 残課題やリスク
なし


## テスト

`docker compose -f docker-compose.yaml -f docker-compose.test.yml run --rm test python manage.py test twitter.tests.test_auto_tweet`  
結果: 149 tests OK。初回は worktree に `.env.local` がなく Compose 起動前に失敗したため、既存ローカル `.env.local` への一時 symlink を作って再実行し、テスト後に削除しました。

---
🤖 Generated with [Codex](https://Codex.com/Codex)
