### PR TITLE
security(cors): CORS_ALLOW_ALL_ORIGINS を環境変数ベースの明示許可に変更

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ HTTP_HOST=localhost
 CSRF_TRUSTED_ORIGIN=http://localhost:8015
 HTTP_X_FORWARDED_PROTO=http  # ローカル開発はhttp、本番は設定不要（nginxが付加）
 
+# CORS 許可オリジン (カンマ区切り)。本番は https://vrc-ta-hub.com 等
+# ローカル開発 (DEBUG=True) では localhost / 127.0.0.1 の任意ポートが自動許可されるため未設定でも可
+CORS_ALLOWED_ORIGINS=
+
 # データベースの設定（MySQL）
 DB_NAME=vrc_ta_hub
 DB_USER=dev_user

--- a/app/website/settings/security.py
+++ b/app/website/settings/security.py
@@ -2,7 +2,7 @@
 
 ALLOWED_HOSTS / SECURE_PROXY_SSL_HEADER / SESSION_COOKIE_SECURE /
 CSRF_COOKIE_SECURE / SECURE_HSTS_* / CSRF_TRUSTED_ORIGINS /
-CORS_ALLOW_ALL_ORIGINS / CORS_URLS_REGEX / DISCORD_AUTH_REQUIRED を扱う。
+CORS_ALLOWED_ORIGINS / CORS_URLS_REGEX / DISCORD_AUTH_REQUIRED を扱う。
 """
 import os
 import sys
@@ -55,8 +55,17 @@ CSRF_TRUSTED_ORIGINS = [
     ] if o
 ]
 
-CORS_ALLOW_ALL_ORIGINS = True
+# CORS は環境変数で明示許可したオリジンのみ受け入れる（本番で全オリジン許可は脆弱性につながるため）
+CORS_ALLOWED_ORIGINS = _split_csv_env('CORS_ALLOWED_ORIGINS')
 CORS_URLS_REGEX = r'^/api/.*$'
+
+# ローカル開発 (DEBUG=True) は localhost / 127.0.0.1 の任意ポートを正規表現で許可
+# 環境変数で個別ポートを管理しなくてもブラウザから API を叩けるようにする
+if DEBUG:
+    CORS_ALLOWED_ORIGIN_REGEXES = [
+        r'^http://localhost:\d+$',
+        r'^http://127\.0\.0\.1:\d+$',
+    ]
 
 # Discord認証強制ミドルウェアの設定
 # DEBUG=True（開発環境）では無効化（ブラウザ操作MCPでのテストのため）

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -124,6 +124,20 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+## CORS 許可オリジン
+
+`/api/` 配下への CORS 許可を環境変数 `CORS_ALLOWED_ORIGINS` で明示的に管理する。
+本番では全オリジン許可をやめ、信頼できるドメインのみを列挙する。
+
+```bash
+# 本番: 自社ドメイン等をカンマ区切りで列挙
+CORS_ALLOWED_ORIGINS=https://vrc-ta-hub.com,https://www.vrc-ta-hub.com
+```
+
+- 値が空のときは CORS を一切許可しない（本番デフォルトは明示設定推奨）
+- ローカル開発（`DEBUG=True`）では `http://localhost:任意ポート` / `http://127.0.0.1:任意ポート` が自動許可されるため、`CORS_ALLOWED_ORIGINS` は未設定のままで動作する
+- 適用範囲は `/api/.*` のみ（`CORS_URLS_REGEX` 制限）
+
 ## 最低限必要な環境変数
 
 `SECRET_KEY` のみ設定すれば基本的な開発が可能です。DB・ストレージの接続情報は `.env.example` にデフォルト値が入っています。


### PR DESCRIPTION
improve-loop W2 #2

## 背景

`app/website/settings/security.py` の `CORS_ALLOW_ALL_ORIGINS = True` は本番でも全オリジン許可になっており、`/api/*` に対する CSRF 系攻撃や情報漏えいの起点になり得る。環境変数で明示許可したオリジンだけを通すように修正する。

## 変更内容

- `CORS_ALLOW_ALL_ORIGINS = True` を削除
- `CORS_ALLOWED_ORIGINS` を環境変数 `CORS_ALLOWED_ORIGINS` (カンマ区切り) から読み込む
  - 既存パターン `_split_csv_env`（base.py で `ALLOWED_HOSTS` 等にも使用済み）を再利用
  - 指示書で挙げられた `config()` + `Csv()` は本リポジトリで未使用のため、既存パターンに統一して新規依存追加を回避
- `DEBUG=True` のときは `CORS_ALLOWED_ORIGIN_REGEXES` で `http://localhost:任意ポート` / `http://127.0.0.1:任意ポート` を自動許可（開発体験を維持）
- `CORS_URLS_REGEX = r'^/api/.*$'` の制限は維持
- `.env.example` に `CORS_ALLOWED_ORIGINS=` を追記
- `docs/setup.md` に CORS 設定セクションを追記

## 変更ファイル数

**3 ファイル**:
- `app/website/settings/security.py`
- `.env.example`
- `docs/setup.md`

## 検証

### Django Middleware 経由の挙動確認（コンテナ内）

```python
# CORS_ALLOWED_ORIGINS=https://vrc-ta-hub.com を設定した状態で
# CorsMiddleware を直接通したリクエストの ACAO ヘッダー
Evil origin (https://evil.example.com):  NOT SET   # 拒否 OK
Allowed origin (https://vrc-ta-hub.com): https://vrc-ta-hub.com   # 許可 OK
Localhost:3000 (DEBUG regex):            http://localhost:3000   # 許可 OK
Non-API path (/event/):                  NOT SET   # CORS_URLS_REGEX 範囲外 OK
```

### Settings 値の確認

```
CORS_ALLOWED_ORIGINS= ['https://vrc-ta-hub.com', 'https://www.vrc-ta-hub.com']
CORS_URLS_REGEX= ^/api/.*$
CORS_ALLOWED_ORIGIN_REGEXES= ['^http://localhost:\\d+$', '^http://127\\.0\\.0\\.1:\\d+$']
CORS_ALLOW_ALL_ORIGINS= NOT SET (django-cors-headers のデフォルト False)
```

### 既存テスト

```
docker exec vrc-ta-hub-app python manage.py test website.tests.test_host_settings --exclude-tag=external_api
Ran 13 tests in 0.002s — OK
```

## 本番反映時の注意

- 本番環境で `CORS_ALLOWED_ORIGINS=https://vrc-ta-hub.com` 等を **必ず明示設定** すること（未設定だと CORS は一切許可されなくなる）
- 未設定のまま反映すると、API を別オリジンから叩いているフロントエンド（あれば）が動かなくなる

## 関連

improve-loop W2 #2