### PR TITLE
refactor(ci): 外部API依存テストを @tag('external_api') で除外する方式に統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,62 +68,7 @@ jobs:
         env:
           EMAIL_FILE_PATH: "/tmp/emails"
         run: |
-          # Run tests for all apps.
-          # Excluded modules (external API / environment dependencies):
-          #   - event.tests.test_generate_blog (OpenRouter/YouTube APIs)
-          #   - event.tests.test_google_calendar (Google Calendar API + credentials file)
-          #   - event.tests.test_recurrence_llm_generation (Google Gemini API)
-          #   - event.tests.test_recurrence_preview_api (LLM API via RecurrenceService)
-          #   - event.tests.test_generate_recurring_events_command (RecurrenceService LLM dependency)
-          #   - event.tests.test_recurrence_rule_generation (LLM mock issues in CI)
-          #   - ta_hub.tests.test_resize_image (requires test image files)
-          #   - twitter.tests.test_auto_tweet (X API OAuth env vars not mockable at module level)
-          #   - user_account.tests.test_adapters (Discord SocialApp required in DB)
-          #   - user_account.tests.test_views (Discord OAuth SocialApp required)
-          #   - user_account.tests.test_middleware (Discord SocialApp required for template rendering)
-          #   - user_account.tests.test_mail (email backend configuration required)
-          python manage.py test \
-            website.tests \
-            community.tests \
-            user_account.tests.test_discord_notification \
-            user_account.tests.test_api_key_views \
-            user_account.tests.test_forms \
-            user_account.tests.test_lt_application_views \
-            user_account.tests.test_templatetags \
-            user_account.tests.test_x_account \
-            api_v1.tests \
-            event.tests.test_bigquery_lazy_init \
-            event.tests.test_community_cleanup \
-            event.tests.test_convert_markdown \
-            event.tests.test_detail_history_rate_limit \
-            event.tests.test_event_delete_view \
-            event.tests.test_event_detail_form \
-            event.tests.test_event_detail_permissions \
-            event.tests.test_event_detail_template \
-            event.tests.test_event_my_list_view \
-            event.tests.test_event_sync \
-            event.tests.test_event_visibility_and_purge_command \
-            event.tests.test_extract_video_info \
-            event.tests.test_google_calendar_list_pagination \
-            event.tests.test_lt_application \
-            event.tests.test_pdf_validation \
-            event.tests.test_recurrence_rule_deletion \
-            event.tests.test_rejected_lt_visibility \
-            event.tests.test_sanitize_event_detail_security_command \
-            event_calendar.tests \
-            guide.tests \
-            ta_hub.tests.test_about_page \
-            ta_hub.tests.test_cloudflare_image \
-            ta_hub.tests.test_google_calendar_sync_ui \
-            ta_hub.tests.test_header_community_dropdown \
-            ta_hub.tests.test_index_view_degraded_mode \
-            ta_hub.tests.test_user_tags \
-            ta_hub.tests.test_utils \
-            ta_hub.tests.test_vket_achievements \
-            twitter.tests.test_delete_permissions \
-            twitter.tests.test_generate_x_token \
-            twitter.tests.test_tweet_length \
-            twitter.tests.test_tweet_queue_views \
-            twitter.tests.test_views \
-            twitter.tests.test_x_api_guard \
-            vket.tests
+          # 外部API / 環境依存テストは @tag('external_api') で除外する
+          # 新規テストを追加した時に「CI で実行されない」事故を防ぐため、
+          # 除外モジュールを列挙するのではなくタグで一括除外する方式に統一している
+          python manage.py test --exclude-tag=external_api --noinput

--- a/app/event/tests/test_generate_blog.py
+++ b/app/event/tests/test_generate_blog.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 from django.core.files import File
-from django.test import TestCase
+from django.test import TestCase, tag
 from PIL import Image
 
 from user_account.models import CustomUser
@@ -39,6 +39,7 @@ HAS_OPENROUTER_API_KEY = _has_non_dummy_env("OPENROUTER_API_KEY")
 HAS_GOOGLE_API_KEY = _has_non_dummy_env("GOOGLE_API_KEY")
 
 
+@tag('external_api')
 class TestGenerateBlog(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/app/event/tests/test_generate_recurring_events_command.py
+++ b/app/event/tests/test_generate_recurring_events_command.py
@@ -2,7 +2,7 @@
 from calendar import monthrange
 from datetime import date, time, timedelta
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.utils import timezone
 from io import StringIO
 
@@ -12,6 +12,7 @@ from event.tests.tweet_generation import TweetGenerationPatchMixin
 from user_account.models import CustomUser
 
 
+@tag('external_api')
 class GenerateRecurringEventsCommandTest(TweetGenerationPatchMixin, TestCase):
     def setUp(self):
         """テストデータのセットアップ"""

--- a/app/event/tests/test_google_calendar.py
+++ b/app/event/tests/test_google_calendar.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from event.google_calendar import GoogleCalendarService
 from website.settings import GOOGLE_CALENDAR_ID, GOOGLE_CALENDAR_CREDENTIALS
+from django.test import tag
 
 
 RUN_EXTERNAL_API_TESTS = os.environ.get("RUN_EXTERNAL_API_TESTS") == "1"
@@ -18,6 +19,7 @@ HAS_CREDENTIALS_FILE = bool(CREDENTIALS_PATH) and os.path.exists(CREDENTIALS_PAT
     RUN_EXTERNAL_API_TESTS and HAS_CREDENTIALS_FILE,
     "外部APIテストのため RUN_EXTERNAL_API_TESTS=1 と GOOGLE_CALENDAR_CREDENTIALS ファイルが必要です",
 )
+@tag('external_api')
 class TestGoogleCalendarService(TestCase):
     def setUp(self):
         """テストの前準備"""

--- a/app/event/tests/test_recurrence_llm_generation.py
+++ b/app/event/tests/test_recurrence_llm_generation.py
@@ -1,6 +1,6 @@
 import os
 from datetime import date, time
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.contrib.auth import get_user_model
 from community.models import Community
 from event.models import Event, RecurrenceRule
@@ -9,6 +9,7 @@ from event.recurrence_service import RecurrenceService
 User = get_user_model()
 
 
+@tag('external_api')
 class TestRecurrenceLLMGeneration(TestCase):
     """実際のLLMを使用した定期ルール生成テスト"""
     

--- a/app/event/tests/test_recurrence_preview_api.py
+++ b/app/event/tests/test_recurrence_preview_api.py
@@ -1,6 +1,6 @@
 import json
 from datetime import date, time
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 from community.models import Community
@@ -9,6 +9,7 @@ from event.models import Event
 User = get_user_model()
 
 
+@tag('external_api')
 class TestRecurrencePreviewAPI(TestCase):
     """定期ルールプレビューAPIのテスト"""
     

--- a/app/event/tests/test_recurrence_rule_generation.py
+++ b/app/event/tests/test_recurrence_rule_generation.py
@@ -1,5 +1,5 @@
 from datetime import date, time
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.contrib.auth import get_user_model
 from community.models import Community
 from event.models import Event, RecurrenceRule
@@ -19,6 +19,7 @@ class FakeEventDateLlmService:
         return self.dates
 
 
+@tag('external_api')
 class TestRecurrenceRuleGeneration(TestCase):
     """定期ルール生成の週計算テスト"""
     

--- a/app/ta_hub/tests/test_resize_image.py
+++ b/app/ta_hub/tests/test_resize_image.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.test import TestCase, tag
 from PIL import Image, UnidentifiedImageError
 
 from ta_hub.libs import (
@@ -15,6 +15,7 @@ from ta_hub.libs import (
 from ta_hub.models import ImageFile
 
 
+@tag('external_api')
 class ImageFileTestCase(TestCase):
     def setUp(self):
         # テストデータのパスを設定
@@ -53,6 +54,7 @@ class ImageFileTestCase(TestCase):
         self.assertTrue(image_file.image.name.endswith('.png'))
 
 
+@tag('external_api')
 class ResizeAndConvertImageTestCase(TestCase):
     """resize_and_convert_image関数の単体テスト"""
 

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -9,7 +9,7 @@ from django.db import DatabaseError, IntegrityError, OperationalError, transacti
 from unittest.mock import MagicMock, Mock, patch
 
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase, TransactionTestCase, override_settings
+from django.test import Client, TestCase, TransactionTestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -21,6 +21,7 @@ from twitter.scheduling import default_scheduled_at, scheduled_at_for_date
 CustomUser = get_user_model()
 
 
+@tag('external_api')
 class EventTestPatchScopeTest(TestCase):
     """event.tests import が twitter signal を汚染しないことを確認する。"""
 
@@ -56,6 +57,7 @@ class EventTestPatchScopeTest(TestCase):
         self.assertIs(signals._start_tweet_generation, original)
 
 
+@tag('external_api')
 class TweetGenerationThreadGuardTest(TestCase):
     """テスト実行時の本文生成スレッド起動ガードを検証する。"""
 
@@ -87,6 +89,7 @@ class TweetGenerationThreadGuardTest(TestCase):
         mock_start.assert_not_called()
 
 
+@tag('external_api')
 class DBReconnectHelperTest(TestCase):
     """MySQL 接続断の再試行ヘルパーのテスト"""
 
@@ -122,6 +125,7 @@ class DBReconnectHelperTest(TestCase):
         mock_close_all.assert_not_called()
 
 
+@tag('external_api')
 class AutoTweetTestBase(TestCase):
     """テスト共通のセットアップ"""
 
@@ -167,6 +171,7 @@ class AutoTweetTestBase(TestCase):
         return timezone.now() - datetime.timedelta(hours=25)
 
 
+@tag('external_api')
 class TweetSchedulingTest(TestCase):
     """tweet_type ごとのデフォルト予約時刻のテスト"""
 
@@ -1677,6 +1682,7 @@ class RetryGenerationTest(AutoTweetTestBase):
         mock_close_all.assert_called_once()
 
 
+@tag('external_api')
 class LLMConnectionManagementTest(TransactionTestCase):
     """LLM 呼び出し時の DB 接続管理テスト"""
 
@@ -1739,6 +1745,7 @@ class LLMConnectionManagementTest(TransactionTestCase):
         self.assertEqual(community.description, "after")
 
 
+@tag('external_api')
 class GetGeneratorHelperTest(TestCase):
     """get_generator ヘルパー関数のテスト"""
 
@@ -1776,6 +1783,7 @@ class GetGeneratorHelperTest(TestCase):
         self.assertIsNone(generator)
 
 
+@tag('external_api')
 class GetPosterImageUrlHelperTest(TestCase):
     """get_poster_image_url ヘルパー関数のテスト"""
 
@@ -1898,6 +1906,7 @@ class GetPosterImageUrlHelperTest(TestCase):
         self.assertIn("community/1/poster.webp", result)
 
 
+@tag('external_api')
 class PostTweetFunctionTest(TestCase):
     """X API 投稿関数の単体テスト（OAuth 1.0a）"""
 
@@ -2020,6 +2029,7 @@ class PostTweetFunctionTest(TestCase):
         mock_post.assert_not_called()
 
 
+@tag('external_api')
 class UploadMediaFunctionTest(TestCase):
     """upload_media 関数のテスト"""
 
@@ -2231,6 +2241,7 @@ class UploadMediaFunctionTest(TestCase):
         self.assertEqual(result, "media_5mb")
 
 
+@tag('external_api')
 class TweetGeneratorTest(TestCase):
     """告知文生成関数のテスト"""
 
@@ -2693,6 +2704,7 @@ class TweetGeneratorTest(TestCase):
         self.assertIn("改行 入り テーマ", user_prompt)
 
 
+@tag('external_api')
 class TweetQueueConstraintTest(TestCase):
     """TweetQueue の一意制約テスト"""
 
@@ -2730,6 +2742,7 @@ class TweetQueueConstraintTest(TestCase):
             )
 
 
+@tag('external_api')
 class SanitizeForPromptTest(TestCase):
     """_sanitize_for_prompt 関数の単体テスト"""
 
@@ -2765,6 +2778,7 @@ class SanitizeForPromptTest(TestCase):
         self.assertEqual(_sanitize_for_prompt("hello   world"), "hello world")
 
 
+@tag('external_api')
 class PostTweetValidationTest(TestCase):
     """post_tweet 関数の入力バリデーションテスト"""
 

--- a/app/user_account/tests/test_adapters.py
+++ b/app/user_account/tests/test_adapters.py
@@ -2,7 +2,7 @@
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, tag
 
 from allauth.socialaccount.models import SocialAccount
 from community.models import Community, CommunityMember
@@ -12,6 +12,7 @@ from user_account.tests.utils import create_discord_linked_user
 User = get_user_model()
 
 
+@tag('external_api')
 class CustomSocialAccountAdapterTests(TestCase):
     """CustomSocialAccountAdapterのテストクラス."""
 
@@ -503,6 +504,7 @@ class CustomSocialAccountAdapterTests(TestCase):
         self.assertEqual(result, '/account/settings/')
 
 
+@tag('external_api')
 class DiscordLoginIntegrationTests(TestCase):
     """Discord OAuth統合テスト."""
 

--- a/app/user_account/tests/test_mail.py
+++ b/app/user_account/tests/test_mail.py
@@ -1,4 +1,4 @@
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase, override_settings, tag
 from django.core.mail import send_mail
 from django.conf import settings
 import logging
@@ -22,6 +22,7 @@ EMAIL_FILE_PATH = '/app/test-emails'
     EMAIL_BACKEND='django.core.mail.backends.filebased.EmailBackend',
     EMAIL_FILE_PATH=EMAIL_FILE_PATH
 )
+@tag('external_api')
 class EmailTest(SimpleTestCase):
     def setUp(self):
         super().setUp()

--- a/app/user_account/tests/test_middleware.py
+++ b/app/user_account/tests/test_middleware.py
@@ -1,6 +1,6 @@
 """Discord認証ミドルウェアのテスト."""
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase, override_settings
+from django.test import Client, TestCase, override_settings, tag
 from django.urls import reverse
 
 from allauth.socialaccount.models import SocialAccount
@@ -9,6 +9,7 @@ User = get_user_model()
 
 
 @override_settings(DISCORD_AUTH_REQUIRED=True)
+@tag('external_api')
 class DiscordAuthRequiredMiddlewareTests(TestCase):
     """DiscordAuthRequiredMiddlewareのテストクラス.
 

--- a/app/user_account/tests/test_views.py
+++ b/app/user_account/tests/test_views.py
@@ -1,7 +1,7 @@
 """認証ビューのテスト."""
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
-from django.test import Client, TestCase, override_settings
+from django.test import Client, TestCase, override_settings, tag
 from django.urls import reverse
 
 from community.models import Community, CommunityMember
@@ -30,6 +30,7 @@ TEST_SOCIALACCOUNT_PROVIDERS_WITH_APPS = {
 
 
 @override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS_WITH_APPS)
+@tag('external_api')
 class CustomLoginViewTests(TestCase):
     """CustomLoginViewのテストクラス."""
 
@@ -155,6 +156,7 @@ class CustomLoginViewTests(TestCase):
         self.assertEqual(response.url, settings.LOGIN_REDIRECT_URL)
 
 
+@tag('external_api')
 class SettingsViewTests(TestCase):
     """SettingsViewのテストクラス."""
 
@@ -404,6 +406,7 @@ class SettingsViewTests(TestCase):
         self.assertNotContains(response, '承認待集会一覧')
 
 
+@tag('external_api')
 class UserUpdateViewTests(TestCase):
     """UserUpdateViewのテストクラス."""
 
@@ -451,6 +454,7 @@ class UserUpdateViewTests(TestCase):
 
 
 @override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS_WITH_APPS)
+@tag('external_api')
 class RegisterViewTests(TestCase):
     """RegisterViewのテストクラス."""
 
@@ -539,6 +543,7 @@ class RegisterViewTests(TestCase):
         self.assertContains(response, 'アカウントを作成しました。ログインしてください。')
 
 
+@tag('external_api')
 class AllauthSignupRedirectTests(TestCase):
     """allauthのsignupページからカスタムregisterページへのリダイレクトテスト."""
 
@@ -574,6 +579,7 @@ class AllauthSignupRedirectTests(TestCase):
         self.assertIn('next=/foo/', response.url)
 
 
+@tag('external_api')
 class LoginPageRegisterLinkTests(TestCase):
     """ログインページの登録リンクテストクラス."""
 
@@ -589,6 +595,7 @@ class LoginPageRegisterLinkTests(TestCase):
         self.assertContains(response, reverse('account:register'))
 
 
+@tag('external_api')
 class HeaderDropdownMenuTests(TestCase):
     """ヘッダーのドロップダウンメニューテストクラス."""
 


### PR DESCRIPTION
## 概要

CI で実行するテストを `.github/workflows/ci.yml` に 44 行ハードコード列挙していたため、
新規テストファイルを追加しても CI で実行されない事故が起きていた。
タグベース除外に置き換えて、CI yaml を 1 行に集約する。

## 変更内容

### テストファイル側（12 ファイル・33 クラス）

外部API / 環境依存の以下のクラスに `@tag('external_api')` を付与:

| ファイル | クラス数 |
|---|---|
| `event/tests/test_generate_blog.py` | 1 |
| `event/tests/test_google_calendar.py` | 1 |
| `event/tests/test_recurrence_llm_generation.py` | 1 |
| `event/tests/test_recurrence_preview_api.py` | 1 |
| `event/tests/test_generate_recurring_events_command.py` | 1 |
| `event/tests/test_recurrence_rule_generation.py` | 1 |
| `ta_hub/tests/test_resize_image.py` | 2 |
| `twitter/tests/test_auto_tweet.py` | 14 |
| `user_account/tests/test_adapters.py` | 2 |
| `user_account/tests/test_views.py` | 7 |
| `user_account/tests/test_middleware.py` | 1 |
| `user_account/tests/test_mail.py` | 1 |

### CI yaml 側

```diff
-          python manage.py test \
-            website.tests \
-            community.tests \
-            user_account.tests.test_discord_notification \
-            ...（44 行列挙）...
+          python manage.py test --exclude-tag=external_api --noinput
```

## ローカル検証

| 範囲 | 結果 |
|---|---|
| `--exclude-tag=external_api` | **1291 tests pass / 20.8 秒** |
| `--tag=external_api` | 309 tests pass / 13.7 秒 |

これまでの CI は 1031 tests しか実行していなかったため、**約 260 件のテストが新たに CI で実行される**ようになる。
（除外モジュール内で external_api に該当しないテストや、CI yaml への追加忘れがあった分）

## メリット

- 新規テストファイルを `app/*/tests/test_xxx.py` に置けば自動で CI で実行される
- 外部API依存テストは `@tag('external_api')` を付ければ自動で除外される
- CI yaml の 44 行のハードコード列挙が消える（メンテ性向上）

## Test plan

- [x] ローカルで全テスト pass を確認
- [ ] CI 全体が pass
- [ ] dev デプロイ反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)