### PR TITLE
security(twitter): upload_media に Content-Type magic bytes 検証を追加

### DIFF
--- a/app/twitter/tests/test_x_api.py
+++ b/app/twitter/tests/test_x_api.py
@@ -14,6 +14,7 @@ from django.test import TestCase
 from twitter.x_api import (
     MAX_IMAGE_SIZE,
     _get_oauth1,
+    _is_valid_image_bytes,
     post_tweet,
     upload_media,
 )
@@ -116,7 +117,9 @@ class UploadMediaSizeLimitTest(TestCase):
     @patch("twitter.x_api.requests.get")
     def test_accepts_image_at_max_size(self, mock_get, mock_post):
         """ちょうど MAX_IMAGE_SIZE の画像は通す（境界値）"""
-        boundary_chunks = [b"a" * MAX_IMAGE_SIZE]
+        # magic bytes 検証を通すため PNG ヘッダーで埋める
+        png_header = b"\x89PNG\r\n\x1a\n"
+        boundary_chunks = [png_header + b"a" * (MAX_IMAGE_SIZE - len(png_header))]
         mock_get_response = MagicMock()
         mock_get_response.raise_for_status.return_value = None
         mock_get_response.iter_content.return_value = boundary_chunks
@@ -150,7 +153,8 @@ class UploadMediaErrorHandlingTest(TestCase):
         """アップロード時の 4xx 応答で raise_for_status → None"""
         mock_get_response = MagicMock()
         mock_get_response.raise_for_status.return_value = None
-        mock_get_response.iter_content.return_value = [b"img"]
+        # magic bytes 検証を通すため PNG ヘッダー付きで返す
+        mock_get_response.iter_content.return_value = [b"\x89PNG\r\n\x1a\nimg"]
         mock_get_response.headers = {"Content-Type": "image/png"}
         mock_get.return_value = mock_get_response
 
@@ -243,6 +247,129 @@ class PostTweetSuccessPathTest(TestCase):
         payload = mock_post.call_args.kwargs["json"]
         self.assertEqual(payload["text"], "hello")
         self.assertEqual(payload["media"]["media_ids"], ["m1", "m2"])
+
+
+class UploadMediaMagicBytesTest(TestCase):
+    """upload_media の magic bytes 検証 (Content-Type ヘッダー偽装防止)"""
+
+    @patch.dict("os.environ", VALID_CREDS_ENV, clear=False)
+    @patch("twitter.x_api.requests.post")
+    @patch("twitter.x_api.requests.get")
+    def test_accepts_png_magic_bytes(self, mock_get, mock_post):
+        """PNG magic bytes を含むデータは pass"""
+        mock_get_response = MagicMock()
+        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.iter_content.return_value = [b"\x89PNG\r\n\x1a\nrest"]
+        mock_get_response.headers = {"Content-Type": "image/png"}
+        mock_get.return_value = mock_get_response
+
+        mock_post_response = MagicMock()
+        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.json.return_value = {"media_id_string": "png-ok"}
+        mock_post.return_value = mock_post_response
+
+        result = upload_media("https://data.vrc-ta-hub.com/png.png")
+        self.assertEqual(result, "png-ok")
+        mock_post.assert_called_once()
+
+    @patch.dict("os.environ", VALID_CREDS_ENV, clear=False)
+    @patch("twitter.x_api.requests.post")
+    @patch("twitter.x_api.requests.get")
+    def test_accepts_jpeg_magic_bytes(self, mock_get, mock_post):
+        """JPEG magic bytes (\\xff\\xd8\\xff) を含むデータは pass"""
+        mock_get_response = MagicMock()
+        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.iter_content.return_value = [b"\xff\xd8\xff\xe0body"]
+        mock_get_response.headers = {"Content-Type": "image/jpeg"}
+        mock_get.return_value = mock_get_response
+
+        mock_post_response = MagicMock()
+        mock_post_response.raise_for_status.return_value = None
+        mock_post_response.json.return_value = {"media_id_string": "jpeg-ok"}
+        mock_post.return_value = mock_post_response
+
+        result = upload_media("https://data.vrc-ta-hub.com/photo.jpg")
+        self.assertEqual(result, "jpeg-ok")
+        mock_post.assert_called_once()
+
+    @patch.dict("os.environ", VALID_CREDS_ENV, clear=False)
+    @patch("twitter.x_api.requests.post")
+    @patch("twitter.x_api.requests.get")
+    def test_rejects_html_payload_with_image_content_type(self, mock_get, mock_post):
+        """HTML が image/png として返されても magic bytes で検出して None"""
+        mock_get_response = MagicMock()
+        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.iter_content.return_value = [b"<html><body>not an image</body></html>"]
+        mock_get_response.headers = {"Content-Type": "image/png"}
+        mock_get.return_value = mock_get_response
+
+        result = upload_media("https://data.vrc-ta-hub.com/fake.png")
+        self.assertIsNone(result)
+        mock_post.assert_not_called()
+
+    @patch.dict("os.environ", VALID_CREDS_ENV, clear=False)
+    @patch("twitter.x_api.requests.post")
+    @patch("twitter.x_api.requests.get")
+    def test_rejects_json_payload_with_image_content_type(self, mock_get, mock_post):
+        """JSON が image/png として返されても magic bytes で検出して None"""
+        mock_get_response = MagicMock()
+        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.iter_content.return_value = [b'{"foo": "bar"}']
+        mock_get_response.headers = {"Content-Type": "image/png"}
+        mock_get.return_value = mock_get_response
+
+        result = upload_media("https://data.vrc-ta-hub.com/fake.png")
+        self.assertIsNone(result)
+        mock_post.assert_not_called()
+
+    @patch.dict("os.environ", VALID_CREDS_ENV, clear=False)
+    @patch("twitter.x_api.requests.post")
+    @patch("twitter.x_api.requests.get")
+    def test_rejects_empty_bytes(self, mock_get, mock_post):
+        """空バイト列は magic bytes が成立しないため None"""
+        mock_get_response = MagicMock()
+        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.iter_content.return_value = [b""]
+        mock_get_response.headers = {"Content-Type": "image/png"}
+        mock_get.return_value = mock_get_response
+
+        result = upload_media("https://data.vrc-ta-hub.com/empty.png")
+        self.assertIsNone(result)
+        mock_post.assert_not_called()
+
+    @patch.dict("os.environ", VALID_CREDS_ENV, clear=False)
+    @patch("twitter.x_api.requests.post")
+    @patch("twitter.x_api.requests.get")
+    def test_rejects_too_short_bytes(self, mock_get, mock_post):
+        """8 バイト未満でいずれの magic bytes にも一致しなければ None"""
+        mock_get_response = MagicMock()
+        mock_get_response.raise_for_status.return_value = None
+        mock_get_response.iter_content.return_value = [b"abc"]
+        mock_get_response.headers = {"Content-Type": "image/png"}
+        mock_get.return_value = mock_get_response
+
+        result = upload_media("https://data.vrc-ta-hub.com/short.png")
+        self.assertIsNone(result)
+        mock_post.assert_not_called()
+
+    def test_is_valid_image_bytes_accepts_gif87a(self):
+        """GIF87a も許可形式"""
+        self.assertTrue(_is_valid_image_bytes(b"GIF87a\x00\x00rest"))
+
+    def test_is_valid_image_bytes_accepts_gif89a(self):
+        """GIF89a も許可形式"""
+        self.assertTrue(_is_valid_image_bytes(b"GIF89a\x00\x00rest"))
+
+    def test_is_valid_image_bytes_accepts_webp(self):
+        """WebP は RIFF....WEBP の特殊形式 (オフセット 8-12)"""
+        # RIFF(4) + size(4) + WEBP(4) + payload
+        webp_bytes = b"RIFF\x00\x00\x00\x10WEBPVP8 rest"
+        self.assertTrue(_is_valid_image_bytes(webp_bytes))
+
+    def test_is_valid_image_bytes_rejects_riff_without_webp(self):
+        """RIFF だけで WEBP 識別子がなければ拒否 (AVI/WAV 等)"""
+        avi_bytes = b"RIFF\x00\x00\x00\x10AVI rest"
+        self.assertFalse(_is_valid_image_bytes(avi_bytes))
 
 
 class PostTweetErrorHandlingTest(TestCase):

--- a/app/twitter/x_api.py
+++ b/app/twitter/x_api.py
@@ -41,6 +41,25 @@ MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5MB (X API の上限)
 ALLOWED_IMAGE_DOMAINS = frozenset({"data.vrc-ta-hub.com"})
 IMAGE_DOWNLOAD_CHUNK_SIZE = 8192
 
+# Content-Type ヘッダー偽装による任意バイナリ送信を防ぐため、
+# ダウンロード後にファイル先頭バイトで実画像形式を再検証する。
+IMAGE_MAGIC_BYTES = [
+    b"\x89PNG\r\n\x1a\n",  # PNG
+    b"\xff\xd8\xff",        # JPEG
+    b"GIF87a",
+    b"GIF89a",
+]
+
+
+def _is_valid_image_bytes(data: bytes) -> bool:
+    """ファイル先頭バイトで画像形式を検証 (SSRF/任意バイナリ防止)"""
+    if any(data.startswith(magic) for magic in IMAGE_MAGIC_BYTES):
+        return True
+    # WebP は RIFF....WEBP の特殊形式
+    if len(data) >= 12 and data[0:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return True
+    return False
+
 
 def _should_block_x_api_in_tests() -> bool:
     """テスト環境では明示的に許可した場合だけ X API 呼び出しを通す。"""
@@ -117,6 +136,10 @@ def upload_media(image_url: str) -> str | None:
             chunks.append(chunk)
 
         image_data = b"".join(chunks)
+        # Content-Type ヘッダーは送信側で偽装可能なため、magic bytes で実体を再検証する
+        if not _is_valid_image_bytes(image_data):
+            logger.warning("Invalid image magic bytes")
+            return None
         content_type = image_response.headers.get('Content-Type', 'image/png')
 
         response = requests.post(


### PR DESCRIPTION
## Summary

X API への画像アップロード経路において、`Content-Type` ヘッダーが信頼できないことに起因する任意バイナリ送信リスクを塞ぐ。**ダウンロード後にファイル先頭バイト (magic bytes)** で実画像形式を再検証し、HTML / JSON / 実行可能ファイル等が画像として X にアップロードされるのを防ぐ。

improve-loop W2 #22 (security hardening)

## 変更内容

- `app/twitter/x_api.py`
  - `IMAGE_MAGIC_BYTES` 定数を追加 (PNG / JPEG / GIF87a / GIF89a)
  - `_is_valid_image_bytes(data: bytes) -> bool` ヘルパー関数を追加
  - WebP は `RIFF....WEBP` のオフセット形式に対応 (`data[0:4] == b\"RIFF\" and data[8:12] == b\"WEBP\"`)
  - `upload_media` の `b\"\".join(chunks)` 直後で `_is_valid_image_bytes` を呼び、失敗時は `logger.warning(\"Invalid image magic bytes\")` + `return None`
- `app/twitter/tests/test_x_api.py`
  - 新規 `UploadMediaMagicBytesTest` クラス (10 件):
    - PNG / JPEG magic bytes で pass
    - HTML / JSON が `Content-Type: image/png` で混入した場合 None
    - 空バイト列 / 短すぎる (`b\"abc\"` < 8 bytes) で None
    - `_is_valid_image_bytes` 単体: GIF87a / GIF89a / WebP 許可、`RIFF...AVI` 拒否
  - 既存テスト 2 件を magic bytes 対応に修正:
    - `test_accepts_image_at_max_size`: 境界値テストの payload を `b\"a\" * MAX_IMAGE_SIZE` → `b\"\\x89PNG\\r\\n\\x1a\\n\" + b\"a\" * (MAX_IMAGE_SIZE - 8)` に変更
    - `test_returns_none_on_upload_response_4xx`: ペイロードを `b\"img\"` → `b\"\\x89PNG\\r\\n\\x1a\\nimg\"` に変更

## 設計判断

- **Content-Type ヘッダーで信頼しない理由**: 許可ドメイン (`data.vrc-ta-hub.com` = Cloudflare R2) は HTTP ヘッダーをクライアントが操作できる経路でもあり、`Content-Type` だけでは「実体が画像である」保証にならない
- **WebP のみ特殊対応**: WebP は `RIFF` コンテナ形式で先頭 4 バイトでは識別できないため、オフセット 8-12 の `WEBP` 識別子も併せてチェック
- **ファイル本体に副作用なし**: 既存の SSRF ドメインチェック / サイズ制限 / 認証ロジックは無変更

## Test plan

- [x] `docker exec vrc-ta-hub-app python manage.py test twitter.tests.test_x_api --keepdb` 全 27 件 pass (既存 17 + 新規 10)
- [x] 既存テスト互換性: PNG ヘッダー付与のみの最小差分で対応、振る舞いの本質は変えていない
- [x] HTML / JSON ペイロードを image/png で偽装した場合に拒否される (`UploadMediaMagicBytesTest.test_rejects_html_payload_with_image_content_type` 等で確認)
- [x] WebP の RIFF/WEBP オフセット判定が AVI/WAV 等の他 RIFF コンテナを誤検知しないことを確認 (`test_is_valid_image_bytes_rejects_riff_without_webp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)