### PR TITLE
security(api_v1): csrf_exempt 削除、SessionAuth 経路は CSRF token 必須に

### DIFF
--- a/app/api_v1/tests/test_csrf.py
+++ b/app/api_v1/tests/test_csrf.py
@@ -1,0 +1,176 @@
+"""CSRF 振る舞いの回帰テスト.
+
+`api_v1` の ViewSet で `csrf_exempt` を削除したため:
+- APIKey 認証経由のリクエストは CSRF token なしで POST/PUT/DELETE できること
+- 公開 ReadOnlyModelViewSet の GET は CSRF チェック対象外で 200 を返すこと
+- SessionAuthentication 経由の POST は DRF 標準動作により CSRF token を要求すること
+
+`APIClient` のデフォルトでは `enforce_csrf_checks=False` のため、SessionAuth の CSRF
+振る舞いを検証する場合は `enforce_csrf_checks=True` を明示する。
+"""
+
+from datetime import date, time
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from community.models import Community, CommunityMember
+from event.models import Event, EventDetail
+from user_account.models import APIKey, CustomUser
+
+
+class CsrfBehaviorTests(TestCase):
+    """`api_v1` の CSRF 関連の振る舞いを検証する."""
+
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(
+            user_name='csrf_test_user',
+            email='csrf_test@example.com',
+            password='testpass123',
+        )
+        self.api_key_obj, self.raw_api_key = APIKey.create_with_raw_key(
+            user=self.user,
+            name='CSRF Test API Key',
+        )
+
+        self.community = Community.objects.create(
+            name='CSRF Test Community',
+            start_time=time(20, 0),
+            duration=120,
+            weekdays='mon',
+            frequency='weekly',
+            organizers='CSRF Test Organizer',
+            status='approved',
+        )
+        CommunityMember.objects.create(
+            community=self.community,
+            user=self.user,
+            role=CommunityMember.Role.OWNER,
+        )
+
+        self.event = Event.objects.create(
+            community=self.community,
+            date=date(2099, 12, 25),
+            start_time=time(20, 0),
+            duration=120,
+            weekday='wed',
+        )
+        self.event_detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            start_time=time(20, 0),
+            duration=30,
+            speaker='CSRF Speaker',
+            theme='CSRF Theme',
+            h1='CSRF Title',
+            contents='CSRF contents',
+        )
+
+        self.event_detail_api_url = reverse('event-detail-api-list')
+        self.event_detail_api_detail_url = reverse(
+            'event-detail-api-detail', kwargs={'pk': self.event_detail.id}
+        )
+
+    def _build_event_detail_payload(self):
+        return {
+            'event': self.event.id,
+            'detail_type': 'LT',
+            'start_time': '20:30:00',
+            'duration': 20,
+            'speaker': 'Posted Speaker',
+            'theme': 'Posted Theme',
+            'h1': 'Posted Title',
+            'contents': 'Posted contents',
+            'generate_from_pdf': False,
+        }
+
+    def test_api_key_post_succeeds_without_csrf_token(self):
+        """APIKey 認証経由なら CSRF token なしで POST が通る (CSRF 強制下でも)."""
+        client = APIClient(enforce_csrf_checks=True)
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.raw_api_key}')
+
+        response = client.post(
+            self.event_detail_api_url,
+            self._build_event_detail_payload(),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_api_key_put_and_delete_succeed_without_csrf_token(self):
+        """APIKey 認証経由なら CSRF token なしで PUT/DELETE が通る."""
+        client = APIClient(enforce_csrf_checks=True)
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.raw_api_key}')
+
+        put_payload = {
+            'event': self.event.id,
+            'detail_type': 'SPECIAL',
+            'start_time': '20:00:00',
+            'duration': 45,
+            'speaker': 'Updated Speaker',
+            'theme': 'Updated Theme',
+            'h1': 'Updated Title',
+            'contents': 'Updated contents',
+        }
+        put_response = client.put(
+            self.event_detail_api_detail_url, put_payload, format='json'
+        )
+        self.assertEqual(put_response.status_code, status.HTTP_200_OK)
+
+        delete_response = client.delete(self.event_detail_api_detail_url)
+        self.assertEqual(delete_response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_session_auth_post_without_csrf_token_is_forbidden(self):
+        """SessionAuth 経由の POST は CSRF token なしだと 403 で拒否される."""
+        client = APIClient(enforce_csrf_checks=True)
+        # `force_login` は session を張るが CSRF cookie/token は付与しないため、
+        # DRF の `SessionAuthentication.enforce_csrf` が 403 を返すことを確認する。
+        client.force_login(self.user)
+
+        response = client.post(
+            self.event_detail_api_url,
+            self._build_event_detail_payload(),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_session_auth_post_without_csrf_check_succeeds(self):
+        """`enforce_csrf_checks=False` の APIClient なら SessionAuth でも POST が通る.
+
+        これは既存のテストが force_authenticate / force_login で POST しているケースを
+        壊さないことを示す回帰テスト。
+        """
+        client = APIClient(enforce_csrf_checks=False)
+        client.force_login(self.user)
+
+        response = client.post(
+            self.event_detail_api_url,
+            self._build_event_detail_payload(),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_public_readonly_endpoints_allow_get_without_csrf(self):
+        """csrf_exempt を削除した公開 ReadOnlyModelViewSet の GET は 200 を返す.
+
+        GET メソッドは CSRF チェック対象外なので、`csrf_exempt` を外しても
+        匿名ユーザーがそのまま読めることを保証する。
+        """
+        client = APIClient(enforce_csrf_checks=True)
+
+        for url in (
+            '/api/v1/community/',
+            '/api/v1/event/',
+            '/api/v1/event_detail/',
+        ):
+            with self.subTest(url=url):
+                response = client.get(url)
+                self.assertEqual(
+                    response.status_code,
+                    status.HTTP_200_OK,
+                    msg=f'GET {url} should be publicly accessible without CSRF token',
+                )

--- a/app/api_v1/views.py
+++ b/app/api_v1/views.py
@@ -1,8 +1,6 @@
 # Create your views here.
 # from corsheaders.middleware import CorsMiddleware  # No longer needed
 from django.utils import timezone
-from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import csrf_exempt
 from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets, status
@@ -60,7 +58,6 @@ class CommunityFilter(filters.FilterSet):
         tags=["Community"]
     )
 )
-@method_decorator(csrf_exempt, name='dispatch')
 class CommunityViewSet(DatabaseReconnectListMixin, viewsets.ReadOnlyModelViewSet):
     queryset = Community.objects.filter(
         end_at__isnull=True,
@@ -136,7 +133,6 @@ class EventFilter(filters.FilterSet):
         tags=["Event"]
     )
 )
-@method_decorator(csrf_exempt, name='dispatch')
 class EventViewSet(DatabaseReconnectListMixin, viewsets.ReadOnlyModelViewSet):
     queryset = Event.objects.filter(
         date__gte=timezone.now().date(),
@@ -174,7 +170,6 @@ class EventDetailFilter(filters.FilterSet):
         tags=["EventDetail"]
     )
 )
-@method_decorator(csrf_exempt, name='dispatch')
 class EventDetailViewSet(DatabaseReconnectListMixin, viewsets.ReadOnlyModelViewSet):
     queryset = EventDetail.objects.filter(
         event__community__status='approved',


### PR DESCRIPTION
## Summary

improve-loop W2 #17

`app/api_v1/views.py` の `CommunityViewSet` / `EventViewSet` / `EventDetailViewSet` に付与されていた `@method_decorator(csrf_exempt, name='dispatch')` を削除し、DRF 標準動作に揃える。

## なぜ削除して安全か

| ViewSet | メソッド | 認証 | 影響 |
|---|---|---|---|
| `CommunityViewSet` (L63) | `ReadOnlyModelViewSet` (GET のみ) | 匿名可 | GET は CSRF 対象外なので挙動不変 |
| `EventViewSet` (L139) | `ReadOnlyModelViewSet` (GET のみ) | 匿名可 | 同上 |
| `EventDetailViewSet` (L177) | `ReadOnlyModelViewSet` (GET のみ) | 匿名可 | 同上 |

書き込み可能な `EventDetailAPIViewSet` / `RecurrenceRuleViewSet` は `authentication_classes = [APIKeyAuthentication, SessionAuthentication]` で、

- **APIKey 認証** (`Authorization: Bearer ...` / `X-API-KEY`) → DRF が CSRF check をスキップ
- **SessionAuthentication** (Cookie 認証) → DRF が CSRF token を要求

という DRF 標準動作にそのまま乗せれば、APIKey 経由の既存クライアント（VRChat ワールド / 外部スクリプト等）は無変更で動き、ブラウザの Cookie 経由でいきなり POST されるシナリオだけ CSRF token 必須になる。

## 既存クライアントへの影響

| クライアント種別 | 影響 |
|---|---|
| `Authorization: Bearer <APIKey>` / `X-API-KEY` を使う API クライアント (curl, スクリプト, VRChat ワールド) | **影響なし** (CSRF token 不要のまま) |
| `/api/v1/community/` `/api/v1/event/` `/api/v1/event_detail/` を GET する全クライアント | **影響なし** (GET は元から CSRF 対象外) |
| ブラウザの Cookie セッションで `/api/v1/event-details/` 等に POST するフロントエンド | **CSRF token 送信が必要になる** ← 該当する実装は現状の `templates/` から確認できる範囲では未確認だが、もし存在すれば 403 になるためフロント側で `X-CSRFToken` ヘッダ送信が必要 |

> ブラウザから SessionAuth で `/api/v1/event-details/` に POST する経路を持つフロントが既にあれば、CSRF token を送るよう修正が必要。なければ影響なし。

## 追加テスト (`app/api_v1/tests/test_csrf.py`)

- `test_api_key_post_succeeds_without_csrf_token`: APIKey で `enforce_csrf_checks=True` でも POST が 201
- `test_api_key_put_and_delete_succeed_without_csrf_token`: 同様に PUT/DELETE が成功
- `test_session_auth_post_without_csrf_token_is_forbidden`: SessionAuth + CSRF check + token なし → 403
- `test_session_auth_post_without_csrf_check_succeeds`: `enforce_csrf_checks=False` の APIClient なら通る (既存 `force_login` パターン保護)
- `test_public_readonly_endpoints_allow_get_without_csrf`: 3 つの ReadOnly エンドポイントの GET が 200

## Test plan

- [x] 新規 CSRF テスト 5 件が pass
- [x] `api_v1.tests` 全体 58 件 pass (`docker exec vrc-ta-hub-app python manage.py test api_v1.tests --keepdb --exclude-tag=external_api`)
- [ ] レビュアー側でフロントエンドが SessionAuth + Cookie で `/api/v1/event-details/` に POST していないか確認