### PR TITLE
docs: functions.md に ensure_pdf_thumbnail (media_service.py) を追記

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -193,6 +193,19 @@ VRCイベントカレンダー投稿用のURLを生成。
 
 MarkdownをHTMLに変換。
 
+### ensure_pdf_thumbnail
+**場所**: `app/event/services/media_service.py:18`
+
+PDFの先頭ページから未設定のサムネイル画像を作成する。
+
+```python
+def ensure_pdf_thumbnail(event_detail: EventDetail, *, save: bool = False, overwrite: bool = False) -> bool:
+    """
+    PDFの先頭ページから未設定のサムネイル画像を作成
+    save=True で thumbnail_image のみ保存、overwrite=True で既存上書き
+    """
+```
+
 ### extract_video_id
 **場所**: `app/event/views.py:210`
 


### PR DESCRIPTION
## 改善内容

PR #414 の services/ 分割で新規追加された \`media_service.ensure_pdf_thumbnail\` を
\`docs/functions.md\` の関数リファレンスに追記する。

Loop 2 で抽出した \`EventDetailMediaFormMixin\` が save 時に呼び出す重要な
public 関数だが、関数リファレンスに記載がなかった。

## 検証

- [x] 該当関数が \`app/event/services/media_service.py:18\` に実在する
- [x] docstring のシグネチャ・引数説明と一致

## 動機

improve-loop Loop 9/10、「ドキュメント鮮度」観点。
Loop 1 で \`generate_blog\` / \`convert_markdown\` のパス更新は済んでいたが、
新規追加された services 関数が記載されていなかった。

## 関連

- improve-loop session: docs/tmp/improve-loop-20260609-1430.md
- Loop 9/10
- 関連: Loop 1 (#419), Loop 2 (#420)