### PR TITLE
docs: functions.md の libs.py 参照を services 分割後のパスに更新

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -67,12 +67,12 @@ def generate_llm_events(request):
 ```
 
 ### generate_blog
-**場所**: `app/event/libs.py`
+**場所**: `app/event/services/content_generation_service.py:59`
 
 YouTubeやPDFからブログ記事を自動生成。
 
 ```python
-def generate_blog(event_detail: EventDetail, model: str = None) -> BlogOutput:
+def generate_blog(event_detail: EventDetail, model=None) -> BlogOutput:
     """
     AI (Gemini) を使用してイベント詳細からブログ記事を生成
     """
@@ -189,7 +189,7 @@ def sync_events(self, community: Community, start_date: date,
 VRCイベントカレンダー投稿用のURLを生成。
 
 ### convert_markdown
-**場所**: `app/event/libs.py`
+**場所**: `app/event/services/markdown_processor.py:208`
 
 MarkdownをHTMLに変換。
 


### PR DESCRIPTION
## 改善内容

PR #414 で `app/event/libs.py` が削除され `services/content_generation_service.py` / `services/markdown_processor.py` 等に分割されたが、`docs/functions.md` の関数リファレンスが旧パスを指したままだった。これを修正する。

- `generate_blog`: `app/event/libs.py` → `app/event/services/content_generation_service.py:59`
- `convert_markdown`: `app/event/libs.py` → `app/event/services/markdown_processor.py:208`
- `generate_blog` のシグネチャを実装と一致させる (`model: str = None` → `model=None`)

## 動機

improve-loop 自律改善 Loop 1/10 で「ドキュメント鮮度」観点 (high severity) として検出。
開発者が API リファレンスを信頼できなくなるため修正コスト極小で実害低減。

## 検証

- [x] docs のみ変更 (lint/テスト不要)
- [x] 該当関数が示すパス・行番号が実コードと一致 (確認済み)

## 関連

- improve-loop session: docs/tmp/improve-loop-20260609-1430.md
- Loop 1/10
- 関連 PR: #414 (libs.py 削除)