### PR TITLE
docs: next-actions.md の settings.py 参照を settings/ ディレクトリ構造に更新

### DIFF
--- a/docs/next-actions.md
+++ b/docs/next-actions.md
@@ -53,7 +53,7 @@
 
 - [ ] README / `.env.example` / settings の環境変数仕様を揃える
   - 理由: `OPENAI_API_KEY`, `GOOGLE_CALENDAR_ID`, `REQUEST_TOKEN` の必須性が実装と文書でズレている
-  - ファイル: `README.md`, `.env.example`, `app/website/settings.py`
+  - ファイル: `README.md`, `.env.example`, `app/website/settings/` (apis.py / authentication.py / security.py 等)
   - 見積もり: 0.5日
 
 - [ ] 副作用ありバッチ入口を `GET` から `POST` に寄せる設計方針を決める
@@ -89,7 +89,7 @@
 
 - [ ] 設定検証と意図不明コードの軽い清掃をする
   - 理由: `assert` 依存の env 検証、空フック、コメントアウト残骸が読みづらさを増している
-  - ファイル: `app/website/settings.py`, `app/event/views.py`, `app/api_v1/recurrence_preview.py`, `app/user_account/views.py`
+  - ファイル: `app/website/settings/base.py`, `app/event/views.py`, `app/api_v1/recurrence_preview.py`, `app/user_account/views.py`
   - 見積もり: 0.5-1日
 
 ## 並列実行可能グループ


### PR DESCRIPTION
## 改善内容

PR #415 で \`app/website/settings.py\` が \`settings/\` ディレクトリに分割されたが
\`docs/next-actions.md\` の P1/P2 アクション項目が旧パスを指していた。

- P1 (環境変数仕様統一): settings.py → settings/ (apis.py / authentication.py / security.py 等)
- P2 (設定検証清掃): settings.py → settings/base.py

## 動機

improve-loop Loop 4/10、「ドキュメント鮮度」観点 (high severity)。
タスク着手時に対象ファイル特定で迷うのを防ぐ。

## 検証

- [x] docs のみ変更
- [x] settings/ 配下のファイル構造 (apis.py / authentication.py / base.py / caching.py / security.py / storage.py) を確認済み

## 関連

- improve-loop session: docs/tmp/improve-loop-20260609-1430.md
- Loop 4/10
- 関連 PR: #415 (settings ディレクトリ化)