### PR TITLE
perf(ci): uv で依存インストール高速化 + Actions Node.js 24 対応

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -55,7 +55,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "requirements.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
       - name: Run ruff lint
         run: |
-          pip install ruff==0.11.6
+          uv pip install --system ruff==0.11.6
           ruff check app/
 
   test:
@@ -42,18 +47,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+          cache-dependency-glob: "requirements.txt"
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+        run: uv pip install --system -r requirements.txt
 
       - name: Run tests
         working-directory: app


### PR DESCRIPTION
## 概要

CI の依存インストールを `pip` → `uv` に切り替えて高速化しつつ、GitHub Actions の Node.js 20 deprecation 警告にも対応する。

## 変更内容

### A. uv 化（短縮効果あり）

- `pip install -r requirements.txt` → `uv pip install --system -r requirements.txt`
- lint job の `pip install ruff` も同様に置換
- `setup-python` の `cache: pip` は `setup-uv` の `enable-cache: true` + `cache-dependency-glob` で代替

### C. Actions バージョン更新（CI 停止リスク排除）

- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`

CI ログに以下の警告が出ていたため:
> Node.js 20 actions are deprecated... Node.js 20 will be removed from the runner on September 16th, 2026.

## 期待効果

直近の test job 内訳（44 秒）:

| ステップ | before | after 想定 |
|---|---|---|
| Install dependencies | 18 秒 | **3〜5 秒** |
| Run tests | 18 秒 | 18 秒（変化なし） |
| その他 | 8 秒 | 8 秒 |
| **合計** | **44 秒** | **30 秒前後** |

CI 全体で **74 秒 → 60 秒前後**を見込む。実機 CI で計測予定。

## Test plan

- [ ] CI 全体が pass
- [ ] Install dependencies ステップが大幅短縮されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)