### PR TITLE
perf(test): MD5 ハッシャー + in-memory SQLite で CI テスト時間を短縮

### DIFF
--- a/app/website/settings/base.py
+++ b/app/website/settings/base.py
@@ -158,8 +158,10 @@ TESTING = os.environ.get('TESTING', '').strip().lower() in {'1', 'true', 'yes', 
 if 'test' in sys.argv or TESTING:
     DATABASES['default'] = {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'test_db.sqlite3',
+        'NAME': ':memory:',
     }
+    # PBKDF2 デフォルトは 600k iterations あり、create_user / client.login が多いテストで支配的になる
+    PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
 
 _settings_logger.info('DB_NAME: %s', _mask(DATABASES['default']['NAME']))
 


### PR DESCRIPTION
## 概要

CI の `manage.py test` ステップ（現状 450 秒 / 全体の 92%）を短縮するために、テスト時のみ:

- `PASSWORD_HASHERS` を `MD5PasswordHasher` に切り替え
- SQLite を `:memory:` 化（I/O削減）

## なぜ

`create_user` / `client.login` を多用するテストが多く、Django デフォルトの PBKDF2（600k iterations）がテスト実行時間を支配していた。実測:

| ファイル | hash 呼び出し回数 |
|---|---|
| `vket/tests/test_vket.py` | 93 |
| `community/tests/test_settings.py` | 53 |
| `event/tests/test_lt_application.py` | 37 |
| `community/tests/test_switch_community.py` | 31 |
| `community/tests/test_member_manage.py` | 27 |

## 計測結果

ローカル Docker 内（`mysqlclient` / SQLite 切替）で計測:

| 範囲 | before | after | 短縮率 |
|---|---|---|---|
| hash 多用 6 モジュール（258 tests） | 76.1 秒 | **1.6 秒** | **98%** |
| CI 全範囲（1031 tests） | 計測なし | **18.4 秒** | - |

直近 20 件の CI 平均は 490 秒（うちテスト実行 450 秒）。本変更で **CI 全体 8 分超 → 2〜3 分台** が見込める。

## 安全性

- 本番設定への影響なし（`if 'test' in sys.argv or TESTING:` 分岐内のみ）
- 1031 テスト全て pass を確認
- MD5 は**テスト DB 上の hash 計算高速化のため**であり、本番 PBKDF2 ハッシュには無関係

## Test plan

- [x] ローカルで CI 全範囲のテスト pass（18.4 秒）
- [ ] GitHub Actions 上で CI 全体時間が大幅短縮されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)