### PR TITLE
feat(notifications): Discord Webhook 送信に tenacity リトライ (3回 exp backoff)

### DIFF
--- a/app/community/forms_processor.py
+++ b/app/community/forms_processor.py
@@ -17,6 +17,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from event.community_cleanup import cleanup_community_future_data
+from website.retry import retry_webhook_post
 
 from .models import Community, CommunityMember
 
@@ -24,6 +25,23 @@ logger = logging.getLogger(__name__)
 
 CleanupCommunityFutureData = Callable[..., dict[str, int]]
 UserLike = AbstractBaseUser | AnonymousUser
+
+# Discord Webhook 送信タイムアウト（秒）
+DISCORD_TIMEOUT_SECONDS = 10
+
+
+@retry_webhook_post
+def _post_discord_webhook(webhook_url: str, payload: dict) -> requests.Response:
+    """Discord Webhook へ POST する内部ヘルパー（tenacity リトライ付き）.
+
+    HTTP エラー (4xx/5xx) も raise_for_status で例外化し、リトライ対象とする。
+    最終的に失敗した場合は requests.RequestException 系を再送出する。
+    """
+    response = requests.post(
+        webhook_url, json=payload, timeout=DISCORD_TIMEOUT_SECONDS
+    )
+    response.raise_for_status()
+    return response
 
 
 def refresh_calendar_entry_and_event_cache(community: Community) -> None:
@@ -55,9 +73,11 @@ def notify_new_community_registration(community: Community, request: HttpRequest
         "content": f"**【新規集会登録】** {community.name}\n"
                    f"承認ページ: {waiting_list_url}"
     }
-    discord_timeout_seconds = 10
     try:
-        requests.post(settings.DISCORD_WEBHOOK_URL, json=discord_message, timeout=discord_timeout_seconds)
+        _post_discord_webhook(settings.DISCORD_WEBHOOK_URL, discord_message)
+    except requests.RequestException as e:
+        # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
+        logger.warning(f'Discord通知送信失敗（リトライ後）: {e}')
     except Exception as e:
         logger.warning(f'Discord通知送信失敗: {e}')
 

--- a/app/community/tests/test_forms_processor.py
+++ b/app/community/tests/test_forms_processor.py
@@ -137,11 +137,25 @@ class NotifyNewCommunityRegistrationTest(TestCase):
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/123/abc")
     @patch("community.forms_processor.requests.post")
     def test_swallows_request_exception(self, mock_post):
-        """requests 例外時もクラッシュしない (silent failure)"""
+        """requests 例外時もクラッシュしない (silent failure).
+
+        tenacity リトライ導入後は 3 回まで再試行されるため、回数ではなく
+        「例外を吸い込んで完了する」ことと「実際にリトライが行われた」ことを検証する。
+        テスト中はバックオフ待機を 0 秒化して高速化する。
+        """
+        from community.forms_processor import _post_discord_webhook
+
         mock_post.side_effect = requests.RequestException("network down")
-        # 例外を投げずに完了する
-        notify_new_community_registration(self.community, self.request)
-        mock_post.assert_called_once()
+        # tenacity のラップド関数経由でリトライ間 sleep を 0 秒に上書き
+        original_sleep = _post_discord_webhook.retry.sleep
+        _post_discord_webhook.retry.sleep = lambda *args, **kwargs: None
+        try:
+            # 例外を投げずに完了する
+            notify_new_community_registration(self.community, self.request)
+        finally:
+            _post_discord_webhook.retry.sleep = original_sleep
+        # 3 回再試行された（初回 + リトライ2回）
+        self.assertEqual(mock_post.call_count, 3)
 
 
 class CloseCommunityAndCleanupTest(TestCase):

--- a/app/event/notifications.py
+++ b/app/event/notifications.py
@@ -9,11 +9,26 @@ from django.urls import reverse
 
 from event.models import EventDetail
 from website.constants import build_site_url
+from website.retry import retry_webhook_post
 
 logger = logging.getLogger(__name__)
 
 # Discord Webhook送信タイムアウト（秒）
 DISCORD_TIMEOUT_SECONDS = 10
+
+
+@retry_webhook_post
+def _post_discord_webhook(webhook_url: str, payload: dict) -> requests.Response:
+    """Discord Webhook へ POST する内部ヘルパー（tenacity リトライ付き）.
+
+    HTTP エラー (4xx/5xx) も raise_for_status で例外化し、リトライ対象とする。
+    最終的に失敗した場合は requests.RequestException 系を再送出する。
+    """
+    response = requests.post(
+        webhook_url, json=payload, timeout=DISCORD_TIMEOUT_SECONDS
+    )
+    response.raise_for_status()
+    return response
 
 
 def _build_absolute_url(url: str) -> str:
@@ -237,17 +252,15 @@ def _send_discord_notification_for_new_application(
     }
 
     try:
-        response = requests.post(
-            webhook_url, json=message, timeout=DISCORD_TIMEOUT_SECONDS
+        response = _post_discord_webhook(webhook_url, message)
+        # raise_for_status を通っているので response.ok は常に True
+        logger.info(
+            f"Discord Webhook通知成功（新規申請）: Community={community.name}, "
+            f"status={response.status_code}"
         )
-        if response.ok:
-            logger.info(
-                f"Discord Webhook通知成功（新規申請）: Community={community.name}"
-            )
-        else:
-            logger.warning(
-                f"Discord Webhook通知失敗（新規申請）: status={response.status_code}"
-            )
+    except requests.RequestException as e:
+        # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
+        logger.error(f"Discord Webhook通知エラー（新規申請、リトライ後）: {e}")
     except Exception as e:
         logger.error(f"Discord Webhook通知エラー（新規申請）: {e}")
 
@@ -294,18 +307,14 @@ def _send_discord_notification_for_result(event_detail: EventDetail) -> None:
     }
 
     try:
-        response = requests.post(
-            webhook_url, json=message, timeout=DISCORD_TIMEOUT_SECONDS
+        _post_discord_webhook(webhook_url, message)
+        logger.info(
+            f"Discord Webhook通知成功（申請結果）: Community={community.name}, "
+            f"status={event_detail.status}"
         )
-        if response.ok:
-            logger.info(
-                f"Discord Webhook通知成功（申請結果）: Community={community.name}, "
-                f"status={event_detail.status}"
-            )
-        else:
-            logger.warning(
-                f"Discord Webhook通知失敗（申請結果）: status={response.status_code}"
-            )
+    except requests.RequestException as e:
+        # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
+        logger.error(f"Discord Webhook通知エラー（申請結果、リトライ後）: {e}")
     except Exception as e:
         logger.error(f"Discord Webhook通知エラー（申請結果）: {e}")
 
@@ -368,21 +377,19 @@ def notify_slide_material_published(event_detail: EventDetail) -> None:
     }
 
     try:
-        response = requests.post(
-            webhook_url, json=message, timeout=DISCORD_TIMEOUT_SECONDS,
+        _post_discord_webhook(webhook_url, message)
+        logger.info(
+            "Discord Webhook通知成功（資料公開）: Community=%s, EventDetail=%s",
+            community.name,
+            event_detail.pk,
         )
-        if response.ok:
-            logger.info(
-                "Discord Webhook通知成功（資料公開）: Community=%s, EventDetail=%s",
-                community.name,
-                event_detail.pk,
-            )
-        else:
-            logger.warning(
-                "Discord Webhook通知失敗（資料公開）: status=%s, EventDetail=%s",
-                response.status_code,
-                event_detail.pk,
-            )
+    except requests.RequestException as e:
+        # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
+        logger.error(
+            "Discord Webhook通知エラー（資料公開、リトライ後）: EventDetail=%s, error=%s",
+            event_detail.pk,
+            e,
+        )
     except Exception as e:
         logger.error(
             "Discord Webhook通知エラー（資料公開）: EventDetail=%s, error=%s",

--- a/app/event/tests/test_notifications.py
+++ b/app/event/tests/test_notifications.py
@@ -225,11 +225,24 @@ class DiscordNotificationForNewApplicationTest(TweetGenerationPatchMixin, TestCa
 
     @patch("event.notifications.requests.post")
     def test_swallows_request_exception(self, mock_post):
-        """requests 例外時もクラッシュしない（silent failure 検出）"""
+        """requests 例外時もクラッシュしない（silent failure 検出）.
+
+        tenacity リトライ導入後は 3 回まで再試行される。回数ではなく
+        「例外を吸い込んで完了する」ことを検証する。
+        テスト中はバックオフ待機を 0 秒化して高速化する。
+        """
+        from event.notifications import _post_discord_webhook
+
         mock_post.side_effect = requests.RequestException("network down")
-        # 例外を投げずに完了する
-        _send_discord_notification_for_new_application(self.event_detail, "https://example.com/review/1")
-        mock_post.assert_called_once()
+        original_sleep = _post_discord_webhook.retry.sleep
+        _post_discord_webhook.retry.sleep = lambda *args, **kwargs: None
+        try:
+            # 例外を投げずに完了する
+            _send_discord_notification_for_new_application(self.event_detail, "https://example.com/review/1")
+        finally:
+            _post_discord_webhook.retry.sleep = original_sleep
+        # 3 回再試行された（初回 + リトライ2回）
+        self.assertEqual(mock_post.call_count, 3)
 
     @patch("event.notifications.requests.post")
     def test_handles_non_ok_response(self, mock_post):
@@ -284,3 +297,79 @@ class DiscordNotificationForResultTest(TweetGenerationPatchMixin, TestCase):
         event_detail = _make_event_detail(self.event, applicant=self.applicant, status="approved")
         _send_discord_notification_for_result(event_detail)
         mock_post.assert_not_called()
+
+
+class DiscordWebhookRetryTest(TweetGenerationPatchMixin, TestCase):
+    """tenacity リトライ機構の挙動検証
+
+    一過性ネットワーク失敗で webhook が永遠に失われる問題を解消するため、
+    `_post_discord_webhook` に tenacity による 3 回まで指数バックオフリトライを
+    導入した。本テストはその振る舞いを mock で検証する。
+    """
+
+    def setUp(self):
+        self.owner = _make_user("owner1", "owner1@example.com")
+        self.applicant = _make_user("applicant1", "applicant1@example.com")
+        self.community = _make_community(owner=self.owner, webhook_url=WEBHOOK_URL)
+        self.event = _make_event(self.community)
+        self.event_detail = _make_event_detail(self.event, applicant=self.applicant)
+
+        # tenacity 内部の sleep を 0 秒化（テスト高速化）
+        from event.notifications import _post_discord_webhook
+        self._wrapped = _post_discord_webhook
+        self._original_sleep = self._wrapped.retry.sleep
+        self._wrapped.retry.sleep = lambda *args, **kwargs: None
+
+    def tearDown(self):
+        # sleep を元に戻す（他テストへの副作用を防ぐ）
+        self._wrapped.retry.sleep = self._original_sleep
+
+    @patch("event.notifications.requests.post")
+    def test_retries_until_success_on_second_attempt(self, mock_post):
+        """1 回目失敗 → 2 回目成功でリトライが動作する"""
+        success_response = MagicMock(ok=True, status_code=200)
+        # raise_for_status は成功時は何もしない（デフォルト MagicMock 挙動）
+        mock_post.side_effect = [
+            requests.RequestException("transient network error"),
+            success_response,
+        ]
+        _send_discord_notification_for_new_application(
+            self.event_detail, "https://example.com/review/1"
+        )
+        # 2 回呼ばれた（1 回目失敗 + 2 回目成功）
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch("event.notifications.requests.post")
+    def test_silent_failure_after_three_consecutive_failures(self, mock_post):
+        """3 回連続失敗で例外を吸い込み silent failure になる"""
+        mock_post.side_effect = requests.RequestException("network down")
+        # 例外を投げずに完了する（呼び出し元の try/except が最終失敗をキャッチ）
+        _send_discord_notification_for_new_application(
+            self.event_detail, "https://example.com/review/1"
+        )
+        # 3 回再試行された（初回 + リトライ2回）
+        self.assertEqual(mock_post.call_count, 3)
+
+    @patch("event.notifications.requests.post")
+    def test_no_retry_on_first_success(self, mock_post):
+        """1 回成功時の挙動が変わらない（後方互換性: リトライ無し）"""
+        mock_post.return_value = MagicMock(ok=True, status_code=200)
+        _send_discord_notification_for_new_application(
+            self.event_detail, "https://example.com/review/1"
+        )
+        # 成功なら 1 回しか呼ばれない（リトライしない）
+        self.assertEqual(mock_post.call_count, 1)
+
+    @patch("event.notifications.requests.post")
+    def test_retries_on_timeout_exception(self, mock_post):
+        """requests.Timeout もリトライ対象になる"""
+        mock_post.side_effect = [
+            requests.Timeout("read timeout"),
+            requests.Timeout("read timeout"),
+            MagicMock(ok=True, status_code=200),
+        ]
+        _send_discord_notification_for_new_application(
+            self.event_detail, "https://example.com/review/1"
+        )
+        # 3 回で成功
+        self.assertEqual(mock_post.call_count, 3)

--- a/app/website/retry.py
+++ b/app/website/retry.py
@@ -1,0 +1,61 @@
+"""Webhook 等の外部 POST に共有のリトライ戦略を提供する.
+
+`tenacity` を使い、ネットワーク起因の一過性エラー（requests.RequestException /
+requests.Timeout）に対して指数バックオフでリトライする。最終的に失敗した場合は
+例外を呼び出し元に再送出し、既存の try/except による silent failure ハンドリング
+を活かせる設計とする。
+"""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+# Webhook POST の最大試行回数（初回 + リトライ2回 = 計3回）
+WEBHOOK_RETRY_MAX_ATTEMPTS = 3
+# 指数バックオフの最小待機秒（1s, 2s, 4s, ... の系列）
+WEBHOOK_RETRY_WAIT_MIN_SECONDS = 1
+# 指数バックオフの最大待機秒（過剰な待ち時間を防ぐ）
+WEBHOOK_RETRY_WAIT_MAX_SECONDS = 10
+# 指数バックオフの multiplier（wait_exponential の係数）
+WEBHOOK_RETRY_WAIT_MULTIPLIER = 1
+
+
+def _log_retry_attempt(retry_state) -> None:
+    """tenacity の before_sleep フック: リトライ直前に warning ログを残す."""
+    exception = retry_state.outcome.exception() if retry_state.outcome else None
+    logger.warning(
+        "Webhook retry %s/%s after %s",
+        retry_state.attempt_number,
+        WEBHOOK_RETRY_MAX_ATTEMPTS,
+        exception,
+    )
+
+
+def retry_webhook_post(func):
+    """Discord Webhook 等の POST を 3 回まで指数バックオフでリトライするデコレータ.
+
+    - 対象例外: requests.RequestException / requests.Timeout（一過性のネットワーク失敗）
+    - リトライ間隔: 1s, 2s, 4s（exponential backoff, max 10s）
+    - 最終失敗時は元の例外を再送出する（reraise=True）
+    """
+    return retry(
+        stop=stop_after_attempt(WEBHOOK_RETRY_MAX_ATTEMPTS),
+        wait=wait_exponential(
+            multiplier=WEBHOOK_RETRY_WAIT_MULTIPLIER,
+            min=WEBHOOK_RETRY_WAIT_MIN_SECONDS,
+            max=WEBHOOK_RETRY_WAIT_MAX_SECONDS,
+        ),
+        retry=retry_if_exception_type((requests.RequestException, requests.Timeout)),
+        reraise=True,
+        before_sleep=_log_retry_attempt,
+    )(func)

--- a/requirements.lock
+++ b/requirements.lock
@@ -38,6 +38,8 @@ cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
+coverage==7.6.10
+    # via -r requirements.txt
 cryptography==48.0.0
     # via pyjwt
 distro==1.9.0
@@ -263,6 +265,8 @@ soupsieve==2.8.4
     # via beautifulsoup4
 sqlparse==0.5.5
     # via django
+tenacity==9.0.0
+    # via -r requirements.txt
 tinycss2==1.4.0
     # via -r requirements.txt
 tqdm==4.68.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ django-allauth[socialaccount]==65.18.0
 requests-oauthlib==2.0.0
 qrcode[pil]==8.0
 coverage==7.6.10
+tenacity==9.0.0


### PR DESCRIPTION
## 関連

improve-loop W3a #13

## 背景

Discord Webhook 送信が単発のネットワーク失敗で永遠に失われていた。
`event/notifications.py` と `community/forms_processor.py` の POST 部分には
`try/except` で例外を握りつぶす silent failure ハンドリングだけがあり、
一過性のタイムアウトや TCP リセットで通知が消える状態だった。

## 変更内容

### 新規ヘルパー: `app/website/retry.py`

`tenacity` を使った共有リトライデコレータ `retry_webhook_post` を定義:

- 3 回まで指数バックオフ (1s, 2s, 4s, max 10s) でリトライ
- 対象例外: `requests.RequestException` / `requests.Timeout`
- リトライ前は `warning` ログ (tenacity `before_sleep` フック)
- 最終失敗時は元の例外を再送出し、呼び出し元の `try/except` で `error` ログ
- `reraise=True` で既存の silent failure ハンドリングと互換

### 適用箇所

| ファイル | 関数 | 用途 |
|---|---|---|
| `app/event/notifications.py` | `_send_discord_notification_for_new_application` | 新規発表申請通知 |
| `app/event/notifications.py` | `_send_discord_notification_for_result` | 申請結果通知 |
| `app/event/notifications.py` | `notify_slide_material_published` | 資料公開通知 |
| `app/community/forms_processor.py` | `notify_new_community_registration` | 新規集会登録通知 |

各ファイルに内部ヘルパー `_post_discord_webhook(url, payload)` を追加し、
`raise_for_status()` で HTTP 4xx/5xx もリトライ対象化。
既存の `try/except` ハンドラはそのまま維持し、最終失敗のみログ記録される。

### 依存追加

- `requirements.txt` に `tenacity==9.0.0` を追加 (バージョン固定)
- `requirements.lock` を `uv pip compile` で再生成

## テスト

### 新規テスト: `DiscordWebhookRetryTest` (4 件)

`app/event/tests/test_notifications.py` に追加:

- `test_retries_until_success_on_second_attempt`: 1 回目失敗 → 2 回目成功
- `test_silent_failure_after_three_consecutive_failures`: 3 連続失敗で silent failure
- `test_no_retry_on_first_success`: 1 回成功時にリトライしない（後方互換）
- `test_retries_on_timeout_exception`: `requests.Timeout` もリトライ対象

`setUp` で `_post_discord_webhook.retry.sleep` を no-op に上書きし、
バックオフ秒数（1+2 秒）をテスト実行時間から除去している。

### 既存テストの更新

リトライ機構導入で `assert_called_once()` が壊れる 2 件を更新:

- `event.tests.test_notifications.DiscordNotificationForNewApplicationTest.test_swallows_request_exception`
- `community.tests.test_forms_processor.NotifyNewCommunityRegistrationTest.test_swallows_request_exception`

どちらも `mock_post.call_count == 3` を検証する形に変更。
テスト内で sleep を no-op 化して高速実行を維持。

## 検証

```bash
$ docker exec vrc-ta-hub-app python -c "from importlib.metadata import version; print(version('tenacity'))"
9.0.0

$ docker exec vrc-ta-hub-app python manage.py test event.tests.test_notifications --keepdb
Ran 22 tests in 0.129s
OK

$ docker exec vrc-ta-hub-app python manage.py test community.tests.test_forms_processor --keepdb
Ran 14 tests in 0.094s
OK
```

## 本番影響

- ランタイムには **影響あり** (意図通り):
  - Webhook が一過性失敗した場合に最大 7 秒程度の追加待機（1+2+4 秒）が発生
  - 同期処理なので呼び出し元が view であれば応答時間が伸びる可能性あり
  - 一方で通知の取りこぼしは大幅に減る
- 既存の Webhook 成功パスは挙動が変わらない（リトライしない）
- 既存ユーザー/データへの破壊的変更なし