### PR TITLE
refactor(twitter): tweet_generator.py 873行を generators/ サブパッケージに分割

### DIFF
--- a/app/twitter/generators/__init__.py
+++ b/app/twitter/generators/__init__.py
@@ -1,0 +1,13 @@
+"""X 自動告知ポスト生成のサブパッケージ。
+
+機能別にモジュール分割:
+- common: 共通定数・バリデーション・サニタイズ・整形ユーティリティ
+- retry: 文字数バリデーション付きリトライラッパー
+- lt_tweet: 発表 (LT) / 特別回告知
+- daily_reminder: 当日リマインダー
+- event_intro: スライド・記事共有 (過去発表資料の紹介)
+- community: 新規集会告知
+
+旧 `twitter.tweet_generator` 経由の import も互換シム経由で動作する。
+新規コードは `from twitter.generators import ...` を使うこと。
+"""

--- a/app/twitter/generators/common.py
+++ b/app/twitter/generators/common.py
@@ -1,0 +1,200 @@
+"""ツイート生成の共通ユーティリティ。
+
+- X の重み付き文字数カウント・本文行数カウント
+- 投稿前バリデーション (文字数 / 本文行数)
+- プロンプト用サニタイズ
+- 登壇者表示・曜日整形・ハッシュタグ整形
+- 決定的フォールバックで使う本文ビルダー (`_build_tweet` / `_trim_to_weight` / `_fit_candidate`)
+"""
+
+import re
+
+MAX_TWEET_TOKENS = 280
+LLM_TEMPERATURE = 0.7
+SANITIZE_MAX_LENGTH = 200
+
+TWEET_MAX_WEIGHTED_LENGTH = 280
+URL_WEIGHTED_LENGTH = 23
+RETRY_TARGET_CHARS_STEP = 20
+MAX_BODY_LINES = 3
+TRUNCATION_SUFFIX = "..."
+
+WEEKDAY_NAMES = {
+    "Sun": "日", "Mon": "月", "Tue": "火", "Wed": "水",
+    "Thu": "木", "Fri": "金", "Sat": "土",
+}
+
+BODY_LINE_CONSTRAINT = (
+    "- **本文は3行以内に収める（X のスパムフィルタ回避のため必須）**\n"
+    "  - 「本文」= URL行・ハッシュタグ行・空行を除いた実質的な告知テキスト行\n"
+    "  - 本文4行以上 + URL の組み合わせは X API が 403 で拒否する\n"
+    "  - 補足説明と誘導文は別行に分けず1行に統合する"
+)
+
+
+def count_tweet_length(text: str) -> int:
+    """X の重み付きカウント方式で文字数を返す。
+
+    - URL (https?://\\S+): 常に23としてカウント
+    - U+0000〜U+10FF の文字: 重み1
+    - U+1100 以上の文字 (CJK等): 重み2
+    """
+    url_pattern = re.compile(r"https?://\S+")
+    urls = url_pattern.findall(text)
+    text_without_urls = url_pattern.sub("", text)
+
+    weight = 0
+    for ch in text_without_urls:
+        weight += 2 if ord(ch) >= 0x1100 else 1
+
+    weight += len(urls) * URL_WEIGHTED_LENGTH
+    return weight
+
+
+def count_body_lines(text: str) -> int:
+    """URL行・ハッシュタグ行・空行を除いた本文行数を返す。
+
+    X API は「本文4行以上 + URL」の組み合わせをスパムフィルタで弾くため、
+    本文行を MAX_BODY_LINES 以下に保つバリデーションに用いる。
+    """
+    count = 0
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        if "https://" in stripped or "http://" in stripped:
+            continue
+        count += 1
+    return count
+
+
+def validate_tweet_text(text: str) -> list[str]:
+    """投稿前に満たすべき X 向け制約の違反理由を返す。"""
+    errors = []
+    length = count_tweet_length(text)
+    if length > TWEET_MAX_WEIGHTED_LENGTH:
+        errors.append(f"weighted_length={length}>{TWEET_MAX_WEIGHTED_LENGTH}")
+
+    body_lines = count_body_lines(text)
+    if body_lines > MAX_BODY_LINES:
+        errors.append(f"body_lines={body_lines}>{MAX_BODY_LINES}")
+
+    return errors
+
+
+def is_tweet_text_valid(text: str) -> bool:
+    """生成済み本文が X 投稿前制約を満たすか返す。"""
+    return not validate_tweet_text(text)
+
+
+def _build_tweet(body_lines: list[str], url: str, hashtag_suffix: str) -> str:
+    lines = [line.strip() for line in body_lines if line and line.strip()]
+    if url:
+        lines.extend(["", url.strip()])
+    hashtags = [line.strip() for line in hashtag_suffix.splitlines() if line.strip()]
+    lines.extend(hashtags)
+    return "\n".join(lines)
+
+
+def _trim_to_weight(text: str, max_weight: int) -> str:
+    if max_weight <= 0:
+        return ""
+    if count_tweet_length(text) <= max_weight:
+        return text
+
+    suffix = TRUNCATION_SUFFIX
+    suffix_weight = count_tweet_length(suffix)
+    if max_weight <= suffix_weight:
+        suffix = ""
+        suffix_weight = 0
+
+    chars = []
+    current = 0
+    for ch in text:
+        weight = 2 if ord(ch) >= 0x1100 else 1
+        if current + weight + suffix_weight > max_weight:
+            break
+        chars.append(ch)
+        current += weight
+
+    return "".join(chars).rstrip() + suffix
+
+
+def _fit_candidate(
+    body_lines: list[str],
+    url: str,
+    hashtag_suffix: str,
+    trim_indexes: list[int],
+) -> str | None:
+    candidate = _build_tweet(body_lines, url, hashtag_suffix)
+    if is_tweet_text_valid(candidate):
+        return candidate
+
+    fitted_lines = body_lines[:]
+    for index in trim_indexes:
+        if index >= len(fitted_lines):
+            continue
+
+        for _ in range(3):
+            candidate = _build_tweet(fitted_lines, url, hashtag_suffix)
+            overage = count_tweet_length(candidate) - TWEET_MAX_WEIGHTED_LENGTH
+            if overage <= 0:
+                break
+
+            current_line = fitted_lines[index]
+            current_weight = count_tweet_length(current_line)
+            fitted_lines[index] = _trim_to_weight(current_line, current_weight - overage)
+            if fitted_lines[index] == current_line:
+                break
+
+        candidate = _build_tweet(fitted_lines, url, hashtag_suffix)
+        if is_tweet_text_valid(candidate):
+            return candidate
+
+    return None
+
+
+def _validation_feedback(text: str) -> str:
+    length = count_tweet_length(text)
+    body_lines = count_body_lines(text)
+    overage = max(0, length - TWEET_MAX_WEIGHTED_LENGTH)
+    return (
+        f"前回出力は weighted_length={length}/{TWEET_MAX_WEIGHTED_LENGTH}, "
+        f"body_lines={body_lines}/{MAX_BODY_LINES} でした。"
+        f"{overage} weighted 以上短くし、補足文を最優先で削ってください。"
+    )
+
+
+def _sanitize_for_prompt(text: str, max_length: int = SANITIZE_MAX_LENGTH) -> str:
+    """プロンプトに埋め込む前のサニタイズ。
+
+    改行・制御文字を除去し、最大長で切り詰める。
+    """
+    if not text:
+        return ""
+    text = " ".join(text.split())
+    return text[:max_length]
+
+
+def _format_speaker_display(event_detail) -> str:
+    """登壇者名を告知本文用の敬称付き表記で返す。"""
+    speaker = _sanitize_for_prompt(event_detail.speaker)
+    display_name = f"{speaker}さん"
+    applicant = getattr(event_detail, "applicant", None)
+    x_account = _sanitize_for_prompt(getattr(applicant, "x_account", ""))
+    if x_account:
+        return f"{display_name}（@{x_account}）"
+    return display_name
+
+
+def _format_weekdays(weekdays: list) -> str:
+    """曜日リストを日本語文字列に変換する。"""
+    return "・".join([WEEKDAY_NAMES.get(d, d) for d in (weekdays or [])])
+
+
+def _build_hashtag_suffix(community) -> str:
+    """ハッシュタグ部分を構築する。"""
+    hashtag = f"#{community.twitter_hashtag}\n" if community.twitter_hashtag else ""
+    return f"{hashtag}#VRChat技術学術"

--- a/app/twitter/generators/community.py
+++ b/app/twitter/generators/community.py
@@ -1,0 +1,104 @@
+"""新規集会の告知ポスト生成。
+
+新しく登録された集会の最初の告知。初回開催日が決まっていれば日程も含める。
+"""
+
+from twitter.generators.common import (
+    WEEKDAY_NAMES,
+    BODY_LINE_CONSTRAINT,
+    _build_hashtag_suffix,
+    _fit_candidate,
+    _format_weekdays,
+    _sanitize_for_prompt,
+)
+from website.constants import build_site_url
+
+
+def _fallback_new_community_tweet(community, first_event=None) -> str | None:
+    weekdays_str = _format_weekdays(community.weekdays)
+    name = _sanitize_for_prompt(community.name)
+    url = f"詳細はこちら {build_site_url(f'/community/{community.pk}/')}"
+    hashtag_suffix = _build_hashtag_suffix(community)
+
+    if first_event:
+        weekday = WEEKDAY_NAMES.get(first_event.date.strftime("%a"), "")
+        schedule = f"{first_event.date.strftime('%-m/%-d')}({weekday}) {first_event.start_time.strftime('%H:%M')}~"
+    else:
+        schedule = f"{community.frequency} {weekdays_str}曜日 {community.start_time.strftime('%H:%M')}~"
+
+    body_lines = [
+        f"新しい集会「{name}」がはじまります",
+        schedule,
+    ]
+    return _fit_candidate(body_lines, url, hashtag_suffix, [0])
+
+
+def generate_new_community_tweet(
+    community,
+    first_event=None,
+    target_chars=140,
+    validation_feedback="",
+) -> str | None:
+    """新規集会の告知ポストを生成する。
+
+    Args:
+        community: Community モデルインスタンス
+        first_event: 初回 Event (あれば日程を含める)
+        target_chars: LLM に指示する目標文字数
+    """
+    from twitter import tweet_generator
+
+    system_prompt = (
+        "あなたはVRChat技術学術系集会の告知ポストを作成するライターです。"
+        "「参加したい」と思わせる告知を書いてください。"
+    )
+
+    weekdays_str = _format_weekdays(community.weekdays)
+
+    event_info = ""
+    if first_event:
+        event_info = (
+            f"\n初回開催日: {first_event.date.strftime('%-m/%-d')}({WEEKDAY_NAMES.get(first_event.date.strftime('%a'), '')})"
+            f" {first_event.start_time.strftime('%H:%M')}~"
+        )
+
+    hashtag_suffix = _build_hashtag_suffix(community)
+    community_url = build_site_url(f"/community/{community.pk}/")
+    name = _sanitize_for_prompt(community.name)
+    description = _sanitize_for_prompt(community.description) or "(なし)"
+
+    user_prompt = f"""以下の新しいVRChat集会の告知ポストを作成してください。
+
+集会名: {name}
+開催: {community.frequency} {weekdays_str}曜日 {community.start_time.strftime('%H:%M')}~
+紹介: {description}{event_info}
+{validation_feedback}
+
+## 必須要素（必ず本文に含めること）
+1. 集会名
+2. 開催スケジュール（曜日・時刻）
+3. どんな人向けか / 何が得られるか（紹介文から1行で）
+
+## 出力フォーマット（本文は3行以内）
+
+新しい集会「{{集会名}}」がはじまります
+
+{{開催スケジュール}}
+{{対象者 + 何が得られるかを1行に統合}}
+
+詳細はこちら {{URL}}
+{{ハッシュタグ}}
+
+## スタイル
+- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
+{BODY_LINE_CONSTRAINT}
+- 「こんな集会が始まりました」ではなく「こういう人は来て」というトーン
+- 末尾に以下を必ず含める:
+  詳細はこちら {community_url}
+  {hashtag_suffix}
+- 意味のまとまり（日時・テーマ・補足・リンク・ハッシュタグ）ごとに空行を入れて読みやすくする
+- ハッシュタグは末尾に指定されたもののみ使用（自分で追加・変形しない）
+- 句点（。）を一切使わない（「〜です。」「〜ます。」も禁止。「〜です」「〜ます」で止める）
+    - ポスト本文のみ出力（説明不要）
+"""
+    return tweet_generator._call_llm(system_prompt, user_prompt)

--- a/app/twitter/generators/daily_reminder.py
+++ b/app/twitter/generators/daily_reminder.py
@@ -1,0 +1,150 @@
+"""当日リマインダーポストの生成。
+
+その日開催される集会の発表一覧を「今夜 HH:MM〜」の形でまとめる。
+"""
+
+import logging
+
+from twitter.generators.common import (
+    BODY_LINE_CONSTRAINT,
+    _build_hashtag_suffix,
+    _fit_candidate,
+    _format_speaker_display,
+    _sanitize_for_prompt,
+)
+from website.constants import build_site_url
+
+logger = logging.getLogger(__name__)
+
+
+def _fallback_daily_reminder_tweet(event) -> str | None:
+    details = list(
+        event.details.filter(
+            status="approved",
+            detail_type__in=("LT", "SPECIAL"),
+        ).order_by("start_time", "pk")
+    )
+    if not details:
+        return None
+
+    community = event.community
+    name = _sanitize_for_prompt(community.name)
+    url = f"詳細はこちら {build_site_url(f'/community/{community.pk}/')}"
+    hashtag_suffix = _build_hashtag_suffix(community)
+
+    for count in range(min(3, len(details)), 0, -1):
+        body_lines = [f"今夜 {event.start_time.strftime('%H:%M')}〜 {name}"]
+        for detail in details[:count]:
+            body_lines.append(
+                f"{_format_speaker_display(detail)}"
+                f"「{_sanitize_for_prompt(detail.theme)}」"
+            )
+        fitted = _fit_candidate(
+            body_lines,
+            url,
+            hashtag_suffix,
+            list(range(len(body_lines) - 1, -1, -1)),
+        )
+        if fitted:
+            return fitted
+
+    return None
+
+
+def generate_daily_reminder_tweet(event, target_chars=140, validation_feedback="") -> str | None:
+    """当日開催イベントのリマインダーポストを生成する。"""
+    from twitter import tweet_generator
+
+    approved_details = list(
+        event.details.filter(
+            status="approved",
+            detail_type__in=("LT", "SPECIAL"),
+        ).order_by("start_time", "pk")
+    )
+    if not approved_details:
+        logger.warning("No approved LT/SPECIAL details found for Event %s", event.pk)
+        return None
+
+    community = event.community
+    hashtag_suffix = _build_hashtag_suffix(community)
+    community_url = build_site_url(f"/community/{community.pk}/")
+
+    presentations = []
+    for detail in approved_details[:3]:
+        label = "発表" if detail.detail_type == "LT" else "特別回"
+        speaker_display = _format_speaker_display(detail)
+        theme = _sanitize_for_prompt(detail.theme)
+        presentations.append(f"- {label}: {speaker_display}「{theme}」")
+
+    more_count = len(approved_details) - len(presentations)
+    extra_line = f"\n- ほか {more_count} 件" if more_count > 0 else ""
+
+    system_prompt = (
+        "あなたはVRChat集会の当日リマインダーポストを書くライターです。"
+        "「誰が」「どんなテーマで」話すのかを主役にして、読んだ人が「聞きたい」と思える告知を書いてください。"
+    )
+
+    name = _sanitize_for_prompt(community.name)
+    presentation_count = len(approved_details)
+    user_prompt = f"""以下のイベント当日リマインダーポストを作成してください。
+
+集会名: {name}
+開催: 今夜 {event.start_time.strftime('%H:%M')}~
+登録発表数: {presentation_count}件（※この数字は本文に書かない。背景情報として参照するだけ）
+発表一覧:
+{chr(10).join(presentations)}{extra_line}
+{validation_feedback}
+
+## 出力フォーマット（本文は3行以内、この構造に厳密に従うこと）
+
+### 発表が1件の場合
+今夜 {{時刻}}〜 {{集会名}}
+
+{{登壇者表記1}}「{{テーマ1}}」
+{{テーマ1の補足 + 参加誘導を1行に統合}}
+
+詳細はこちら {{URL}}
+{{ハッシュタグ}}
+
+### 発表が2件の場合
+今夜 {{時刻}}〜 {{集会名}}
+
+{{登壇者表記1}}「{{テーマ1}}」
+{{登壇者表記2}}「{{テーマ2}}」
+
+詳細はこちら {{URL}}
+{{ハッシュタグ}}
+
+### 発表が3件以上の場合（4件以上なら上位3件＋「ほかN件」）
+今夜 {{時刻}}〜 {{集会名}}
+{{登壇者表記1}}「{{テーマ1}}」
+{{登壇者表記2}}「{{テーマ2}}」／{{登壇者表記3}}「{{テーマ3}}」
+
+詳細はこちら {{URL}}
+{{ハッシュタグ}}
+
+## ルール
+- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
+{BODY_LINE_CONSTRAINT}
+- 1行目は「今夜 {event.start_time.strftime('%H:%M')}〜 {name}」の形式で、今日の開催であることと時刻が一目で伝わるようにする（日付表記は禁止）
+- 各発表は発表一覧の登壇者表記をそのまま使い、「○○さん「テーマ名」」または「○○さん（@handle）「テーマ名」」の形式で記載する
+  - テーマ名は発表一覧のものをそのまま使う（言い換え・要約・省略禁止）
+  - Xアカウントがある登壇者は「（@handle）」も含める
+- **発表数の言及禁止**: 「発表は1件」「全○件」「○本立て」「N件の発表」など、発表の本数を伝える表現は本文に一切書かない（通常1件なので情報価値がない）
+- 発表が1件の場合は、発表行の直後に「テーマの補足 + 参加誘導」を**1行に統合**して入れる
+  - 補足と誘導は別行に分けず、1文にまとめる（本文3行制約のため必須）
+  - 補足は発表一覧に含まれるキーワードや背景知識から自然に膨らませる（事実の捏造は禁止）
+- 発表が2件以上の場合は補足・誘導を省略し、発表行のみ並べる（本文3行に収めるため）
+- 発表が4件以上の場合は上位3件を記載し、残りは「ほかN件」としてテーマ3の行末にまとめる
+- 散文や自然文で発表内容をまとめない（一覧形式を崩さない）
+- 末尾に以下を必ず含める:
+  詳細はこちら {community_url}
+  {hashtag_suffix}
+- 空行の入れ方は**本文3行制約を最優先**に決める
+  - 発表1件: 集会名の後・発表ブロックの後に空行（出力例の「### 発表が1件の場合」参照）
+  - 発表2件以上: 本文行を詰めて配置（出力例の対応ブロック参照）。URL/ハッシュタグとの間にのみ空行を入れる
+- ハッシュタグは末尾に指定されたもののみ使用（自分で追加・変形しない）
+- 句点（。）を一切使わない
+    - ポスト本文のみ出力（説明不要）
+"""
+    return tweet_generator._call_llm(system_prompt, user_prompt)

--- a/app/twitter/generators/event_intro.py
+++ b/app/twitter/generators/event_intro.py
@@ -1,0 +1,105 @@
+"""イベント紹介 (過去発表資料の共有) ポスト生成。
+
+公開済みスライド・動画への誘導ポストを LLM で生成する。
+"""
+
+from twitter.generators.common import (
+    BODY_LINE_CONSTRAINT,
+    _build_hashtag_suffix,
+    _fit_candidate,
+    _sanitize_for_prompt,
+)
+from website.constants import build_site_url
+
+
+def _fallback_slide_share_tweet(event_detail) -> str | None:
+    community = event_detail.event.community
+    resources = []
+    if event_detail.slide_url or event_detail.slide_file:
+        resources.append("スライド")
+    if event_detail.youtube_url:
+        resources.append("動画")
+    resources_text = "・".join(resources) or "資料"
+    body_lines = [
+        (
+            f"{_sanitize_for_prompt(community.name)} "
+            f"{_sanitize_for_prompt(event_detail.speaker)}さん"
+            f"「{_sanitize_for_prompt(event_detail.theme)}」"
+        ),
+        f"{resources_text}が公開されました",
+    ]
+    url = f"詳細はこちら {build_site_url(f'/event/detail/{event_detail.pk}/')}"
+    return _fit_candidate(body_lines, url, _build_hashtag_suffix(community), [0])
+
+
+def generate_slide_share_tweet(event_detail, target_chars=140, validation_feedback="") -> str | None:
+    """スライド/記事共有ポストを生成する。
+
+    Args:
+        event_detail: EventDetail モデルインスタンス（slide_url または youtube_url が設定済み）
+        target_chars: LLM に指示する目標文字数
+    """
+    from twitter import tweet_generator
+
+    system_prompt = (
+        "あなたはVRChat集会の発表資料を紹介するライターです。"
+        "「この資料、読んでみたい」と思わせるポストを書いてください。"
+    )
+
+    event = event_detail.event
+    community = event.community
+    hashtag_suffix = _build_hashtag_suffix(community)
+    detail_url = build_site_url(f"/event/detail/{event_detail.pk}/")
+
+    name = _sanitize_for_prompt(community.name)
+    speaker = _sanitize_for_prompt(event_detail.speaker)
+    theme = _sanitize_for_prompt(event_detail.theme)
+
+    # 公開リソースの種類をフラグで判定（URLはプロンプトに含めない）
+    resources = []
+    if event_detail.slide_url or event_detail.slide_file:
+        resources.append("スライド")
+    if event_detail.youtube_url:
+        resources.append("動画")
+    resources_text = "・".join(resources)
+
+    user_prompt = f"""以下の発表の{resources_text}が公開されたことを伝えるポストを作成してください。
+
+集会名: {name}
+発表者: {speaker}
+テーマ: {theme}
+公開された資料: {resources_text}
+{validation_feedback}
+
+## 必須要素（必ず本文に含めること）
+1. 集会名（「{name}」）
+2. 発表者名（敬称は「さん」を付ける）
+3. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
+4. {resources_text}が公開されたこと
+5. 内容の補足と次のアクション（資料を見る・チェックする等）への誘導を**1行にまとめる**（本文3行制約のため別行にしない）
+
+## 出力フォーマット（本文は3行以内）
+
+{{集会名}} {{発表者}}さん「{{テーマ}}」
+
+{{resources_text}}が公開されました
+{{内容補足 + 閲覧誘導を1行に統合}}
+
+詳細はこちら {{URL}}
+{{ハッシュタグ}}
+
+## スタイル
+- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
+{BODY_LINE_CONSTRAINT}
+- 日付は不要（過去のイベントなので）
+- テーマ名をそのまま書いた上で、「読むと何がわかるか」を1文で補足する
+- 誘導の一文は毎回異なる自然な表現にする（「〜な方はチェック」のような定型文の繰り返し禁止）
+- 末尾に以下を必ず含める:
+  詳細はこちら {detail_url}
+  {hashtag_suffix}
+- 意味のまとまり（日時・テーマ・補足・リンク・ハッシュタグ）ごとに空行を入れて読みやすくする
+- ハッシュタグは末尾に指定されたもののみ使用（自分で追加・変形しない）
+- 句点（。）を一切使わない（「〜です。」「〜ます。」も禁止。「〜です」「〜ます」で止める）
+    - ポスト本文のみ出力（説明不要）
+"""
+    return tweet_generator._call_llm(system_prompt, user_prompt)

--- a/app/twitter/generators/lt_tweet.py
+++ b/app/twitter/generators/lt_tweet.py
@@ -1,0 +1,161 @@
+"""発表 (LT) / 特別回告知ポストの生成。
+
+LLM 呼び出し本体 (`_call_llm`) は `twitter.tweet_generator` 経由で参照する。
+これは `@patch("twitter.tweet_generator._call_llm")` を使う既存テストとの後方互換性のため。
+"""
+
+from twitter.generators.common import (
+    WEEKDAY_NAMES,
+    BODY_LINE_CONSTRAINT,
+    _build_hashtag_suffix,
+    _fit_candidate,
+    _format_speaker_display,
+    _sanitize_for_prompt,
+)
+from website.constants import build_site_url
+
+
+def _fallback_presentation_tweet(event_detail, *, special: bool = False) -> str | None:
+    event = event_detail.event
+    community = event.community
+    weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
+    label = " 特別回" if special else ""
+    speaker_display = _format_speaker_display(event_detail)
+    body_lines = [
+        f"{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~ {_sanitize_for_prompt(community.name)}{label}",
+        f"{speaker_display}「{_sanitize_for_prompt(event_detail.theme)}」",
+    ]
+    url = f"詳細はこちら {build_site_url(f'/community/{community.pk}/')}"
+    return _fit_candidate(body_lines, url, _build_hashtag_suffix(community), [1, 0])
+
+
+def generate_lt_tweet(event_detail, target_chars=140, validation_feedback="") -> str | None:
+    """発表告知ポストを生成する。
+
+    Args:
+        event_detail: EventDetail モデルインスタンス (detail_type='LT')
+        target_chars: LLM に指示する目標文字数
+    """
+    # _call_llm を遅延 import (シム側 namespace を参照して @patch を有効にする)
+    from twitter import tweet_generator
+
+    system_prompt = (
+        "あなたはVRChat集会の発表告知ポストを書くライターです。"
+        "読んだ人が「聞きたい」「行きたい」と思う告知を書いてください。"
+    )
+
+    event = event_detail.event
+    community = event.community
+    hashtag_suffix = _build_hashtag_suffix(community)
+    community_url = build_site_url(f"/community/{community.pk}/")
+    weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
+
+    name = _sanitize_for_prompt(community.name)
+    speaker_display = _format_speaker_display(event_detail)
+    theme = _sanitize_for_prompt(event_detail.theme)
+
+    user_prompt = f"""以下の発表の告知ポストを作成してください。
+
+集会名: {name}
+日時: {event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~
+発表者: {speaker_display}
+テーマ: {theme}
+{validation_feedback}
+
+## 必須要素（必ず本文に含めること）
+1. 集会名（「{name}」）
+2. 開催日時（「{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~」の形式で）
+3. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
+4. 発表者（「{speaker_display}」をそのまま記載）
+5. テーマの補足説明と次のアクション（聞きに来る・詳細を見る等）への誘導を**1行にまとめる**（本文3行制約のため別行にしない）
+
+## 出力フォーマット（本文は3行以内）
+
+{{日時}} {{集会名}}
+
+{{発表者}}「{{テーマ}}」
+{{テーマ補足 + 参加誘導を1行に統合}}
+
+詳細はこちら {{URL}}
+{{ハッシュタグ}}
+
+## スタイル
+- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
+{BODY_LINE_CONSTRAINT}
+- テーマ名をそのまま書いた上で、何が聞けるかを1文で補足する
+- 誘導の一文は毎回異なる自然な表現にする（「このテーマが気になる人は聞きに来て」のような定型文の繰り返し禁止）
+- 末尾に以下を必ず含める:
+  詳細はこちら {community_url}
+  {hashtag_suffix}
+- 意味のまとまり（日時・テーマ・補足・リンク・ハッシュタグ）ごとに空行を入れて読みやすくする
+- ハッシュタグは末尾に指定されたもののみ使用（自分で追加・変形しない）
+- 句点（。）を一切使わない（「〜です。」「〜ます。」も禁止。「〜です」「〜ます」で止める）
+    - ポスト本文のみ出力（説明不要）
+"""
+    return tweet_generator._call_llm(system_prompt, user_prompt)
+
+
+def generate_special_event_tweet(event_detail, target_chars=140, validation_feedback="") -> str | None:
+    """特別回告知ポストを生成する。
+
+    Args:
+        event_detail: EventDetail モデルインスタンス (detail_type='SPECIAL')
+        target_chars: LLM に指示する目標文字数
+    """
+    from twitter import tweet_generator
+
+    system_prompt = (
+        "あなたはVRChat集会の特別イベント告知ポストを書くライターです。"
+        "通常回とは違う特別な回であることを伝え、「行きたい」と思わせてください。"
+    )
+
+    event = event_detail.event
+    community = event.community
+    hashtag_suffix = _build_hashtag_suffix(community)
+    community_url = build_site_url(f"/community/{community.pk}/")
+    weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
+
+    name = _sanitize_for_prompt(community.name)
+    speaker = _sanitize_for_prompt(event_detail.speaker)
+    theme = _sanitize_for_prompt(event_detail.theme)
+
+    user_prompt = f"""以下の特別イベントの告知ポストを作成してください。
+
+集会名: {name}
+日時: {event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~
+発表者/ゲスト: {speaker}
+テーマ: {theme}
+{validation_feedback}
+
+## 必須要素（必ず本文に含めること）
+1. 集会名（「{name}」）
+2. 「特別回」であること
+3. 開催日時（「{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~」の形式で）
+4. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
+5. 発表者/ゲスト名（敬称は「さん」を付ける）
+6. テーマの補足説明と次のアクション（聞きに来る・詳細を見る等）への誘導を**1行にまとめる**（本文3行制約のため別行にしない）
+
+## 出力フォーマット（本文は3行以内）
+
+{{日時}} {{集会名}} 特別回
+
+{{発表者}}さん「{{テーマ}}」
+{{テーマ補足 + 参加誘導を1行に統合}}
+
+詳細はこちら {{URL}}
+{{ハッシュタグ}}
+
+## スタイル
+- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
+{BODY_LINE_CONSTRAINT}
+- テーマ名をそのまま書いた上で、特別回ならではの見どころを1文で補足する
+- 誘導の一文は毎回異なる自然な表現にする（「このテーマに興味ある人は来て」のような定型文の繰り返し禁止）
+- 末尾に以下を必ず含める:
+  詳細はこちら {community_url}
+  {hashtag_suffix}
+- 意味のまとまり（日時・テーマ・補足・リンク・ハッシュタグ）ごとに空行を入れて読みやすくする
+- ハッシュタグは末尾に指定されたもののみ使用（自分で追加・変形しない）
+- 句点（。）を一切使わない（「〜です。」「〜ます。」も禁止。「〜です」「〜ます」で止める）
+    - ポスト本文のみ出力（説明不要）
+"""
+    return tweet_generator._call_llm(system_prompt, user_prompt)

--- a/app/twitter/generators/retry.py
+++ b/app/twitter/generators/retry.py
@@ -1,0 +1,114 @@
+"""ツイート生成のリトライラッパー。
+
+LLM 生成関数を文字数バリデーション付きで実行し、違反時は target_chars を
+段階的に減らしてリトライ。最終フォールバックとして決定的圧縮関数を呼ぶ。
+"""
+
+import inspect
+import logging
+from typing import Any, Callable, Optional
+
+from twitter.generators.common import (
+    RETRY_TARGET_CHARS_STEP,
+    _validation_feedback,
+    count_body_lines,
+    count_tweet_length,
+    is_tweet_text_valid,
+    validate_tweet_text,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _call_generate_fn(
+    generate_fn: Callable[..., Optional[str]],
+    *args: Any,
+    target_chars: int,
+    validation_feedback: str,
+    **kwargs: Any,
+) -> Optional[str]:
+    parameters = inspect.signature(generate_fn).parameters
+    accepts_feedback = (
+        "validation_feedback" in parameters
+        or any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
+    )
+    if accepts_feedback:
+        return generate_fn(
+            *args,
+            target_chars=target_chars,
+            validation_feedback=validation_feedback,
+            **kwargs,
+        )
+    return generate_fn(*args, target_chars=target_chars, **kwargs)
+
+
+def _generate_with_retry(
+    generate_fn: Callable[..., Optional[str]],
+    *args: Any,
+    max_retries: int = 3,
+    fallback_fn: Optional[Callable[..., Optional[str]]] = None,
+    **kwargs: Any,
+) -> Optional[str]:
+    """生成関数をリトライラッパーで実行する。
+
+    1. target_chars=140 で生成
+    2. count_tweet_length() と count_body_lines() でバリデーション
+       （文字数 <= TWEET_MAX_WEIGHTED_LENGTH かつ 本文行数 <= MAX_BODY_LINES）
+    3. どちらか違反していたら target_chars を RETRY_TARGET_CHARS_STEP ずつ減らしてリトライ
+    4. max_retries 回リトライ後も違反している場合は決定的な圧縮にフォールバック
+    """
+    target_chars = 140
+    result = None
+    validation_feedback = ""
+
+    for attempt in range(max_retries + 1):
+        result = _call_generate_fn(
+            generate_fn,
+            *args,
+            target_chars=target_chars,
+            validation_feedback=validation_feedback,
+            **kwargs,
+        )
+        if result is None:
+            return None
+
+        errors = validate_tweet_text(result)
+
+        if not errors:
+            if attempt > 0:
+                logger.info(
+                    "Tweet validation OK after %d retries (weighted=%d, body_lines=%d, target_chars=%d)",
+                    attempt,
+                    count_tweet_length(result),
+                    count_body_lines(result),
+                    target_chars,
+                )
+            return result
+
+        logger.warning(
+            "Tweet validation failed (%s, attempt=%d/%d, target_chars=%d). Retrying.",
+            ", ".join(errors),
+            attempt + 1,
+            max_retries + 1,
+            target_chars,
+        )
+        validation_feedback = _validation_feedback(result)
+        target_chars -= RETRY_TARGET_CHARS_STEP
+
+    if fallback_fn is None:
+        return None
+
+    fallback_result = fallback_fn(*args)
+    if fallback_result and is_tweet_text_valid(fallback_result):
+        logger.info(
+            "Tweet deterministic fallback succeeded (weighted=%d, body_lines=%d)",
+            count_tweet_length(fallback_result),
+            count_body_lines(fallback_result),
+        )
+        return fallback_result
+
+    logger.error(
+        "Tweet deterministic fallback failed after generation retries: %s",
+        validate_tweet_text(fallback_result or ""),
+    )
+    return None

--- a/app/twitter/tweet_generator.py
+++ b/app/twitter/tweet_generator.py
@@ -1,380 +1,84 @@
-"""X 自動告知ポストの生成
+"""tweet_generator 互換シム (後方互換性のため re-export)
 
-OpenRouter API 経由で LLM を呼び出し、各種告知ポストを生成する。
-既存の twitter/utils.py (テンプレートベース生成) とは独立したモジュール。
+実装は `twitter.generators.*` サブパッケージへ分割済み:
+- common: 共通定数・バリデーション・サニタイズ・整形ユーティリティ
+- retry: 文字数バリデーション付きリトライラッパー
+- lt_tweet: 発表 (LT) / 特別回告知
+- daily_reminder: 当日リマインダー
+- event_intro: スライド・記事共有
+- community: 新規集会告知
+
+新規コードは `from twitter.generators import ...` を使うこと。
+本ファイルは段階的に削除予定だが、以下の理由で当面は残す:
+
+1. `signals.py` / `x_api.py` / `utils.py` など外部参照の後方互換
+2. テストの `@patch("twitter.tweet_generator._call_llm")` 等のモジュールパス指定
+   - `_call_llm` 本体はこの module 内に置き、各サブモジュールは
+     `from twitter import tweet_generator` を遅延 import して
+     `tweet_generator._call_llm(...)` 経由で呼ぶことで patch が効く
+3. `@patch("twitter.tweet_generator.OpenAI")` / `connections.close_all` も
+   `_call_llm` がここに居ることで成立
 """
 
-import inspect
 import logging
 import os
-import re
-from typing import Any, Callable, Optional
 
 from django.conf import settings
 from django.db import connections
 from openai import OpenAI
 
 from ta_hub.libs import cloudflare_image_url
+from twitter.generators.common import (  # noqa: F401
+    BODY_LINE_CONSTRAINT,
+    LLM_TEMPERATURE,
+    MAX_BODY_LINES,
+    MAX_TWEET_TOKENS,
+    RETRY_TARGET_CHARS_STEP,
+    SANITIZE_MAX_LENGTH,
+    TRUNCATION_SUFFIX,
+    TWEET_MAX_WEIGHTED_LENGTH,
+    URL_WEIGHTED_LENGTH,
+    WEEKDAY_NAMES,
+    _build_hashtag_suffix,
+    _build_tweet,
+    _fit_candidate,
+    _format_speaker_display,
+    _format_weekdays,
+    _sanitize_for_prompt,
+    _trim_to_weight,
+    _validation_feedback,
+    count_body_lines,
+    count_tweet_length,
+    is_tweet_text_valid,
+    validate_tweet_text,
+)
+from twitter.generators.community import (  # noqa: F401
+    _fallback_new_community_tweet,
+    generate_new_community_tweet,
+)
+from twitter.generators.daily_reminder import (  # noqa: F401
+    _fallback_daily_reminder_tweet,
+    generate_daily_reminder_tweet,
+)
+from twitter.generators.event_intro import (  # noqa: F401
+    _fallback_slide_share_tweet,
+    generate_slide_share_tweet,
+)
+from twitter.generators.lt_tweet import (  # noqa: F401
+    _fallback_presentation_tweet,
+    generate_lt_tweet,
+    generate_special_event_tweet,
+)
+from twitter.generators.retry import (  # noqa: F401
+    _call_generate_fn,
+    _generate_with_retry,
+)
 from website.constants import (
     OPENROUTER_BASE_URL,
     build_openrouter_extra_headers,
-    build_site_url,
 )
 
 logger = logging.getLogger(__name__)
-
-MAX_TWEET_TOKENS = 280
-LLM_TEMPERATURE = 0.7
-SANITIZE_MAX_LENGTH = 200
-
-TWEET_MAX_WEIGHTED_LENGTH = 280
-URL_WEIGHTED_LENGTH = 23
-RETRY_TARGET_CHARS_STEP = 20
-MAX_BODY_LINES = 3
-TRUNCATION_SUFFIX = "..."
-
-WEEKDAY_NAMES = {
-    "Sun": "日", "Mon": "月", "Tue": "火", "Wed": "水",
-    "Thu": "木", "Fri": "金", "Sat": "土",
-}
-
-
-def count_tweet_length(text: str) -> int:
-    """X の重み付きカウント方式で文字数を返す。
-
-    - URL (https?://\\S+): 常に23としてカウント
-    - U+0000〜U+10FF の文字: 重み1
-    - U+1100 以上の文字 (CJK等): 重み2
-    """
-    url_pattern = re.compile(r"https?://\S+")
-    urls = url_pattern.findall(text)
-    text_without_urls = url_pattern.sub("", text)
-
-    weight = 0
-    for ch in text_without_urls:
-        weight += 2 if ord(ch) >= 0x1100 else 1
-
-    weight += len(urls) * URL_WEIGHTED_LENGTH
-    return weight
-
-
-def count_body_lines(text: str) -> int:
-    """URL行・ハッシュタグ行・空行を除いた本文行数を返す。
-
-    X API は「本文4行以上 + URL」の組み合わせをスパムフィルタで弾くため、
-    本文行を MAX_BODY_LINES 以下に保つバリデーションに用いる。
-    """
-    count = 0
-    for line in text.split("\n"):
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if stripped.startswith("#"):
-            continue
-        if "https://" in stripped or "http://" in stripped:
-            continue
-        count += 1
-    return count
-
-
-def validate_tweet_text(text: str) -> list[str]:
-    """投稿前に満たすべき X 向け制約の違反理由を返す。"""
-    errors = []
-    length = count_tweet_length(text)
-    if length > TWEET_MAX_WEIGHTED_LENGTH:
-        errors.append(f"weighted_length={length}>{TWEET_MAX_WEIGHTED_LENGTH}")
-
-    body_lines = count_body_lines(text)
-    if body_lines > MAX_BODY_LINES:
-        errors.append(f"body_lines={body_lines}>{MAX_BODY_LINES}")
-
-    return errors
-
-
-def is_tweet_text_valid(text: str) -> bool:
-    """生成済み本文が X 投稿前制約を満たすか返す。"""
-    return not validate_tweet_text(text)
-
-
-def _build_tweet(body_lines: list[str], url: str, hashtag_suffix: str) -> str:
-    lines = [line.strip() for line in body_lines if line and line.strip()]
-    if url:
-        lines.extend(["", url.strip()])
-    hashtags = [line.strip() for line in hashtag_suffix.splitlines() if line.strip()]
-    lines.extend(hashtags)
-    return "\n".join(lines)
-
-
-def _trim_to_weight(text: str, max_weight: int) -> str:
-    if max_weight <= 0:
-        return ""
-    if count_tweet_length(text) <= max_weight:
-        return text
-
-    suffix = TRUNCATION_SUFFIX
-    suffix_weight = count_tweet_length(suffix)
-    if max_weight <= suffix_weight:
-        suffix = ""
-        suffix_weight = 0
-
-    chars = []
-    current = 0
-    for ch in text:
-        weight = 2 if ord(ch) >= 0x1100 else 1
-        if current + weight + suffix_weight > max_weight:
-            break
-        chars.append(ch)
-        current += weight
-
-    return "".join(chars).rstrip() + suffix
-
-
-def _fit_candidate(
-    body_lines: list[str],
-    url: str,
-    hashtag_suffix: str,
-    trim_indexes: list[int],
-) -> str | None:
-    candidate = _build_tweet(body_lines, url, hashtag_suffix)
-    if is_tweet_text_valid(candidate):
-        return candidate
-
-    fitted_lines = body_lines[:]
-    for index in trim_indexes:
-        if index >= len(fitted_lines):
-            continue
-
-        for _ in range(3):
-            candidate = _build_tweet(fitted_lines, url, hashtag_suffix)
-            overage = count_tweet_length(candidate) - TWEET_MAX_WEIGHTED_LENGTH
-            if overage <= 0:
-                break
-
-            current_line = fitted_lines[index]
-            current_weight = count_tweet_length(current_line)
-            fitted_lines[index] = _trim_to_weight(current_line, current_weight - overage)
-            if fitted_lines[index] == current_line:
-                break
-
-        candidate = _build_tweet(fitted_lines, url, hashtag_suffix)
-        if is_tweet_text_valid(candidate):
-            return candidate
-
-    return None
-
-
-def _fallback_new_community_tweet(community, first_event=None) -> str | None:
-    weekdays_str = _format_weekdays(community.weekdays)
-    name = _sanitize_for_prompt(community.name)
-    url = f"詳細はこちら {build_site_url(f'/community/{community.pk}/')}"
-    hashtag_suffix = _build_hashtag_suffix(community)
-
-    if first_event:
-        weekday = WEEKDAY_NAMES.get(first_event.date.strftime("%a"), "")
-        schedule = f"{first_event.date.strftime('%-m/%-d')}({weekday}) {first_event.start_time.strftime('%H:%M')}~"
-    else:
-        schedule = f"{community.frequency} {weekdays_str}曜日 {community.start_time.strftime('%H:%M')}~"
-
-    body_lines = [
-        f"新しい集会「{name}」がはじまります",
-        schedule,
-    ]
-    return _fit_candidate(body_lines, url, hashtag_suffix, [0])
-
-
-def _fallback_presentation_tweet(event_detail, *, special: bool = False) -> str | None:
-    event = event_detail.event
-    community = event.community
-    weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
-    label = " 特別回" if special else ""
-    speaker_display = _format_speaker_display(event_detail)
-    body_lines = [
-        f"{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~ {_sanitize_for_prompt(community.name)}{label}",
-        f"{speaker_display}「{_sanitize_for_prompt(event_detail.theme)}」",
-    ]
-    url = f"詳細はこちら {build_site_url(f'/community/{community.pk}/')}"
-    return _fit_candidate(body_lines, url, _build_hashtag_suffix(community), [1, 0])
-
-
-def _fallback_slide_share_tweet(event_detail) -> str | None:
-    community = event_detail.event.community
-    resources = []
-    if event_detail.slide_url or event_detail.slide_file:
-        resources.append("スライド")
-    if event_detail.youtube_url:
-        resources.append("動画")
-    resources_text = "・".join(resources) or "資料"
-    body_lines = [
-        (
-            f"{_sanitize_for_prompt(community.name)} "
-            f"{_sanitize_for_prompt(event_detail.speaker)}さん"
-            f"「{_sanitize_for_prompt(event_detail.theme)}」"
-        ),
-        f"{resources_text}が公開されました",
-    ]
-    url = f"詳細はこちら {build_site_url(f'/event/detail/{event_detail.pk}/')}"
-    return _fit_candidate(body_lines, url, _build_hashtag_suffix(community), [0])
-
-
-def _fallback_daily_reminder_tweet(event) -> str | None:
-    details = list(
-        event.details.filter(
-            status="approved",
-            detail_type__in=("LT", "SPECIAL"),
-        ).order_by("start_time", "pk")
-    )
-    if not details:
-        return None
-
-    community = event.community
-    name = _sanitize_for_prompt(community.name)
-    url = f"詳細はこちら {build_site_url(f'/community/{community.pk}/')}"
-    hashtag_suffix = _build_hashtag_suffix(community)
-
-    for count in range(min(3, len(details)), 0, -1):
-        body_lines = [f"今夜 {event.start_time.strftime('%H:%M')}〜 {name}"]
-        for detail in details[:count]:
-            body_lines.append(
-                f"{_format_speaker_display(detail)}"
-                f"「{_sanitize_for_prompt(detail.theme)}」"
-            )
-        fitted = _fit_candidate(
-            body_lines,
-            url,
-            hashtag_suffix,
-            list(range(len(body_lines) - 1, -1, -1)),
-        )
-        if fitted:
-            return fitted
-
-    return None
-
-
-def _validation_feedback(text: str) -> str:
-    length = count_tweet_length(text)
-    body_lines = count_body_lines(text)
-    overage = max(0, length - TWEET_MAX_WEIGHTED_LENGTH)
-    return (
-        f"前回出力は weighted_length={length}/{TWEET_MAX_WEIGHTED_LENGTH}, "
-        f"body_lines={body_lines}/{MAX_BODY_LINES} でした。"
-        f"{overage} weighted 以上短くし、補足文を最優先で削ってください。"
-    )
-
-
-def _call_generate_fn(
-    generate_fn: Callable[..., Optional[str]],
-    *args: Any,
-    target_chars: int,
-    validation_feedback: str,
-    **kwargs: Any,
-) -> Optional[str]:
-    parameters = inspect.signature(generate_fn).parameters
-    accepts_feedback = (
-        "validation_feedback" in parameters
-        or any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
-    )
-    if accepts_feedback:
-        return generate_fn(
-            *args,
-            target_chars=target_chars,
-            validation_feedback=validation_feedback,
-            **kwargs,
-        )
-    return generate_fn(*args, target_chars=target_chars, **kwargs)
-
-
-def _generate_with_retry(
-    generate_fn: Callable[..., Optional[str]],
-    *args: Any,
-    max_retries: int = 3,
-    fallback_fn: Optional[Callable[..., Optional[str]]] = None,
-    **kwargs: Any,
-) -> Optional[str]:
-    """生成関数をリトライラッパーで実行する。
-
-    1. target_chars=140 で生成
-    2. count_tweet_length() と count_body_lines() でバリデーション
-       （文字数 <= TWEET_MAX_WEIGHTED_LENGTH かつ 本文行数 <= MAX_BODY_LINES）
-    3. どちらか違反していたら target_chars を RETRY_TARGET_CHARS_STEP ずつ減らしてリトライ
-    4. max_retries 回リトライ後も違反している場合は決定的な圧縮にフォールバック
-    """
-    target_chars = 140
-    result = None
-    validation_feedback = ""
-
-    for attempt in range(max_retries + 1):
-        result = _call_generate_fn(
-            generate_fn,
-            *args,
-            target_chars=target_chars,
-            validation_feedback=validation_feedback,
-            **kwargs,
-        )
-        if result is None:
-            return None
-
-        errors = validate_tweet_text(result)
-
-        if not errors:
-            if attempt > 0:
-                logger.info(
-                    "Tweet validation OK after %d retries (weighted=%d, body_lines=%d, target_chars=%d)",
-                    attempt,
-                    count_tweet_length(result),
-                    count_body_lines(result),
-                    target_chars,
-                )
-            return result
-
-        logger.warning(
-            "Tweet validation failed (%s, attempt=%d/%d, target_chars=%d). Retrying.",
-            ", ".join(errors),
-            attempt + 1,
-            max_retries + 1,
-            target_chars,
-        )
-        validation_feedback = _validation_feedback(result)
-        target_chars -= RETRY_TARGET_CHARS_STEP
-
-    if fallback_fn is None:
-        return None
-
-    fallback_result = fallback_fn(*args)
-    if fallback_result and is_tweet_text_valid(fallback_result):
-        logger.info(
-            "Tweet deterministic fallback succeeded (weighted=%d, body_lines=%d)",
-            count_tweet_length(fallback_result),
-            count_body_lines(fallback_result),
-        )
-        return fallback_result
-
-    logger.error(
-        "Tweet deterministic fallback failed after generation retries: %s",
-        validate_tweet_text(fallback_result or ""),
-    )
-    return None
-
-
-def _sanitize_for_prompt(text: str, max_length: int = SANITIZE_MAX_LENGTH) -> str:
-    """プロンプトに埋め込む前のサニタイズ。
-
-    改行・制御文字を除去し、最大長で切り詰める。
-    """
-    if not text:
-        return ""
-    text = " ".join(text.split())
-    return text[:max_length]
-
-
-def _format_speaker_display(event_detail) -> str:
-    """登壇者名を告知本文用の敬称付き表記で返す。"""
-    speaker = _sanitize_for_prompt(event_detail.speaker)
-    display_name = f"{speaker}さん"
-    applicant = getattr(event_detail, "applicant", None)
-    x_account = _sanitize_for_prompt(getattr(applicant, "x_account", ""))
-    if x_account:
-        return f"{display_name}（@{x_account}）"
-    return display_name
 
 
 def _call_llm(system_prompt: str, user_prompt: str) -> str | None:
@@ -410,325 +114,6 @@ def _call_llm(system_prompt: str, user_prompt: str) -> str | None:
     except Exception:
         logger.exception("LLM generation failed")
         return None
-
-
-def _format_weekdays(weekdays: list) -> str:
-    """曜日リストを日本語文字列に変換する。"""
-    return "・".join([WEEKDAY_NAMES.get(d, d) for d in (weekdays or [])])
-
-
-def _build_hashtag_suffix(community) -> str:
-    """ハッシュタグ部分を構築する。"""
-    hashtag = f"#{community.twitter_hashtag}\n" if community.twitter_hashtag else ""
-    return f"{hashtag}#VRChat技術学術"
-
-
-BODY_LINE_CONSTRAINT = (
-    "- **本文は3行以内に収める（X のスパムフィルタ回避のため必須）**\n"
-    "  - 「本文」= URL行・ハッシュタグ行・空行を除いた実質的な告知テキスト行\n"
-    "  - 本文4行以上 + URL の組み合わせは X API が 403 で拒否する\n"
-    "  - 補足説明と誘導文は別行に分けず1行に統合する"
-)
-
-
-def generate_new_community_tweet(
-    community,
-    first_event=None,
-    target_chars=140,
-    validation_feedback="",
-) -> str | None:
-    """新規集会の告知ポストを生成する。
-
-    Args:
-        community: Community モデルインスタンス
-        first_event: 初回 Event (あれば日程を含める)
-        target_chars: LLM に指示する目標文字数
-    """
-    system_prompt = (
-        "あなたはVRChat技術学術系集会の告知ポストを作成するライターです。"
-        "「参加したい」と思わせる告知を書いてください。"
-    )
-
-    weekdays_str = _format_weekdays(community.weekdays)
-
-    event_info = ""
-    if first_event:
-        event_info = (
-            f"\n初回開催日: {first_event.date.strftime('%-m/%-d')}({WEEKDAY_NAMES.get(first_event.date.strftime('%a'), '')})"
-            f" {first_event.start_time.strftime('%H:%M')}~"
-        )
-
-    hashtag_suffix = _build_hashtag_suffix(community)
-    community_url = build_site_url(f"/community/{community.pk}/")
-    name = _sanitize_for_prompt(community.name)
-    description = _sanitize_for_prompt(community.description) or "(なし)"
-
-    user_prompt = f"""以下の新しいVRChat集会の告知ポストを作成してください。
-
-集会名: {name}
-開催: {community.frequency} {weekdays_str}曜日 {community.start_time.strftime('%H:%M')}~
-紹介: {description}{event_info}
-{validation_feedback}
-
-## 必須要素（必ず本文に含めること）
-1. 集会名
-2. 開催スケジュール（曜日・時刻）
-3. どんな人向けか / 何が得られるか（紹介文から1行で）
-
-## 出力フォーマット（本文は3行以内）
-
-新しい集会「{{集会名}}」がはじまります
-
-{{開催スケジュール}}
-{{対象者 + 何が得られるかを1行に統合}}
-
-詳細はこちら {{URL}}
-{{ハッシュタグ}}
-
-## スタイル
-- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
-{BODY_LINE_CONSTRAINT}
-- 「こんな集会が始まりました」ではなく「こういう人は来て」というトーン
-- 末尾に以下を必ず含める:
-  詳細はこちら {community_url}
-  {hashtag_suffix}
-- 意味のまとまり（日時・テーマ・補足・リンク・ハッシュタグ）ごとに空行を入れて読みやすくする
-- ハッシュタグは末尾に指定されたもののみ使用（自分で追加・変形しない）
-- 句点（。）を一切使わない（「〜です。」「〜ます。」も禁止。「〜です」「〜ます」で止める）
-    - ポスト本文のみ出力（説明不要）
-"""
-    return _call_llm(system_prompt, user_prompt)
-
-
-def generate_lt_tweet(event_detail, target_chars=140, validation_feedback="") -> str | None:
-    """発表告知ポストを生成する。
-
-    Args:
-        event_detail: EventDetail モデルインスタンス (detail_type='LT')
-        target_chars: LLM に指示する目標文字数
-    """
-    system_prompt = (
-        "あなたはVRChat集会の発表告知ポストを書くライターです。"
-        "読んだ人が「聞きたい」「行きたい」と思う告知を書いてください。"
-    )
-
-    event = event_detail.event
-    community = event.community
-    hashtag_suffix = _build_hashtag_suffix(community)
-    community_url = build_site_url(f"/community/{community.pk}/")
-    weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
-
-    name = _sanitize_for_prompt(community.name)
-    speaker_display = _format_speaker_display(event_detail)
-    theme = _sanitize_for_prompt(event_detail.theme)
-
-    user_prompt = f"""以下の発表の告知ポストを作成してください。
-
-集会名: {name}
-日時: {event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~
-発表者: {speaker_display}
-テーマ: {theme}
-{validation_feedback}
-
-## 必須要素（必ず本文に含めること）
-1. 集会名（「{name}」）
-2. 開催日時（「{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~」の形式で）
-3. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
-4. 発表者（「{speaker_display}」をそのまま記載）
-5. テーマの補足説明と次のアクション（聞きに来る・詳細を見る等）への誘導を**1行にまとめる**（本文3行制約のため別行にしない）
-
-## 出力フォーマット（本文は3行以内）
-
-{{日時}} {{集会名}}
-
-{{発表者}}「{{テーマ}}」
-{{テーマ補足 + 参加誘導を1行に統合}}
-
-詳細はこちら {{URL}}
-{{ハッシュタグ}}
-
-## スタイル
-- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
-{BODY_LINE_CONSTRAINT}
-- テーマ名をそのまま書いた上で、何が聞けるかを1文で補足する
-- 誘導の一文は毎回異なる自然な表現にする（「このテーマが気になる人は聞きに来て」のような定型文の繰り返し禁止）
-- 末尾に以下を必ず含める:
-  詳細はこちら {community_url}
-  {hashtag_suffix}
-- 意味のまとまり（日時・テーマ・補足・リンク・ハッシュタグ）ごとに空行を入れて読みやすくする
-- ハッシュタグは末尾に指定されたもののみ使用（自分で追加・変形しない）
-- 句点（。）を一切使わない（「〜です。」「〜ます。」も禁止。「〜です」「〜ます」で止める）
-    - ポスト本文のみ出力（説明不要）
-"""
-    return _call_llm(system_prompt, user_prompt)
-
-
-def generate_slide_share_tweet(event_detail, target_chars=140, validation_feedback="") -> str | None:
-    """スライド/記事共有ポストを生成する。
-
-    Args:
-        event_detail: EventDetail モデルインスタンス（slide_url または youtube_url が設定済み）
-        target_chars: LLM に指示する目標文字数
-    """
-    system_prompt = (
-        "あなたはVRChat集会の発表資料を紹介するライターです。"
-        "「この資料、読んでみたい」と思わせるポストを書いてください。"
-    )
-
-    event = event_detail.event
-    community = event.community
-    hashtag_suffix = _build_hashtag_suffix(community)
-    detail_url = build_site_url(f"/event/detail/{event_detail.pk}/")
-
-    name = _sanitize_for_prompt(community.name)
-    speaker = _sanitize_for_prompt(event_detail.speaker)
-    theme = _sanitize_for_prompt(event_detail.theme)
-
-    # 公開リソースの種類をフラグで判定（URLはプロンプトに含めない）
-    resources = []
-    if event_detail.slide_url or event_detail.slide_file:
-        resources.append("スライド")
-    if event_detail.youtube_url:
-        resources.append("動画")
-    resources_text = "・".join(resources)
-
-    user_prompt = f"""以下の発表の{resources_text}が公開されたことを伝えるポストを作成してください。
-
-集会名: {name}
-発表者: {speaker}
-テーマ: {theme}
-公開された資料: {resources_text}
-{validation_feedback}
-
-## 必須要素（必ず本文に含めること）
-1. 集会名（「{name}」）
-2. 発表者名（敬称は「さん」を付ける）
-3. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
-4. {resources_text}が公開されたこと
-5. 内容の補足と次のアクション（資料を見る・チェックする等）への誘導を**1行にまとめる**（本文3行制約のため別行にしない）
-
-## 出力フォーマット（本文は3行以内）
-
-{{集会名}} {{発表者}}さん「{{テーマ}}」
-
-{{resources_text}}が公開されました
-{{内容補足 + 閲覧誘導を1行に統合}}
-
-詳細はこちら {{URL}}
-{{ハッシュタグ}}
-
-## スタイル
-- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
-{BODY_LINE_CONSTRAINT}
-- 日付は不要（過去のイベントなので）
-- テーマ名をそのまま書いた上で、「読むと何がわかるか」を1文で補足する
-- 誘導の一文は毎回異なる自然な表現にする（「〜な方はチェック」のような定型文の繰り返し禁止）
-- 末尾に以下を必ず含める:
-  詳細はこちら {detail_url}
-  {hashtag_suffix}
-- 意味のまとまり（日時・テーマ・補足・リンク・ハッシュタグ）ごとに空行を入れて読みやすくする
-- ハッシュタグは末尾に指定されたもののみ使用（自分で追加・変形しない）
-- 句点（。）を一切使わない（「〜です。」「〜ます。」も禁止。「〜です」「〜ます」で止める）
-    - ポスト本文のみ出力（説明不要）
-"""
-    return _call_llm(system_prompt, user_prompt)
-
-
-def generate_daily_reminder_tweet(event, target_chars=140, validation_feedback="") -> str | None:
-    """当日開催イベントのリマインダーポストを生成する。"""
-    approved_details = list(
-        event.details.filter(
-            status="approved",
-            detail_type__in=("LT", "SPECIAL"),
-        ).order_by("start_time", "pk")
-    )
-    if not approved_details:
-        logger.warning("No approved LT/SPECIAL details found for Event %s", event.pk)
-        return None
-
-    community = event.community
-    hashtag_suffix = _build_hashtag_suffix(community)
-    community_url = build_site_url(f"/community/{community.pk}/")
-
-    presentations = []
-    for detail in approved_details[:3]:
-        label = "発表" if detail.detail_type == "LT" else "特別回"
-        speaker_display = _format_speaker_display(detail)
-        theme = _sanitize_for_prompt(detail.theme)
-        presentations.append(f"- {label}: {speaker_display}「{theme}」")
-
-    more_count = len(approved_details) - len(presentations)
-    extra_line = f"\n- ほか {more_count} 件" if more_count > 0 else ""
-
-    system_prompt = (
-        "あなたはVRChat集会の当日リマインダーポストを書くライターです。"
-        "「誰が」「どんなテーマで」話すのかを主役にして、読んだ人が「聞きたい」と思える告知を書いてください。"
-    )
-
-    name = _sanitize_for_prompt(community.name)
-    presentation_count = len(approved_details)
-    user_prompt = f"""以下のイベント当日リマインダーポストを作成してください。
-
-集会名: {name}
-開催: 今夜 {event.start_time.strftime('%H:%M')}~
-登録発表数: {presentation_count}件（※この数字は本文に書かない。背景情報として参照するだけ）
-発表一覧:
-{chr(10).join(presentations)}{extra_line}
-{validation_feedback}
-
-## 出力フォーマット（本文は3行以内、この構造に厳密に従うこと）
-
-### 発表が1件の場合
-今夜 {{時刻}}〜 {{集会名}}
-
-{{登壇者表記1}}「{{テーマ1}}」
-{{テーマ1の補足 + 参加誘導を1行に統合}}
-
-詳細はこちら {{URL}}
-{{ハッシュタグ}}
-
-### 発表が2件の場合
-今夜 {{時刻}}〜 {{集会名}}
-
-{{登壇者表記1}}「{{テーマ1}}」
-{{登壇者表記2}}「{{テーマ2}}」
-
-詳細はこちら {{URL}}
-{{ハッシュタグ}}
-
-### 発表が3件以上の場合（4件以上なら上位3件＋「ほかN件」）
-今夜 {{時刻}}〜 {{集会名}}
-{{登壇者表記1}}「{{テーマ1}}」
-{{登壇者表記2}}「{{テーマ2}}」／{{登壇者表記3}}「{{テーマ3}}」
-
-詳細はこちら {{URL}}
-{{ハッシュタグ}}
-
-## ルール
-- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
-{BODY_LINE_CONSTRAINT}
-- 1行目は「今夜 {event.start_time.strftime('%H:%M')}〜 {name}」の形式で、今日の開催であることと時刻が一目で伝わるようにする（日付表記は禁止）
-- 各発表は発表一覧の登壇者表記をそのまま使い、「○○さん「テーマ名」」または「○○さん（@handle）「テーマ名」」の形式で記載する
-  - テーマ名は発表一覧のものをそのまま使う（言い換え・要約・省略禁止）
-  - Xアカウントがある登壇者は「（@handle）」も含める
-- **発表数の言及禁止**: 「発表は1件」「全○件」「○本立て」「N件の発表」など、発表の本数を伝える表現は本文に一切書かない（通常1件なので情報価値がない）
-- 発表が1件の場合は、発表行の直後に「テーマの補足 + 参加誘導」を**1行に統合**して入れる
-  - 補足と誘導は別行に分けず、1文にまとめる（本文3行制約のため必須）
-  - 補足は発表一覧に含まれるキーワードや背景知識から自然に膨らませる（事実の捏造は禁止）
-- 発表が2件以上の場合は補足・誘導を省略し、発表行のみ並べる（本文3行に収めるため）
-- 発表が4件以上の場合は上位3件を記載し、残りは「ほかN件」としてテーマ3の行末にまとめる
-- 散文や自然文で発表内容をまとめない（一覧形式を崩さない）
-- 末尾に以下を必ず含める:
-  詳細はこちら {community_url}
-  {hashtag_suffix}
-- 空行の入れ方は**本文3行制約を最優先**に決める
-  - 発表1件: 集会名の後・発表ブロックの後に空行（出力例の「### 発表が1件の場合」参照）
-  - 発表2件以上: 本文行を詰めて配置（出力例の対応ブロック参照）。URL/ハッシュタグとの間にのみ空行を入れる
-- ハッシュタグは末尾に指定されたもののみ使用（自分で追加・変形しない）
-- 句点（。）を一切使わない
-    - ポスト本文のみ出力（説明不要）
-"""
-    return _call_llm(system_prompt, user_prompt)
 
 
 def get_generator(tweet_type: str):
@@ -814,67 +199,3 @@ def get_tweet_image_url(queue_item) -> str:
             return thumbnail_url
 
     return get_poster_image_url(queue_item.community)
-
-
-def generate_special_event_tweet(event_detail, target_chars=140, validation_feedback="") -> str | None:
-    """特別回告知ポストを生成する。
-
-    Args:
-        event_detail: EventDetail モデルインスタンス (detail_type='SPECIAL')
-        target_chars: LLM に指示する目標文字数
-    """
-    system_prompt = (
-        "あなたはVRChat集会の特別イベント告知ポストを書くライターです。"
-        "通常回とは違う特別な回であることを伝え、「行きたい」と思わせてください。"
-    )
-
-    event = event_detail.event
-    community = event.community
-    hashtag_suffix = _build_hashtag_suffix(community)
-    community_url = build_site_url(f"/community/{community.pk}/")
-    weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
-
-    name = _sanitize_for_prompt(community.name)
-    speaker = _sanitize_for_prompt(event_detail.speaker)
-    theme = _sanitize_for_prompt(event_detail.theme)
-
-    user_prompt = f"""以下の特別イベントの告知ポストを作成してください。
-
-集会名: {name}
-日時: {event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~
-発表者/ゲスト: {speaker}
-テーマ: {theme}
-{validation_feedback}
-
-## 必須要素（必ず本文に含めること）
-1. 集会名（「{name}」）
-2. 「特別回」であること
-3. 開催日時（「{event.date.strftime('%-m/%-d')}({weekday}) {event.start_time.strftime('%H:%M')}~」の形式で）
-4. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
-5. 発表者/ゲスト名（敬称は「さん」を付ける）
-6. テーマの補足説明と次のアクション（聞きに来る・詳細を見る等）への誘導を**1行にまとめる**（本文3行制約のため別行にしない）
-
-## 出力フォーマット（本文は3行以内）
-
-{{日時}} {{集会名}} 特別回
-
-{{発表者}}さん「{{テーマ}}」
-{{テーマ補足 + 参加誘導を1行に統合}}
-
-詳細はこちら {{URL}}
-{{ハッシュタグ}}
-
-## スタイル
-- {target_chars}文字以内（URLやハッシュタグ含む。日本語は1文字としてカウント）
-{BODY_LINE_CONSTRAINT}
-- テーマ名をそのまま書いた上で、特別回ならではの見どころを1文で補足する
-- 誘導の一文は毎回異なる自然な表現にする（「このテーマに興味ある人は来て」のような定型文の繰り返し禁止）
-- 末尾に以下を必ず含める:
-  詳細はこちら {community_url}
-  {hashtag_suffix}
-- 意味のまとまり（日時・テーマ・補足・リンク・ハッシュタグ）ごとに空行を入れて読みやすくする
-- ハッシュタグは末尾に指定されたもののみ使用（自分で追加・変形しない）
-- 句点（。）を一切使わない（「〜です。」「〜ます。」も禁止。「〜です」「〜ます」で止める）
-    - ポスト本文のみ出力（説明不要）
-"""
-    return _call_llm(system_prompt, user_prompt)


### PR DESCRIPTION
## 概要

`app/twitter/tweet_generator.py` (873 行) を機能別に `app/twitter/generators/` サブパッケージに分割。責務を分離し、可読性とテスト容易性を改善する。

後方互換性のため `tweet_generator.py` は **互換シム** として残し、既存の `from twitter.tweet_generator import ...` は全てそのまま動作する。

## 分割後の構成

| ファイル | 行数 | 責務 |
|---|---:|---|
| `generators/__init__.py` | 13 | パッケージ doc |
| `generators/common.py` | 200 | 定数 / カウント / バリデーション / サニタイズ / 整形ユーティリティ |
| `generators/retry.py` | 114 | `_call_generate_fn` / `_generate_with_retry` |
| `generators/lt_tweet.py` | 161 | `generate_lt_tweet` / `generate_special_event_tweet` / `_fallback_presentation_tweet` |
| `generators/daily_reminder.py` | 150 | `generate_daily_reminder_tweet` / `_fallback_daily_reminder_tweet` |
| `generators/event_intro.py` | 105 | `generate_slide_share_tweet` / `_fallback_slide_share_tweet` |
| `generators/community.py` | 104 | `generate_new_community_tweet` / `_fallback_new_community_tweet` |
| `tweet_generator.py` (シム) | 201 | `_call_llm` / `get_generator` / 画像URLヘルパー + サブモジュールからの re-export |

合計 1048 行 (旧 873 行から、互換シム + サブモジュール doc により若干増加)。

## 関数の振り分け表

| 旧位置 | 新位置 |
|---|---|
| 定数 (`MAX_TWEET_TOKENS`, `TWEET_MAX_WEIGHTED_LENGTH`, `BODY_LINE_CONSTRAINT`, etc.) | `common.py` |
| `WEEKDAY_NAMES` | `common.py` |
| `count_tweet_length` / `count_body_lines` | `common.py` |
| `validate_tweet_text` / `is_tweet_text_valid` | `common.py` |
| `_build_tweet` / `_trim_to_weight` / `_fit_candidate` | `common.py` |
| `_validation_feedback` | `common.py` |
| `_sanitize_for_prompt` | `common.py` |
| `_format_speaker_display` / `_format_weekdays` / `_build_hashtag_suffix` | `common.py` |
| `_call_generate_fn` / `_generate_with_retry` | `retry.py` |
| `generate_lt_tweet` / `generate_special_event_tweet` / `_fallback_presentation_tweet` | `lt_tweet.py` |
| `generate_daily_reminder_tweet` / `_fallback_daily_reminder_tweet` | `daily_reminder.py` |
| `generate_slide_share_tweet` / `_fallback_slide_share_tweet` | `event_intro.py` |
| `generate_new_community_tweet` / `_fallback_new_community_tweet` | `community.py` |
| `_call_llm` (LLM 呼び出し本体) | **`tweet_generator.py` に保持** ※後述 |
| `get_generator` / `get_poster_image_url` / `get_tweet_image_url` / `_image_field_url` / `TWITTER_IMAGE_WIDTH` | **`tweet_generator.py` に保持** |

## 後方互換性の維持

### 1. import 互換

`tweet_generator.py` (シム) が各サブモジュールから関数・定数を明示的に re-export しているため、以下の既存 import は無変更で動作する:

```python
from twitter.tweet_generator import (
    validate_tweet_text, count_tweet_length, MAX_BODY_LINES, TWEET_MAX_WEIGHTED_LENGTH,
    _generate_with_retry, _call_llm, generate_lt_tweet, generate_new_community_tweet,
    generate_special_event_tweet, generate_daily_reminder_tweet, generate_slide_share_tweet,
    get_generator, get_poster_image_url, get_tweet_image_url, _sanitize_for_prompt,
)
```

### 2. `@patch("twitter.tweet_generator._call_llm")` の互換

テストでは `_call_llm` をモジュールパスで多用してパッチしている (例: `@patch("twitter.tweet_generator._call_llm")`)。
patch はパス先のモジュール namespace 属性を差し替えるだけなので、`_call_llm` 本体を別モジュールに切り出すと、サブモジュール側の `generate_lt_tweet` 等が呼び出す `_call_llm` には patch が届かなくなる。

そのため:

- **`_call_llm` 本体は `tweet_generator.py` (シム) に残す**
- **各生成関数は `from twitter import tweet_generator` を関数内で遅延 import** し、`tweet_generator._call_llm(...)` 経由で呼ぶ。これで late binding が効き、`@patch` が反映される
- 同様に `@patch("twitter.tweet_generator.OpenAI")` / `@patch("twitter.tweet_generator.connections.close_all")` も `_call_llm` がシムに居ることで成立

### 3. `@patch("twitter.tweet_generator.generate_new_community_tweet")` 等の互換

シム module global に生成関数を import 済みなので、`get_generator` 内 lambda が module global 参照経由で呼ぶ場合、patch がそのまま効く。

## 影響範囲

- `app/twitter/signals.py` (3箇所), `app/twitter/x_api.py`, `app/twitter/utils.py` の既存 import は **無変更** で動作
- 外部 (signals/x_api/utils/services) のコード変更なし
- `.github/workflows/`, ruff format / lint 一括修正なし (本 PR で触ったファイルのみ ruff チェック実行)

## 検証

- [x] `from twitter.tweet_generator import ...` (シム経由) で全シンボル import 可能
- [x] `from twitter.generators.common import ...` (新パス) で import 可能
- [x] twitter アプリのテスト 129 件 全 pass (`--exclude-tag=external_api`)
- [x] `uvx ruff check app/twitter/generators/ app/twitter/tweet_generator.py` パス

```
Ran 129 tests in 0.775s
OK
```

## 関連

- W4-8 リファクタリング (873 行 → 機能別分割)
- PR #424 で型ヒント追加済みの `_call_generate_fn` / `_generate_with_retry` を `retry.py` に分離