### PR TITLE
refactor(event/forms): EventDetailMediaFormMixin を抽出して clean/save 重複を解消

### DIFF
--- a/app/event/forms.py
+++ b/app/event/forms.py
@@ -192,7 +192,30 @@ class RecurringEventForm(forms.Form):
         return cleaned_data
 
 
-class EventDetailForm(forms.ModelForm):
+class EventDetailMediaFormMixin:
+    """スライドPDF・サムネ画像の検証と保存後処理を共通化するMixin。
+
+    EventDetailForm と LTApplicationEditForm の両方で同一実装が重複していたため抽出。
+    """
+
+    def clean_slide_file(self):
+        return validate_and_sanitize_pdf(self.cleaned_data.get('slide_file'))
+
+    def clean_thumbnail_image(self):
+        return validate_thumbnail_image(self.cleaned_data.get('thumbnail_image'))
+
+    def save(self, commit=True):
+        instance = super().save(commit=commit)
+        if commit:
+            from event.services.media_service import ensure_pdf_thumbnail
+            from twitter.signals import sync_slide_share_queue_image
+
+            ensure_pdf_thumbnail(instance, save=True)
+            sync_slide_share_queue_image(instance)
+        return instance
+
+
+class EventDetailForm(EventDetailMediaFormMixin, forms.ModelForm):
     start_time = forms.TimeField(
         label='開始時間',
         widget=forms.TimeInput(
@@ -332,25 +355,9 @@ class EventDetailForm(forms.ModelForm):
             cleaned_data['duration'] = self.instance.duration
 
         return cleaned_data
-    
-    def clean_slide_file(self):
-        return validate_and_sanitize_pdf(self.cleaned_data.get('slide_file'))
-
-    def clean_thumbnail_image(self):
-        return validate_thumbnail_image(self.cleaned_data.get('thumbnail_image'))
-
-    def save(self, commit=True):
-        instance = super().save(commit=commit)
-        if commit:
-            from event.services.media_service import ensure_pdf_thumbnail
-            from twitter.signals import sync_slide_share_queue_image
-
-            ensure_pdf_thumbnail(instance, save=True)
-            sync_slide_share_queue_image(instance)
-        return instance
 
 
-class LTApplicationEditForm(forms.ModelForm):
+class LTApplicationEditForm(EventDetailMediaFormMixin, forms.ModelForm):
     """LT申請者が自分の申請内容を編集するフォーム"""
 
     generate_blog_article = forms.BooleanField(
@@ -397,22 +404,6 @@ class LTApplicationEditForm(forms.ModelForm):
         # 記事未生成ならON、生成済みならOFF
         has_article = self.instance and self.instance.pk and self.instance.meta_description
         self.initial['generate_blog_article'] = not has_article
-
-    def clean_slide_file(self):
-        return validate_and_sanitize_pdf(self.cleaned_data.get('slide_file'))
-
-    def clean_thumbnail_image(self):
-        return validate_thumbnail_image(self.cleaned_data.get('thumbnail_image'))
-
-    def save(self, commit=True):
-        instance = super().save(commit=commit)
-        if commit:
-            from event.services.media_service import ensure_pdf_thumbnail
-            from twitter.signals import sync_slide_share_queue_image
-
-            ensure_pdf_thumbnail(instance, save=True)
-            sync_slide_share_queue_image(instance)
-        return instance
 
 
 RECURRENCE_CHOICES = [


### PR DESCRIPTION
## 改善内容

\`EventDetailForm\` と \`LTApplicationEditForm\` で完全に同一だった 3 メソッド
(\`clean_slide_file\` / \`clean_thumbnail_image\` / \`save\`) を Mixin に抽出。

- 新規: \`EventDetailMediaFormMixin\` (app/event/forms.py)
- 両フォームを \`(Mixin, forms.ModelForm)\` として継承
- 純減 9 行 (+25/-34)、挙動変更なし

## 動機

improve-loop 自律改善 Loop 2/10 で「コード品質」観点 (medium severity, DRY違反) として検出。
PDF/サムネ検証ロジックが2箇所で重複していたため、片方だけ修正されてバグが
同期しないリスクがあった。1 ファイル変更で完結する低コスト改善。

## 検証

- [x] EventDetailForm 関連テスト: 30 件 pass
- [x] event アプリ全テスト (external_api 除外): 337 件 pass
- [x] Mixin 継承構造により両フォームで同じ実装が呼ばれることを動作確認

## 関連

- improve-loop session: docs/tmp/improve-loop-20260609-1430.md
- Loop 2/10