### PR TITLE
refactor(twitter): tweet_generator の動的呼び出し関数に Callable 型ヒントを追加

### DIFF
--- a/app/twitter/tweet_generator.py
+++ b/app/twitter/tweet_generator.py
@@ -8,6 +8,7 @@ import inspect
 import logging
 import os
 import re
+from typing import Any, Callable, Optional
 
 from django.conf import settings
 from django.db import connections
@@ -260,7 +261,13 @@ def _validation_feedback(text: str) -> str:
     )
 
 
-def _call_generate_fn(generate_fn, *args, target_chars: int, validation_feedback: str, **kwargs):
+def _call_generate_fn(
+    generate_fn: Callable[..., Optional[str]],
+    *args: Any,
+    target_chars: int,
+    validation_feedback: str,
+    **kwargs: Any,
+) -> Optional[str]:
     parameters = inspect.signature(generate_fn).parameters
     accepts_feedback = (
         "validation_feedback" in parameters
@@ -277,12 +284,12 @@ def _call_generate_fn(generate_fn, *args, target_chars: int, validation_feedback
 
 
 def _generate_with_retry(
-    generate_fn,
-    *args,
-    max_retries=3,
-    fallback_fn=None,
-    **kwargs,
-) -> str | None:
+    generate_fn: Callable[..., Optional[str]],
+    *args: Any,
+    max_retries: int = 3,
+    fallback_fn: Optional[Callable[..., Optional[str]]] = None,
+    **kwargs: Any,
+) -> Optional[str]:
     """生成関数をリトライラッパーで実行する。
 
     1. target_chars=140 で生成


### PR DESCRIPTION
## 改善内容

\`_call_generate_fn\` と \`_generate_with_retry\` の \`generate_fn\` / \`fallback_fn\` が
型ヒント未指定で、\`inspect.signature\` による動的呼び出しがあるため型チェッカーでの
検出が効かなかった。\`Callable[..., Optional[str]]\` で明示する。

- typing から Any, Callable, Optional を import
- _call_generate_fn: generate_fn / *args / **kwargs / 戻り値に型ヒント
- _generate_with_retry: 上記 + max_retries, fallback_fn

## 検証

- [x] twitter アプリ全 102 テスト pass (external_api 除外)
- [x] 挙動変更なし（型アノテーション追加のみ）

## 動機

improve-loop Loop 6/10、「コード品質」観点 (high severity)。
動的呼び出しで型情報が失われると、リファクタ時の呼び出し元シグネチャ変更が
実行時にしか検出できない。Callable 注釈で IDE/mypy が検出可能になる。

## 関連

- improve-loop session: docs/tmp/improve-loop-20260609-1430.md
- Loop 6/10