### PR TITLE
docs: improve-loop 2026-06-09 セッションの findings を docs/research/ に記録

### DIFF
--- a/docs/research/improve-loop-2026-06-09-findings.md
+++ b/docs/research/improve-loop-2026-06-09-findings.md
@@ -1,0 +1,94 @@
+# improve-loop 2026-06-09 セッション findings
+
+`improve-loop -n 10` 実行時に検出した改善候補のうち、当該セッションで PR 化しなかったものの記録。
+別エージェント・別セッション・別 PR で拾える形で残す。
+
+## セッション概要
+
+- 実行日: 2026-06-09
+- 完了 PR: 10 件 (#419, #420, #421, #422, #423, #424, #425, #426, #427, #428)
+- スコープ: refactor / test / docs (バグ修正・新機能追加は対象外)
+- 体制: 自由探索モード、各ループで最重要 1 件を選定して PR 化
+
+## 完了 PR (参考)
+
+| Loop | PR | scope | 1 行要約 |
+|------|----|-------|---------|
+| 1 | #419 | docs | functions.md の libs.py 参照を services/ 分割後に更新 |
+| 2 | #420 | refactor | EventDetailMediaFormMixin 抽出で clean/save 重複を解消 |
+| 3 | #421 | docs | docs/index.md の死リンク (notes/index.md) 削除 |
+| 4 | #422 | docs | next-actions.md の settings.py パスを settings/ 構造に更新 |
+| 5 | #423 | docs | django-5.2-warning-cleanup の対応完了状態を反映 |
+| 6 | #424 | refactor | tweet_generator に Callable 型ヒント追加 |
+| 7 | #425 | refactor | RecurrenceService の community パラメータに Optional[Community] 追加 |
+| 8 | #426 | docs | next-actions.md の存在しない docs/notes/ 参照を整理 |
+| 9 | #427 | docs | functions.md に ensure_pdf_thumbnail を追記 |
+| 10 | #428 | docs | 本ドキュメント追加 |
+
+## 未対応の改善候補
+
+### refactor (中規模)
+
+#### RecurrenceService._get_recent_events_history() の分割
+
+- **対象**: `app/event/recurrence_service.py:358-389`
+- **severity**: medium
+- **effort**: 約 35 行
+- **内容**: 40+ 行の長関数で複数のクエリパターンが混在。`_get_master_events()` / `_get_community_events()` に分割し各々に戻り値型ヒント `List[Event]` を明示すれば、N+1 クエリリスク低減＆テスト容易性向上。
+
+#### tweet_generator._call_generate_fn の Protocol 化
+
+- **対象**: `app/twitter/tweet_generator.py:263-276`
+- **severity**: medium
+- **effort**: 約 18 行
+- **内容**: `inspect.signature` で `validation_feedback` 引数の有無を動的に検査して条件分岐している。`Protocol[TweetGenerator]` に統一し `validation_feedback: str = ""` をデフォルト値で受け取るシグネチャに揃えれば、inspect 除去可。Loop 6 で型ヒント (`Callable[..., Optional[str]]`) は付与済みだが、Protocol 化はさらに先のリファクタとして残す。
+
+### test (大規模・優先度高)
+
+#### event.notifications テスト追加 (critical)
+
+- **対象**: `app/event/notifications.py` (391 行)
+- **追加先**: `app/event/tests/test_notifications.py`
+- **effort**: 約 200 行 / 6-8 テストメソッド
+- **理由**: 発表申請通知 (Email/Discord 統合) の失敗が完全にサイレント。主催者が申請通知を受け取らないリスク。`community.get_owners` ループの recipient list 構築エラーが検出不可。
+- **対象メソッド**: `notify_owners_of_new_application` / `notify_applicant_of_result` / `_send_discord_notification_for_new_application`
+
+#### twitter.x_api テスト追加 (high)
+
+- **対象**: `app/twitter/x_api.py` (211 行)
+- **追加先**: `app/twitter/tests/test_x_api.py`
+- **effort**: 約 150 行 / 5-7 テストメソッド
+- **理由**: 既存テスト (`test_x_api_guard.py` 57 行) は `TESTING=True` ガードのみ。実ネットワーク呼び出しパス (stream chunk 5MB 制限、SSRF domain チェック、JSON デコード失敗、timeout) が未テスト。
+- **対象メソッド**: `upload_media` / `post_tweet` / `_get_oauth1`
+
+#### event.llm_service Provider config テスト追加 (high)
+
+- **対象**: `app/event/llm_service.py` (221 行)
+- **追加先**: `app/event/tests/test_llm_service.py` (拡張)
+- **effort**: 約 180 行 / 6 テストメソッド
+- **理由**: external_api tag で CI 除外。openrouter / openai / gemini の 3 分岐、`extract_event_dates` の JSON parse 失敗 / 日付フォーマット不一致 / 非リスト値で silent return [] が未テスト。
+
+#### community.forms_processor テスト追加 (high)
+
+- **対象**: `app/community/forms_processor.py` (171 行)
+- **追加先**: `app/community/tests/test_forms_processor.py`
+- **effort**: 約 200 行 / 7-9 テストメソッド
+- **理由**: approve/reject/close の 3 関数が Email/Discord 送信で silent logging のみ。close 操作後の orphaned events 検出不可。
+
+#### api_v1.recurrence_preview テスト追加 (medium)
+
+- **対象**: `app/api_v1/recurrence_preview.py` (80+ 行)
+- **追加先**: `app/api_v1/tests/test_recurrence_preview.py`
+- **effort**: 約 120 行 / 4-5 テストメソッド
+- **理由**: 新規 API endpoint でテストなし。base_date parse エラー、`community_id` の silent fallback (community=None で続行) が意図的かバグか判定不可。
+
+## バグ候補
+
+**当該セッションでは [BUG_FOUND] 0 件**。3 体の Explore agent (コード品質 / テストカバレッジ / ドキュメント鮮度) のいずれも実害のあるバグ・セキュリティ懸念を検出しなかった。
+
+## 次回 improve-loop への申し送り
+
+- **同じ調査をやり直す必要は薄い**: 本ファイルの「未対応の改善候補」から拾えば直接実装に入れる
+- **スコープ別残量**: docs はほぼ枯渇、refactor は中規模が 2 件、test は大規模が 5 件
+- **推奨次回スコープ**: `--scope test` で固定して大規模テスト追加 1-2 件を 1 セッションで仕上げるのが効率的
+- **`docs/notes/` 配下の方針判断**: 未作成のまま `next-actions.md` で「整理する」と書かれているタスクがある。`note` skill の DB に集約するか、`docs/notes/` を作って中身を入れるか方針未定 (Loop 8 で文言整理のみ完了)

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -7,3 +7,4 @@
 - [Issue #356 OpenRouter HTTP-Referer 調査](issue-356-openrouter-http-referer.md) — preview/staging URL が OpenRouter の `HTTP-Referer` に漏れないようにする調査と検証方針
 - [Issue #343 LT申請「追加情報」テンプレート初期値化](issue-343-lt-application-additional-info-initial.md) — LT申請フォームのテンプレート表示を placeholder から initial に変更する調査と検証方針
 - [リファクタリング計画 (2026-05-25)](refactor-plan.html) — `app/` 配下のPythonコードを構造/品質/設計の3軸で機械的にスキャンし、優先度付き改善ロードマップを提示
+- [improve-loop 2026-06-09 findings](improve-loop-2026-06-09-findings.md) — `improve-loop -n 10` セッションの完了 PR 一覧と未対応の改善候補（refactor 中規模 2 件 / test 大規模 5 件）の引き継ぎメモ


### PR DESCRIPTION
## 改善内容

\`improve-loop -n 10\` セッションで完了した 10 PR の summary と、調査時に拾ったが
当該セッションで PR 化しなかった改善候補（refactor 中規模 2 件 / test 大規模 5 件）を
\`docs/research/improve-loop-2026-06-09-findings.md\` として記録する。

将来の improve-loop / 別エージェント / 別セッションが拾える引き継ぎメモ。

### 含まれる内容

- 完了 PR 10 件の summary テーブル
- 未対応の refactor 候補（_get_recent_events_history 分割 / _call_generate_fn の Protocol 化）
- 未対応の test 候補 5 件（notifications critical / x_api high / llm_service high / forms_processor high / recurrence_preview medium）
- 次回 improve-loop への申し送り（推奨スコープ、docs/notes/ 配下の方針判断など）
- \`docs/research/index.md\` から本ファイルへのリンク追加

## 動機

improve-loop Loop 10/10 (最終ループ)。

調査で挙がった候補を捨てずに残すことで、次回の調査コストを削減し、
findings が「やる気はあるが手が回らない」改善として塩漬けになるのを防ぐ。

## 関連

- improve-loop session: docs/tmp/improve-loop-20260609-1430.md
- Loop 10/10
- 関連: 本セッションの全 PR (#419-#427)