### PR TITLE
refactor(event): content_sanitizer/media_service を分離 (#329 PR1)

### DIFF
--- a/app/event/forms.py
+++ b/app/event/forms.py
@@ -342,7 +342,7 @@ class EventDetailForm(forms.ModelForm):
     def save(self, commit=True):
         instance = super().save(commit=commit)
         if commit:
-            from event.libs import ensure_pdf_thumbnail
+            from event.services.media_service import ensure_pdf_thumbnail
             from twitter.signals import sync_slide_share_queue_image
 
             ensure_pdf_thumbnail(instance, save=True)
@@ -407,7 +407,7 @@ class LTApplicationEditForm(forms.ModelForm):
     def save(self, commit=True):
         instance = super().save(commit=commit)
         if commit:
-            from event.libs import ensure_pdf_thumbnail
+            from event.services.media_service import ensure_pdf_thumbnail
             from twitter.signals import sync_slide_share_queue_image
 
             ensure_pdf_thumbnail(instance, save=True)

--- a/app/event/libs.py
+++ b/app/event/libs.py
@@ -3,7 +3,6 @@ import logging
 import os
 import re
 import tempfile
-from io import BytesIO
 from datetime import datetime
 from typing import Optional
 from urllib.parse import urlparse
@@ -12,18 +11,21 @@ import bleach
 from bleach.css_sanitizer import CSSSanitizer
 import markdown
 from bs4 import BeautifulSoup
-from django.core.files.base import ContentFile
 from googleapiclient.discovery import build
 from openai import OpenAI
 from pydantic import BaseModel, Field
-import pypdfium2 as pdfium
 from pypdf import PdfReader
 from youtube_transcript_api import YouTubeTranscriptApi
 from youtube_transcript_api._errors import NoTranscriptFound
 
 from event.models import EventDetail
 from event.prompts import BLOG_GENERATION_TEMPLATE
-from event.thumbnail import crop_to_slide_thumbnail_aspect_ratio
+from event.services.content_sanitizer import (
+    ALLOWED_IFRAME_DOMAINS,
+    _escape_unknown_html_tags,
+    _filter_iframe_attributes,
+)
+from event.services.media_service import ensure_pdf_thumbnail
 from website.constants import (
     OPENROUTER_BASE_URL,
     build_openrouter_extra_headers,
@@ -33,56 +35,6 @@ from website.settings import GOOGLE_API_KEY
 
 logger = logging.getLogger(__name__)
 
-# iframeのsrc属性で許可するドメインのホワイトリスト
-ALLOWED_IFRAME_DOMAINS = frozenset([
-    # 動画
-    'www.youtube.com',
-    'www.youtube-nocookie.com',
-    'player.vimeo.com',
-    # スライド共有
-    'docs.google.com',
-    'www.slideshare.net',
-    'speakerdeck.com',
-    'www.canva.com',
-    'prezi.com',
-    'pitch.com',
-    'www.figma.com',
-    'onedrive.live.com',
-    'view.officeapps.live.com',
-])
-
-
-def _filter_iframe_attributes(tag: str, name: str, value: str) -> bool:
-    """iframeの属性をフィルタリングする
-
-    src属性は信頼できるドメインのみ許可し、
-    それ以外の属性は許可リストで判定する。
-
-    Args:
-        tag: タグ名（常に'iframe'）
-        name: 属性名
-        value: 属性値
-
-    Returns:
-        属性を許可する場合はTrue、除去する場合はFalse
-    """
-    if name == 'src':
-        try:
-            parsed = urlparse(value)
-            # スキームがhttpまたはhttpsのみ許可（data:, javascript:等は除外）
-            if parsed.scheme not in ('http', 'https'):
-                return False
-            # 自ドメイン配下（サブドメイン含む）はiframeでの埋め込みを禁止（アップロード偽装等の踏み台になり得る）
-            if is_site_domain(parsed.hostname):
-                return False
-            return parsed.netloc in ALLOWED_IFRAME_DOMAINS
-        except (TypeError, ValueError):
-            logger.exception("iframe srcのURL解析に失敗しました: src=%r", value)
-            return False
-    # src以外の属性は許可リストで判定
-    return name in ('frameborder', 'allowfullscreen', 'width', 'height',
-                    'referrerpolicy', 'allow')
-
 
 class BlogOutput(BaseModel):
     """ブログ記事の出力形式を定義するPydanticモデル"""
@@ -90,60 +42,6 @@ class BlogOutput(BaseModel):
     meta_description: str = Field(
         description="ブログ記事のメタディスクリプション。120文字以内でコンテンツの要約を記述。")
     text: str = Field(description="ブログ記事の本文。マークダウン形式で記述された1000〜1800文字の記事。")
-
-
-def ensure_pdf_thumbnail(event_detail: EventDetail, *, save: bool = False, overwrite: bool = False) -> bool:
-    """PDFの先頭ページから未設定のサムネイル画像を作成する.
-
-    Args:
-        event_detail: サムネイルを設定するイベント詳細
-        save: Trueの場合はthumbnail_imageだけを保存する
-        overwrite: Trueの場合は既存のthumbnail_imageがあっても再生成する
-
-    Returns:
-        サムネイルを新規作成した場合はTrue
-    """
-    if (event_detail.thumbnail_image and not overwrite) or not event_detail.slide_file:
-        return False
-
-    temp_file_path = None
-    try:
-        with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as temp_file:
-            event_detail.slide_file.open('rb')
-            for chunk in event_detail.slide_file.chunks():
-                temp_file.write(chunk)
-            temp_file_path = temp_file.name
-
-        pdf = pdfium.PdfDocument(temp_file_path)
-        try:
-            page = pdf[0]
-            try:
-                bitmap = page.render(scale=2.0)
-                try:
-                    image = crop_to_slide_thumbnail_aspect_ratio(bitmap.to_pil().convert('RGB'))
-                finally:
-                    if hasattr(bitmap, 'close'):
-                        bitmap.close()
-            finally:
-                if hasattr(page, 'close'):
-                    page.close()
-        finally:
-            if hasattr(pdf, 'close'):
-                pdf.close()
-
-        image_buffer = BytesIO()
-        image.save(image_buffer, format='JPEG', quality=85, optimize=True)
-        filename = f"event_detail_{event_detail.pk or 'new'}_thumbnail.jpg"
-        event_detail.thumbnail_image.save(filename, ContentFile(image_buffer.getvalue()), save=False)
-        if save:
-            event_detail.save(update_fields=['thumbnail_image'])
-        return True
-    except Exception:
-        logger.exception("PDFサムネイルの生成に失敗しました: EventDetail ID=%s", event_detail.pk)
-        return False
-    finally:
-        if temp_file_path and os.path.exists(temp_file_path):
-            os.unlink(temp_file_path)
 
 
 def apply_blog_output_to_event_detail(event_detail: EventDetail, blog_output: BlogOutput) -> bool:
@@ -505,76 +403,6 @@ def get_transcript(video_id, language='ja') -> Optional[str]:
     except Exception as e:
         logger.error(f"Youtubeから文字起こしを取得するときにエラーが発生しました: {str(e)}")
         return None
-
-
-def _escape_unknown_html_tags(text: str) -> str:
-    """Markdown変換前に、許可されていないHTMLタグ形式の文字列をエスケープする
-
-    P-AMI<Q>のような技術用語内の<>がHTMLタグとして解釈されるのを防ぐ。
-    コードブロックやインラインコード内のタグは保護される。
-
-    Args:
-        text: 入力テキスト（Markdown形式）
-
-    Returns:
-        エスケープ処理されたテキスト
-    """
-    # 許可されたHTMLタグのリスト（convert_markdownのallowed_tagsと同期）
-    allowed_tags = {
-        'a', 'p', 'h1', 'h2', 'h3', 'h4', 'ul', 'ol', 'li', 'strong', 'em',
-        'code', 'pre', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'hr',
-        'br', 'blockquote', 'div', 'iframe', 'span', 'img', 'button', 'i'
-    }
-
-    # コードブロックを一時的に保護（```...```）
-    code_blocks = []
-
-    def protect_code_block(match):
-        code_blocks.append(match.group(0))
-        return f'\x00CODE_BLOCK_{len(code_blocks) - 1}\x00'
-
-    text = re.sub(r'```[\s\S]*?```', protect_code_block, text)
-
-    # インラインコードを一時的に保護（`...`）
-    inline_codes = []
-
-    def protect_inline_code(match):
-        inline_codes.append(match.group(0))
-        return f'\x00INLINE_CODE_{len(inline_codes) - 1}\x00'
-
-    text = re.sub(r'`[^`]+`', protect_inline_code, text)
-
-    # HTMLタグパターンをエスケープ（許可タグ以外）
-    def escape_tag(match):
-        full_match = match.group(0)
-        tag_name = match.group(1).lower()
-
-        if tag_name in allowed_tags:
-            return full_match
-        return full_match.replace('<', '&lt;').replace('>', '&gt;')
-
-    # 開始タグ・自己閉じタグ: <tagname...>
-    text = re.sub(r'<([a-zA-Z][a-zA-Z0-9]*)[^>]*/?>', escape_tag, text)
-
-    # 閉じタグ: </tagname>
-    def escape_closing_tag(match):
-        full_match = match.group(0)
-        tag_name = match.group(1).lower()
-
-        if tag_name in allowed_tags:
-            return full_match
-        return full_match.replace('<', '&lt;').replace('>', '&gt;')
-
-    text = re.sub(r'</([a-zA-Z][a-zA-Z0-9]*)>', escape_closing_tag, text)
-
-    # 保護したコードを復元
-    for i, block in enumerate(code_blocks):
-        text = text.replace(f'\x00CODE_BLOCK_{i}\x00', block)
-
-    for i, code in enumerate(inline_codes):
-        text = text.replace(f'\x00INLINE_CODE_{i}\x00', code)
-
-    return text
 
 
 def convert_markdown(markdown_text: str, auto_format: bool = False) -> str:

--- a/app/event/management/commands/backfill_event_detail_pdf_thumbnails.py
+++ b/app/event/management/commands/backfill_event_detail_pdf_thumbnails.py
@@ -3,7 +3,7 @@ import logging
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Q
 
-from event.libs import ensure_pdf_thumbnail
+from event.services.media_service import ensure_pdf_thumbnail
 from event.models import EventDetail
 from twitter.signals import sync_slide_share_queue_image
 

--- a/app/event/services/content_sanitizer.py
+++ b/app/event/services/content_sanitizer.py
@@ -1,0 +1,130 @@
+"""HTMLサニタイズ・iframeホワイトリスト・タグエスケープを提供するモジュール."""
+from __future__ import annotations
+
+import logging
+import re
+from urllib.parse import urlparse
+
+from website.constants import is_site_domain
+
+logger = logging.getLogger(__name__)
+
+# iframeのsrc属性で許可するドメインのホワイトリスト
+ALLOWED_IFRAME_DOMAINS = frozenset([
+    # 動画
+    'www.youtube.com',
+    'www.youtube-nocookie.com',
+    'player.vimeo.com',
+    # スライド共有
+    'docs.google.com',
+    'www.slideshare.net',
+    'speakerdeck.com',
+    'www.canva.com',
+    'prezi.com',
+    'pitch.com',
+    'www.figma.com',
+    'onedrive.live.com',
+    'view.officeapps.live.com',
+])
+
+
+def _filter_iframe_attributes(tag: str, name: str, value: str) -> bool:
+    """iframeの属性をフィルタリングする
+
+    src属性は信頼できるドメインのみ許可し、
+    それ以外の属性は許可リストで判定する。
+
+    Args:
+        tag: タグ名（常に'iframe'）
+        name: 属性名
+        value: 属性値
+
+    Returns:
+        属性を許可する場合はTrue、除去する場合はFalse
+    """
+    if name == 'src':
+        try:
+            parsed = urlparse(value)
+            # スキームがhttpまたはhttpsのみ許可（data:, javascript:等は除外）
+            if parsed.scheme not in ('http', 'https'):
+                return False
+            # 自ドメイン配下（サブドメイン含む）はiframeでの埋め込みを禁止（アップロード偽装等の踏み台になり得る）
+            if is_site_domain(parsed.hostname):
+                return False
+            return parsed.netloc in ALLOWED_IFRAME_DOMAINS
+        except (TypeError, ValueError):
+            logger.exception("iframe srcのURL解析に失敗しました: src=%r", value)
+            return False
+    # src以外の属性は許可リストで判定
+    return name in ('frameborder', 'allowfullscreen', 'width', 'height',
+                    'referrerpolicy', 'allow')
+
+
+def _escape_unknown_html_tags(text: str) -> str:
+    """Markdown変換前に、許可されていないHTMLタグ形式の文字列をエスケープする
+
+    P-AMI<Q>のような技術用語内の<>がHTMLタグとして解釈されるのを防ぐ。
+    コードブロックやインラインコード内のタグは保護される。
+
+    Args:
+        text: 入力テキスト（Markdown形式）
+
+    Returns:
+        エスケープ処理されたテキスト
+    """
+    # 許可されたHTMLタグのリスト（convert_markdownのallowed_tagsと同期）
+    allowed_tags = {
+        'a', 'p', 'h1', 'h2', 'h3', 'h4', 'ul', 'ol', 'li', 'strong', 'em',
+        'code', 'pre', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'hr',
+        'br', 'blockquote', 'div', 'iframe', 'span', 'img', 'button', 'i'
+    }
+
+    # コードブロックを一時的に保護（```...```）
+    code_blocks = []
+
+    def protect_code_block(match):
+        code_blocks.append(match.group(0))
+        return f'\x00CODE_BLOCK_{len(code_blocks) - 1}\x00'
+
+    text = re.sub(r'```[\s\S]*?```', protect_code_block, text)
+
+    # インラインコードを一時的に保護（`...`）
+    inline_codes = []
+
+    def protect_inline_code(match):
+        inline_codes.append(match.group(0))
+        return f'\x00INLINE_CODE_{len(inline_codes) - 1}\x00'
+
+    text = re.sub(r'`[^`]+`', protect_inline_code, text)
+
+    # HTMLタグパターンをエスケープ（許可タグ以外）
+    def escape_tag(match):
+        full_match = match.group(0)
+        tag_name = match.group(1).lower()
+
+        if tag_name in allowed_tags:
+            return full_match
+        return full_match.replace('<', '&lt;').replace('>', '&gt;')
+
+    # 開始タグ・自己閉じタグ: <tagname...>
+    text = re.sub(r'<([a-zA-Z][a-zA-Z0-9]*)[^>]*/?>', escape_tag, text)
+
+    # 閉じタグ: </tagname>
+    def escape_closing_tag(match):
+        full_match = match.group(0)
+        tag_name = match.group(1).lower()
+
+        if tag_name in allowed_tags:
+            return full_match
+        return full_match.replace('<', '&lt;').replace('>', '&gt;')
+
+    text = re.sub(r'</([a-zA-Z][a-zA-Z0-9]*)>', escape_closing_tag, text)
+
+    # 保護したコードを復元
+    for i, block in enumerate(code_blocks):
+        text = text.replace(f'\x00CODE_BLOCK_{i}\x00', block)
+
+    for i, code in enumerate(inline_codes):
+        text = text.replace(f'\x00INLINE_CODE_{i}\x00', code)
+
+    return text

--- a/app/event/services/media_service.py
+++ b/app/event/services/media_service.py
@@ -1,4 +1,4 @@
-"""PDF処理 / サムネイル生成 / アップロード検証を提供するモジュール."""
+"""PDFサムネイル生成を提供するモジュール."""
 from __future__ import annotations
 
 import logging

--- a/app/event/services/media_service.py
+++ b/app/event/services/media_service.py
@@ -1,0 +1,69 @@
+"""PDF処理 / サムネイル生成 / アップロード検証を提供するモジュール."""
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from io import BytesIO
+
+import pypdfium2 as pdfium
+from django.core.files.base import ContentFile
+
+from event.models import EventDetail
+from event.thumbnail import crop_to_slide_thumbnail_aspect_ratio
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_pdf_thumbnail(event_detail: EventDetail, *, save: bool = False, overwrite: bool = False) -> bool:
+    """PDFの先頭ページから未設定のサムネイル画像を作成する.
+
+    Args:
+        event_detail: サムネイルを設定するイベント詳細
+        save: Trueの場合はthumbnail_imageだけを保存する
+        overwrite: Trueの場合は既存のthumbnail_imageがあっても再生成する
+
+    Returns:
+        サムネイルを新規作成した場合はTrue
+    """
+    if (event_detail.thumbnail_image and not overwrite) or not event_detail.slide_file:
+        return False
+
+    temp_file_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as temp_file:
+            event_detail.slide_file.open('rb')
+            for chunk in event_detail.slide_file.chunks():
+                temp_file.write(chunk)
+            temp_file_path = temp_file.name
+
+        pdf = pdfium.PdfDocument(temp_file_path)
+        try:
+            page = pdf[0]
+            try:
+                bitmap = page.render(scale=2.0)
+                try:
+                    image = crop_to_slide_thumbnail_aspect_ratio(bitmap.to_pil().convert('RGB'))
+                finally:
+                    if hasattr(bitmap, 'close'):
+                        bitmap.close()
+            finally:
+                if hasattr(page, 'close'):
+                    page.close()
+        finally:
+            if hasattr(pdf, 'close'):
+                pdf.close()
+
+        image_buffer = BytesIO()
+        image.save(image_buffer, format='JPEG', quality=85, optimize=True)
+        filename = f"event_detail_{event_detail.pk or 'new'}_thumbnail.jpg"
+        event_detail.thumbnail_image.save(filename, ContentFile(image_buffer.getvalue()), save=False)
+        if save:
+            event_detail.save(update_fields=['thumbnail_image'])
+        return True
+    except Exception:
+        logger.exception("PDFサムネイルの生成に失敗しました: EventDetail ID=%s", event_detail.pk)
+        return False
+    finally:
+        if temp_file_path and os.path.exists(temp_file_path):
+            os.unlink(temp_file_path)

--- a/app/event/tests/test_convert_markdown.py
+++ b/app/event/tests/test_convert_markdown.py
@@ -1,7 +1,8 @@
 """convert_markdown関数と_escape_unknown_html_tags関数のテスト"""
 from django.test import TestCase
 
-from event.libs import _escape_unknown_html_tags, _filter_iframe_attributes, convert_markdown
+from event.libs import convert_markdown
+from event.services.content_sanitizer import _escape_unknown_html_tags, _filter_iframe_attributes
 
 
 class TestEscapeUnknownHtmlTags(TestCase):
@@ -274,7 +275,7 @@ class TestIframeSrcRestriction(TestCase):
 
     def test_filter_iframe_attributes_logs_invalid_src(self):
         """不正なiframe srcはログ出力して拒否される"""
-        with self.assertLogs("event.libs", level="ERROR") as log_ctx:
+        with self.assertLogs("event.services.content_sanitizer", level="ERROR") as log_ctx:
             allowed = _filter_iframe_attributes('iframe', 'src', 'https://[invalid')
         self.assertFalse(allowed)
         self.assertIn('iframe srcのURL解析に失敗しました', log_ctx.output[0])

--- a/app/event/tests/test_event_detail_form.py
+++ b/app/event/tests/test_event_detail_form.py
@@ -130,7 +130,7 @@ class EventDetailFormCleanTest(TweetGenerationPatchMixin, TestCase):
         self.assertIn('まずここにスライドPDFをアップロード', form.fields['slide_file'].help_text)
         self.assertIn('URL入力のみでは記事は生成されません', form.fields['slide_url'].help_text)
 
-    @patch('event.libs.ensure_pdf_thumbnail')
+    @patch('event.services.media_service.ensure_pdf_thumbnail')
     def test_event_detail_form_save_generates_pdf_thumbnail(self, mock_ensure_pdf_thumbnail):
         """EventDetailForm保存時にPDFサムネイル補完を実行する."""
         request = self._create_request()
@@ -155,7 +155,7 @@ class EventDetailFormCleanTest(TweetGenerationPatchMixin, TestCase):
         mock_ensure_pdf_thumbnail.assert_called_once_with(saved, save=True)
 
     @override_settings(AWS_S3_CUSTOM_DOMAIN='data.vrc-ta-hub.com')
-    @patch('event.libs.ensure_pdf_thumbnail')
+    @patch('event.services.media_service.ensure_pdf_thumbnail')
     def test_event_detail_form_save_syncs_slide_share_thumbnail_image(self, mock_ensure_pdf_thumbnail):
         """フォーム保存後に生成されたPDFサムネイルを未投稿slide_shareキューへ反映する."""
         request = self._create_request()
@@ -216,7 +216,7 @@ class EventDetailFormCleanTest(TweetGenerationPatchMixin, TestCase):
         self.assertIn('thumbnail/generated.jpg', queue.image_url)
         mock_ensure_pdf_thumbnail.assert_called_once()
 
-    @patch('event.libs.ensure_pdf_thumbnail')
+    @patch('event.services.media_service.ensure_pdf_thumbnail')
     def test_lt_application_edit_form_save_generates_pdf_thumbnail(self, mock_ensure_pdf_thumbnail):
         """LT申請者編集フォーム保存時にもPDFサムネイル補完を実行する."""
         form_data = {

--- a/app/event/tests/test_generate_blog.py
+++ b/app/event/tests/test_generate_blog.py
@@ -14,7 +14,8 @@ from PIL import Image
 
 from user_account.models import CustomUser
 from community.models import Community
-from event.libs import apply_blog_output_to_event_detail, ensure_pdf_thumbnail, generate_blog, get_transcript, BlogOutput
+from event.libs import apply_blog_output_to_event_detail, generate_blog, get_transcript, BlogOutput
+from event.services.media_service import ensure_pdf_thumbnail
 from event.models import Event, EventDetail
 
 logger = logging.getLogger(__name__)
@@ -282,7 +283,7 @@ class TestGenerateBlog(TestCase):
         self.assertTrue(valid_output.meta_description)
         self.assertTrue(valid_output.text)
 
-    @patch("event.libs.pdfium.PdfDocument")
+    @patch("event.services.media_service.pdfium.PdfDocument")
     def test_ensure_pdf_thumbnail_creates_image_from_pdf(self, mock_pdf_document):
         """PDFの先頭ページから16:9のサムネイル画像を作成する."""
         event_detail = self.create_event_detail(slide_file=True)
@@ -299,7 +300,7 @@ class TestGenerateBlog(TestCase):
             self.assertEqual(thumbnail.size, (120, 67))
         mock_pdf_document.assert_called_once()
 
-    @patch("event.libs.pdfium.PdfDocument")
+    @patch("event.services.media_service.pdfium.PdfDocument")
     def test_ensure_pdf_thumbnail_skips_when_already_set(self, mock_pdf_document):
         """既存サムネイルがある場合はPDFレンダリングしない."""
         event_detail = self.create_event_detail(slide_file=True)
@@ -316,7 +317,7 @@ class TestGenerateBlog(TestCase):
         self.assertFalse(result)
         mock_pdf_document.assert_not_called()
 
-    @patch("event.libs.pdfium.PdfDocument")
+    @patch("event.services.media_service.pdfium.PdfDocument")
     def test_ensure_pdf_thumbnail_overwrites_existing_thumbnail(self, mock_pdf_document):
         """overwrite=Trueの場合は既存サムネイルがあってもPDFから再生成する."""
         event_detail = self.create_event_detail(slide_file=True)

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -3147,7 +3147,7 @@ class SlideShareSignalTest(AutoTweetTestBase):
 
         self.assertEqual(TweetQueue.objects.count(), 0)
 
-    @patch("event.libs.ensure_pdf_thumbnail", return_value=False)
+    @patch("event.services.media_service.ensure_pdf_thumbnail", return_value=False)
     @patch("twitter.signals.threading.Thread")
     def test_slide_file_first_set_creates_queue(self, mock_thread_cls, _mock_ensure_pdf_thumbnail):
         """slide_file が初めて設定され、発表日が過去ならキューが作成される"""


### PR DESCRIPTION
## 概要

#329 の3PR分割の1本目。`app/event/libs.py` (795行) から以下を `event/services/` に切り出す。

| 移動先 | 内容 |
|--------|------|
| `services/content_sanitizer.py` | `ALLOWED_IFRAME_DOMAINS` / `_filter_iframe_attributes` / `_escape_unknown_html_tags` |
| `services/media_service.py` | `ensure_pdf_thumbnail` |

`libs.py` は `convert_markdown` / `apply_blog_output_to_event_detail` / `generate_blog` / `get_transcript` / `BlogOutput` を保持し、内部で新サービスから import する。

## 後方互換について

Issue で「後方互換性は維持しない」と明記されていたので re-export は行わず、import 元（forms.py / management / tests / twitter signals）はすべて services パスに直接書き換えた。

## 検証

- `docker compose exec vrc-ta-hub python manage.py check` → OK
- `docker compose exec vrc-ta-hub python manage.py test event` → **379 tests OK** (skipped=13)
- `docker compose exec vrc-ta-hub python manage.py test twitter.tests.test_auto_tweet.SlideShareSignalTest` → 17 tests OK

## 次のPR

- PR2: `content_generation_service.py` / `markdown_processor.py` 分離 + `convert_markdown` (215行) を50行以内×複数関数に分解
- PR3: `libs.py` 削除と残 import 整理

Closes part of #329