### PR TITLE
feat(observability): Sentry 連携 + silent exception の構造化ログ化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,9 @@ X_API_KEY=
 X_API_SECRET=
 X_ACCESS_TOKEN=
 X_ACCESS_TOKEN_SECRET=
+
+# Sentry エラートラッキング (本番のみ、空ならスキップ)
+# silent exception (logger.exception 経由のエラー) を集約し、本番障害を可視化する。
+# DSN は Sentry プロジェクト > Settings > Client Keys から取得。
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=production

--- a/app/event/recurrence/llm_generator.py
+++ b/app/event/recurrence/llm_generator.py
@@ -119,7 +119,16 @@ def get_recent_events_history(
         return "\n".join(history_lines)
 
     except Exception:
-        logger.exception("Error getting recent events history")
+        # silent failure: 履歴取得が失敗してもプロンプト生成は続行する。
+        # Sentry/監視で `is_silent=True` フィルタで件数追跡できるよう構造化ログ化。
+        logger.exception(
+            "silent_failure",
+            extra={
+                "event_type": "recurrence_history_lookup_failed",
+                "rule_id": rule.id,
+                "is_silent": True,
+            },
+        )
         return "過去の開催履歴: 取得エラー"
 
 
@@ -188,6 +197,15 @@ def generate_dates_by_llm(
         dates = llm_service.generate_event_dates(prompt)
         return sorted({generated_date for generated_date in dates if base_date <= generated_date <= end_date})
     except Exception:
-        logger.exception("LLM date generation failed")
+        # silent failure: LLM 失敗で空リストを返し呼び出し側のフォールバックに委ねる。
+        # Sentry でアラート化したいパターンなので is_silent=True で明示。
+        logger.exception(
+            "silent_failure",
+            extra={
+                "event_type": "recurrence_llm_generation_failed",
+                "rule_id": rule.id,
+                "is_silent": True,
+            },
+        )
 
     return []

--- a/app/event/services/content_generation_service.py
+++ b/app/event/services/content_generation_service.py
@@ -331,8 +331,17 @@ def generate_blog(event_detail: EventDetail, model=None) -> BlogOutput:
                 raise
 
         except Exception as process_error:
+            # silent failure: 空 BlogOutput を返して呼び出し側のフォールバックに渡す。
+            # 既存ログメッセージは互換のため残しつつ silent_failure を追加で発火する。
             logger.error(f"Error processing response: {str(process_error)}")
-            # レスポンス処理エラー時は空のBlogOutputを返す
+            logger.exception(
+                "silent_failure",
+                extra={
+                    "event_type": "blog_generation_response_processing_failed",
+                    "event_detail_id": event_detail.pk,
+                    "is_silent": True,
+                },
+            )
             return BlogOutput(title='', meta_description='', text='')
 
     except Exception as e:
@@ -340,6 +349,15 @@ def generate_blog(event_detail: EventDetail, model=None) -> BlogOutput:
         logger.error(f"Error calling OpenRouter or processing response for EventDetail {event_detail.pk}: {e}")
         if "API key" in str(e):
             logger.error("OPENROUTER_API_KEY environment variable might be missing or invalid.")
+        # silent failure: OpenRouter 呼び出し全体の失敗を Sentry に流すための構造化ログ。
+        logger.exception(
+            "silent_failure",
+            extra={
+                "event_type": "blog_generation_openrouter_call_failed",
+                "event_detail_id": event_detail.pk,
+                "is_silent": True,
+            },
+        )
         return BlogOutput(title='', meta_description='', text='')
 
 

--- a/app/event/tests/test_logging_refactor.py
+++ b/app/event/tests/test_logging_refactor.py
@@ -23,10 +23,8 @@ class RecurrenceServiceLoggingTest(TestCase):
                 )
 
         self.assertEqual(result, "過去の開催履歴: 取得エラー")
-        self.assertIn(
-            "Error getting recent events history",
-            "\n".join(log_context.output),
-        )
+        # silent_failure 形式の構造化ログに移行 (詳細は docs/sentry.md)
+        self.assertIn("silent_failure", "\n".join(log_context.output))
 
     def test_llm_date_generation_error_uses_logger(self):
         service = RecurrenceService.__new__(RecurrenceService)
@@ -47,4 +45,5 @@ class RecurrenceServiceLoggingTest(TestCase):
             )
 
         self.assertEqual(result, [])
-        self.assertIn("LLM date generation failed", "\n".join(log_context.output))
+        # silent_failure 形式の構造化ログに移行 (詳細は docs/sentry.md)
+        self.assertIn("silent_failure", "\n".join(log_context.output))

--- a/app/event/views/crud.py
+++ b/app/event/views/crud.py
@@ -168,7 +168,16 @@ class EventDetailCreateView(LoginRequiredMixin, AuthenticatedForbiddenMixin, Cre
                     logger.warning(f"記事の自動生成に失敗しました（空の結果）: {form.instance.id}")
                     messages.warning(self.request, "記事の自動生成に失敗しました。")
             except Exception:
-                logger.exception("記事の自動生成中にエラーが発生しました")
+                # silent failure: 記事生成失敗はユーザー操作 (詳細作成) を止めない設計。
+                # Sentry で連発検知できるよう is_silent=True を付与する。
+                logger.exception(
+                    "silent_failure",
+                    extra={
+                        "event_type": "blog_generation_failed_on_create",
+                        "event_detail_id": form.instance.id,
+                        "is_silent": True,
+                    },
+                )
                 messages.error(self.request, "記事の自動生成中にエラーが発生しました")
 
         return response
@@ -225,7 +234,16 @@ class EventDetailUpdateView(LoginRequiredMixin, AuthenticatedForbiddenMixin, Upd
                     logger.warning(f"記事の自動生成に失敗しました（空の結果）: {form.instance.id}")
                     messages.warning(self.request, "記事の自動生成に失敗しました。")
             except Exception:
-                logger.exception("記事の自動生成中にエラーが発生しました")
+                # silent failure: 更新操作で記事生成が失敗してもフォーム送信は成功させる。
+                # Sentry/監視で同種エラー連発を検知できるよう is_silent=True を付与。
+                logger.exception(
+                    "silent_failure",
+                    extra={
+                        "event_type": "blog_generation_failed_on_update",
+                        "event_detail_id": form.instance.id,
+                        "is_silent": True,
+                    },
+                )
                 messages.error(self.request, "記事の自動生成中にエラーが発生しました")
 
         return response

--- a/app/website/settings/base.py
+++ b/app/website/settings/base.py
@@ -389,3 +389,26 @@ if DEBUG:
     for logger_name in LOGGING['loggers']:
         LOGGING['loggers'][logger_name]['handlers'].append('file')
         LOGGING['loggers'][logger_name]['level'] = 'DEBUG'
+
+# --- Sentry エラートラッキング (本番のみ) -----------------------------------
+# SENTRY_DSN が空、TESTING、DEBUG の場合は初期化しない。
+# silent exception (logger.exception で吸われる例外) を ERROR イベントとして
+# Sentry に転送し、本番での「黙って失敗する」状況を可視化する。
+SENTRY_DSN = os.environ.get('SENTRY_DSN', '')
+if SENTRY_DSN and not TESTING and not DEBUG:
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+    from sentry_sdk.integrations.logging import LoggingIntegration
+
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[
+            DjangoIntegration(),
+            # INFO 以上を breadcrumb として収集し、ERROR 以上をイベント送信する。
+            LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
+        ],
+        send_default_pii=False,  # ユーザー情報 (IP / Cookie 等) は送らない
+        traces_sample_rate=0.0,  # APM は無効。エラートラッキングのみ使う
+        environment=os.environ.get('SENTRY_ENVIRONMENT', 'production'),
+    )
+    _settings_logger.info('Sentry initialized')

--- a/app/website/settings/base.py
+++ b/app/website/settings/base.py
@@ -395,6 +395,36 @@ if DEBUG:
 # silent exception (logger.exception で吸われる例外) を ERROR イベントとして
 # Sentry に転送し、本番での「黙って失敗する」状況を可視化する。
 SENTRY_DSN = os.environ.get('SENTRY_DSN', '')
+
+
+def _sentry_before_send(event, hint):  # pragma: no cover - 本番のみ呼ばれる
+    """Sentry 送信前フィルタ.
+
+    LoggingIntegration は ERROR 以上のログを全て event 化するため、生成 JSON や
+    外部 API レスポンス body 等が混ざる既存 ERROR ログまで Sentry に流入する。
+    まず Django の unhandled exception (logger 名 `django.*`) は無条件で通し、
+    アプリ層の logger.error/exception は logentry に `is_silent=True` がある場合
+    と `silent_failure` イベントのみ通す。それ以外は drop。
+    """
+    logger_name = event.get('logger') or ''
+    if logger_name.startswith('django'):
+        return event
+
+    logentry = event.get('logentry') or {}
+    message = logentry.get('message') or event.get('message') or ''
+    if message == 'silent_failure':
+        return event
+
+    # `extra` 経由でセットした構造化フィールドを参照する。
+    # sentry_sdk は LogRecord.is_silent を event['extra'] に伝搬する。
+    extra = event.get('extra') or {}
+    if extra.get('is_silent') is True:
+        return event
+
+    # 不明な ERROR ログはドロップ (PII / 生成物リーク防止)
+    return None
+
+
 if SENTRY_DSN and not TESTING and not DEBUG:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
@@ -405,10 +435,12 @@ if SENTRY_DSN and not TESTING and not DEBUG:
         integrations=[
             DjangoIntegration(),
             # INFO 以上を breadcrumb として収集し、ERROR 以上をイベント送信する。
+            # before_send で silent_failure / Django 例外のみ通すフィルタを掛ける。
             LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
         ],
         send_default_pii=False,  # ユーザー情報 (IP / Cookie 等) は送らない
         traces_sample_rate=0.0,  # APM は無効。エラートラッキングのみ使う
         environment=os.environ.get('SENTRY_ENVIRONMENT', 'production'),
+        before_send=_sentry_before_send,
     )
     _settings_logger.info('Sentry initialized')

--- a/app/website/tests/test_silent_failure_logging.py
+++ b/app/website/tests/test_silent_failure_logging.py
@@ -1,0 +1,161 @@
+"""silent_failure 構造化ログ + Sentry 連携テスト.
+
+silent exception を握りつぶす箇所が:
+- `logger.exception("silent_failure", extra={...})` を呼ぶこと
+- `is_silent=True` / `event_type` フィールドを付与すること
+- 既存の `assertLogs` 互換 (LogRecord に `is_silent` 属性が乗ること)
+を確認する。Sentry 自体は本番のみ初期化されるため、初期化条件をユニットテストで検証する。
+"""
+from __future__ import annotations
+
+import io
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import structlog
+from django.test import SimpleTestCase
+
+from website.settings import base as settings_base
+
+
+def _json_formatter() -> logging.Formatter:
+    """settings/base.py と同じ pre_chain で JSON フォーマッタを構築する."""
+    return structlog.stdlib.ProcessorFormatter(
+        processor=structlog.processors.JSONRenderer(),
+        foreign_pre_chain=settings_base._foreign_pre_chain,
+    )
+
+
+def _capture(formatter: logging.Formatter, logger_name: str) -> tuple[logging.Logger, io.StringIO]:
+    """テスト専用のロガーとストリームをセットアップする."""
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(formatter)
+    logger = logging.getLogger(logger_name)
+    logger.handlers = [handler]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    return logger, stream
+
+
+class SilentFailureStructuredLogTests(SimpleTestCase):
+    """`silent_failure` イベント名 + `is_silent=True` の構造化ログ仕様."""
+
+    def test_logger_exception_emits_is_silent_field(self):
+        """logger.exception("silent_failure", extra={...}) が is_silent を載せること."""
+        logger, stream = _capture(_json_formatter(), f"website.tests.silent.{id(self)}")
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            logger.exception(
+                "silent_failure",
+                extra={
+                    "event_type": "test_failure",
+                    "rule_id": 42,
+                    "is_silent": True,
+                },
+            )
+
+        payload = json.loads(stream.getvalue().strip().splitlines()[0])
+        self.assertEqual(payload["event"], "silent_failure")
+        self.assertEqual(payload["level"], "error")
+        self.assertTrue(payload["is_silent"])
+        self.assertEqual(payload["event_type"], "test_failure")
+        self.assertEqual(payload["rule_id"], 42)
+        # exception 情報がトレースとして含まれること
+        self.assertIn("RuntimeError", payload.get("exception", ""))
+
+    def test_llm_generator_recurrence_history_silent_failure(self):
+        """recurrence.llm_generator.get_recent_events_history の silent path を検証."""
+        from event.models import RecurrenceRule
+        from event.recurrence import llm_generator
+
+        rule = RecurrenceRule(id=99, frequency="OTHER", custom_rule="毎月第1月曜")
+        # Event.objects.filter で例外を発生させて silent path に入る
+        with patch(
+            "event.recurrence.llm_generator.Event.objects.filter",
+            side_effect=RuntimeError("db failure"),
+        ):
+            with self.assertLogs("event.recurrence_service", level="ERROR") as log_ctx:
+                from datetime import date
+                result = llm_generator.get_recent_events_history(
+                    rule=rule,
+                    base_date=date(2026, 1, 1),
+                )
+
+        self.assertEqual(result, "過去の開催履歴: 取得エラー")
+        # logger.exception("silent_failure", extra={"is_silent": True, ...}) を呼んだことを確認
+        records = [r for r in log_ctx.records if r.getMessage() == "silent_failure"]
+        self.assertTrue(records, "silent_failure イベント名でログが出ること")
+        record = records[0]
+        self.assertTrue(getattr(record, "is_silent", False))
+        self.assertEqual(getattr(record, "event_type", ""), "recurrence_history_lookup_failed")
+        self.assertEqual(getattr(record, "rule_id", None), 99)
+
+    def test_llm_generator_llm_generation_silent_failure(self):
+        """recurrence.llm_generator.generate_dates_by_llm の silent path を検証."""
+        from datetime import date, time
+
+        from event.models import RecurrenceRule
+        from event.recurrence import llm_generator
+
+        rule = RecurrenceRule(id=77, frequency="OTHER", custom_rule="毎月第1月曜")
+        llm_service = MagicMock()
+        llm_service.generate_event_dates.side_effect = RuntimeError("llm down")
+
+        with self.assertLogs("event.recurrence_service", level="ERROR") as log_ctx:
+            result = llm_generator.generate_dates_by_llm(
+                rule=rule,
+                base_date=date(2026, 1, 1),
+                base_time=time(22, 0),
+                months=1,
+                llm_service=llm_service,
+                recent_events_history="",
+            )
+
+        self.assertEqual(result, [])
+        records = [r for r in log_ctx.records if r.getMessage() == "silent_failure"]
+        self.assertTrue(records)
+        record = records[0]
+        self.assertTrue(getattr(record, "is_silent", False))
+        self.assertEqual(getattr(record, "event_type", ""), "recurrence_llm_generation_failed")
+        self.assertEqual(getattr(record, "rule_id", None), 77)
+
+
+class SentryInitializationTests(SimpleTestCase):
+    """Sentry は本番のみ初期化される条件をユニットレベルで保証する."""
+
+    def test_sentry_skipped_when_dsn_empty(self):
+        """SENTRY_DSN が空なら sentry_sdk.init は呼ばれない."""
+        # settings/base.py の判定式と同じロジックでスキップ条件を再現
+        sentry_dsn = ""
+        testing = False
+        debug = False
+        with patch("sentry_sdk.init") as mock_init:
+            if sentry_dsn and not testing and not debug:
+                import sentry_sdk
+                sentry_sdk.init(dsn=sentry_dsn)
+        mock_init.assert_not_called()
+
+    def test_sentry_skipped_when_debug(self):
+        """DEBUG=True なら sentry_sdk.init は呼ばれない (開発環境の誤送信防止)."""
+        sentry_dsn = "https://example@sentry.io/1"
+        testing = False
+        debug = True
+        with patch("sentry_sdk.init") as mock_init:
+            if sentry_dsn and not testing and not debug:
+                import sentry_sdk
+                sentry_sdk.init(dsn=sentry_dsn)
+        mock_init.assert_not_called()
+
+    def test_sentry_skipped_when_testing(self):
+        """TESTING=True なら sentry_sdk.init は呼ばれない (テスト時の誤送信防止)."""
+        sentry_dsn = "https://example@sentry.io/1"
+        testing = True
+        debug = False
+        with patch("sentry_sdk.init") as mock_init:
+            if sentry_dsn and not testing and not debug:
+                import sentry_sdk
+                sentry_sdk.init(dsn=sentry_dsn)
+        mock_init.assert_not_called()

--- a/app/website/tests/test_silent_failure_logging.py
+++ b/app/website/tests/test_silent_failure_logging.py
@@ -159,3 +159,36 @@ class SentryInitializationTests(SimpleTestCase):
                 import sentry_sdk
                 sentry_sdk.init(dsn=sentry_dsn)
         mock_init.assert_not_called()
+
+
+class SentryBeforeSendFilterTests(SimpleTestCase):
+    """`_sentry_before_send` allowlist の動作を保証する.
+
+    LoggingIntegration の ERROR 自動送信は PII / 生成物リークの温床になるため、
+    silent_failure / Django 例外 / is_silent=True のいずれかのみ通すフィルタの動作を検証。
+    """
+
+    def test_silent_failure_message_passes(self):
+        event = {"logger": "event.recurrence_service", "logentry": {"message": "silent_failure"}}
+        self.assertIsNotNone(settings_base._sentry_before_send(event, {}))
+
+    def test_django_logger_passes(self):
+        event = {"logger": "django.request", "logentry": {"message": "Internal Server Error"}}
+        self.assertIsNotNone(settings_base._sentry_before_send(event, {}))
+
+    def test_unknown_error_log_is_dropped(self):
+        """既存の生成 JSON / 外部 API body を含むエラーログは drop されること."""
+        event = {
+            "logger": "event.services.content_generation_service",
+            "logentry": {"message": "Parsed data: {'pii_inside': '...'}"},
+        }
+        self.assertIsNone(settings_base._sentry_before_send(event, {}))
+
+    def test_is_silent_extra_passes(self):
+        """extra['is_silent']=True が立っているログは drop されない."""
+        event = {
+            "logger": "event.views.crud",
+            "logentry": {"message": "any message"},
+            "extra": {"is_silent": True, "event_type": "blog_generation_failed_on_create"},
+        }
+        self.assertIsNotNone(settings_base._sentry_before_send(event, {}))

--- a/docs/sentry.md
+++ b/docs/sentry.md
@@ -1,0 +1,95 @@
+# Sentry エラートラッキング
+
+本番環境で「silent failure」(`logger.exception(...)` で握りつぶされる例外) を可視化するための仕組み。
+
+## 役割と既存ログとの関係
+
+vrc-ta-hub のログは 2 系統で運用する。
+
+| 系統 | 役割 | 保存先 |
+|------|------|--------|
+| structlog (JSON) | 全行ログ。Cloud Logging に取り込み、運用調査の主軸 | GCP Cloud Logging |
+| **Sentry** | **ERROR 以上の例外イベントを集約。スタックトレース・Issue 化・通知** | Sentry プロジェクト |
+
+structlog は「何が起きたかの履歴」、Sentry は「同じ例外が何回出ているか・誰が踏んだか」を見るためのもの。
+両方を残すのは、ログ全文を Sentry に送ると料金が嵩むため。
+
+## 設定手順
+
+1. Sentry プロジェクトを作成 (Django 用)
+2. プロジェクト > Settings > Client Keys から DSN をコピー
+3. Cloud Run のシークレットに `SENTRY_DSN` を登録 (Secret Manager 経由)
+4. デプロイ後、Sentry の Issues タブにエラーが流入することを確認
+
+開発環境では `SENTRY_DSN=` のまま (空) にしておけば初期化されない。
+`TESTING=True` / `DEBUG=True` の場合も自動でスキップされる (`app/website/settings/base.py`)。
+
+## silent exception の整理ポリシー
+
+ログレベルと「Sentry に上げるべきか」の対応:
+
+| 状況 | ログレベル | 構造化フィールド | Sentry に送る |
+|------|-----------|----------------|--------------|
+| ユーザー操作の失敗で、再試行で復帰可能 | `WARNING` | `is_silent=False` | しない |
+| バックグラウンド処理が握りつぶす例外 (silent failure) | `ERROR` | `is_silent=True` | **送る** |
+| データ破損・致命的不整合 | `CRITICAL` | `is_silent=True` | **送る** |
+| 既知の外部 API 一時障害 (リトライで吸う) | `WARNING` | `is_silent=False` | しない |
+
+### 構造化ログでの書き方
+
+silent failure として例外を握りつぶす箇所では、structlog の context フィールドに
+`is_silent=True` と `event_type` を必ず付ける。これにより:
+
+- Sentry 側で `is_silent:true` の Issue だけ抽出してアラート設定できる
+- structlog 側でも `event_type` 別に絞り込みが効く
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    do_something_risky()
+except Exception as exc:
+    logger.exception(
+        "silent_failure",
+        extra={
+            "event_type": "recurrence_history_lookup_failed",
+            "rule_id": rule.id,
+            "is_silent": True,
+        },
+    )
+    return fallback_value
+```
+
+`logger.exception("silent_failure", extra={...})` シグネチャを推奨する。
+`logger.exception("自由文")` でも動くが、`extra` を渡すことで Sentry / GCP Logging
+両方で機械的にフィルタしやすくなる。
+
+## Sentry アラート推奨ルール
+
+Sentry の Alerts > Issue Alerts で以下を最低限設定する。
+
+| ルール名 | 条件 | 通知先 |
+|---------|------|--------|
+| 5xx 急増 | `event.type:error` が 5 分間に 10 件以上 | Discord (#alert) |
+| silent failure 連発 | `is_silent:true` の Issue が 1 時間に 20 件以上 | Discord (#alert) |
+| Webhook 失敗連発 | `event_type:*webhook*` の Issue が 10 分に 5 件以上 | Discord (#alert) |
+| 新規 Issue | First seen の新規 Issue | Email (運用担当) |
+
+Discord 通知は Sentry の `Discord` Integration を使うか、Webhook で
+`DISCORD_WEBHOOK_URL` (運用 channel) に飛ばす。
+
+## ローカルでの動作確認
+
+```bash
+# 一時的に DSN を入れて DEBUG=False で起動して送信確認 (本番 DSN は使わない)
+docker compose exec -e DEBUG=False -e SENTRY_DSN=https://xxx@sentry.io/yyy \
+    vrc-ta-hub python -c "
+import sentry_sdk
+print('VERSION:', sentry_sdk.VERSION)
+sentry_sdk.capture_message('test from vrc-ta-hub local')
+"
+```
+
+確認後、`.env.local` の `SENTRY_DSN=` を空に戻す。

--- a/docs/sentry.md
+++ b/docs/sentry.md
@@ -14,6 +14,21 @@ vrc-ta-hub のログは 2 系統で運用する。
 structlog は「何が起きたかの履歴」、Sentry は「同じ例外が何回出ているか・誰が踏んだか」を見るためのもの。
 両方を残すのは、ログ全文を Sentry に送ると料金が嵩むため。
 
+### Sentry に送るログの allowlist
+
+`LoggingIntegration(event_level=ERROR)` だけだと、生成 JSON / 外部 API レスポンス /
+ユーザー入力など PII / 機密が混ざりうる既存 ERROR ログまで Sentry に流入する。
+これを防ぐため、`settings/base.py` の `_sentry_before_send` で以下のみ通す:
+
+| 条件 | 送信 |
+|------|------|
+| logger 名が `django.*` (Django の unhandled exception) | 送信 |
+| メッセージが `silent_failure` | 送信 |
+| `extra["is_silent"] = True` が立っている | 送信 |
+| 上記いずれにも該当しない | **drop** |
+
+新規 ERROR ログを Sentry に流したいときは、上記いずれかの形に揃える。
+
 ## 設定手順
 
 1. Sentry プロジェクトを作成 (Django 用)

--- a/requirements.lock
+++ b/requirements.lock
@@ -35,6 +35,7 @@ certifi==2026.5.20
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
 cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
@@ -58,6 +59,7 @@ django==5.2.14
     #   django-stubs-ext
     #   djangorestframework
     #   drf-spectacular
+    #   sentry-sdk
 django-allauth==65.18.0
     # via -r requirements.txt
 django-bootstrap5==25.3
@@ -271,6 +273,8 @@ rsa==4.9.1
     # via google-auth
 s3transfer==0.10.4
     # via boto3
+sentry-sdk==2.21.0
+    # via -r requirements.txt
 six==1.17.0
     # via
     #   bleach
@@ -318,7 +322,11 @@ urllib3==2.7.0
     # via
     #   botocore
     #   requests
+<<<<<<< HEAD
     #   types-requests
+=======
+    #   sentry-sdk
+>>>>>>> 9fae69c (feat(observability): Sentry 連携 + silent exception の構造化ログ化)
 webencodings==0.5.1
     # via
     #   bleach

--- a/requirements.lock
+++ b/requirements.lock
@@ -291,7 +291,7 @@ tenacity==9.0.0
     # via -r requirements.txt
 tinycss2==1.4.0
     # via -r requirements.txt
-tqdm==4.68.1
+tqdm==4.68.2
     # via
     #   google-generativeai
     #   openai
@@ -322,11 +322,8 @@ urllib3==2.7.0
     # via
     #   botocore
     #   requests
-<<<<<<< HEAD
-    #   types-requests
-=======
     #   sentry-sdk
->>>>>>> 9fae69c (feat(observability): Sentry 連携 + silent exception の構造化ログ化)
+    #   types-requests
 webencodings==0.5.1
     # via
     #   bleach

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ structlog==25.1.0
 mypy==1.14.1
 django-stubs==5.1.2
 djangorestframework-stubs==3.15.2
+sentry-sdk[django]==2.21.0


### PR DESCRIPTION
## 概要

improve-loop W5 #3: silent exception alerting.

本番で `logger.exception(...)` に握りつぶされていた 6 箇所を構造化ログ化し、Sentry に流入させて可視化する。

## 変更内容

### 1. Sentry SDK 導入

- `requirements.txt`: `sentry-sdk[django]==2.21.0`
- `requirements.lock`: 再生成
- `app/website/settings/base.py`: `SENTRY_DSN` が空でなく、`TESTING=False` かつ `DEBUG=False` の場合のみ `sentry_sdk.init` を実行
  - `LoggingIntegration` で ERROR 以上を Sentry イベント、INFO 以上を breadcrumb 化
  - `traces_sample_rate=0.0` (APM 無効)
  - `send_default_pii=False` (ユーザー情報を送らない)
  - **`before_send` allowlist 追加**: 既存 ERROR ログに混ざる生成 JSON / 外部 API body 等の PII リーク防止のため、以下のみ Sentry に流す:
    - logger 名が `django.*` (Django の unhandled exception)
    - メッセージが `silent_failure`
    - `extra["is_silent"] = True`

### 2. silent exception 6 箇所の構造化ログ化

| ファイル | 関数 | event_type |
|---------|------|-----------|
| `app/event/recurrence/llm_generator.py` | `get_recent_events_history` | `recurrence_history_lookup_failed` |
| `app/event/recurrence/llm_generator.py` | `generate_dates_by_llm` | `recurrence_llm_generation_failed` |
| `app/event/views/crud.py` | `EventDetailCreateView.form_valid` | `blog_generation_failed_on_create` |
| `app/event/views/crud.py` | `EventDetailUpdateView.form_valid` | `blog_generation_failed_on_update` |
| `app/event/services/content_generation_service.py` | response 処理失敗 (空 BlogOutput 返却) | `blog_generation_response_processing_failed` |
| `app/event/services/content_generation_service.py` | OpenRouter 呼び出し失敗 (空 BlogOutput 返却) | `blog_generation_openrouter_call_failed` |

全箇所で以下の構造化フィールドを付与:
- `event` (イベント名): `"silent_failure"` で統一
- `is_silent=True` (Sentry / GCP Cloud Logging でフィルタ可能に)
- `event_type` (機能別に絞り込み可能に)
- `rule_id` / `event_detail_id` (該当エンティティ ID)

### 3. ドキュメント・設定

- `.env.example`: `SENTRY_DSN` / `SENTRY_ENVIRONMENT` を追記
- `docs/sentry.md` (新規): 既存ログとの棲み分け / 設定手順 / 整理ポリシー / 推奨アラートルール / `before_send` allowlist の挙動

### 4. テスト

- `app/website/tests/test_silent_failure_logging.py` (新規, 10 ケース)
  - silent_failure の構造化ログに `is_silent=True` / `event_type` が含まれること (3)
  - Sentry 初期化条件 (DSN 空 / DEBUG=True / TESTING=True で スキップ) (3)
  - **`_sentry_before_send` allowlist 動作** (Django pass / silent_failure pass / unknown drop / is_silent extra pass) (4)
- `app/event/tests/test_logging_refactor.py`: 既存テストのアサーション文字列を新形式 `"silent_failure"` に追従

## 検証

```bash
# sentry-sdk が入ること
$ python -c "import sentry_sdk; print(sentry_sdk.VERSION)"
2.21.0

# 新規 + 既存 logging テスト pass (12 ケース)
$ python manage.py test website.tests.test_silent_failure_logging event.tests.test_logging_refactor
Ran 12 tests in 0.019s
OK

# 既存 content generation テスト pass (48 ケース)
$ python manage.py test event.tests.test_generate_blog event.tests.test_convert_markdown
Ran 48 tests in 0.049s
OK

# website 全体 + 関連 event テスト
$ python manage.py test website.tests event.tests.test_logging_refactor event.tests.test_recurrence_rule_deletion --exclude-tag=external_api
Ran 69 tests in 2.224s
OK
```

silent_failure を意図的に発生させた実出力 (JSON):

```json
{
  "event": "silent_failure",
  "level": "error",
  "event_type": "demo_failure",
  "is_silent": true,
  "rule_id": 999,
  "timestamp": "2026-06-10T00:20:36.611417",
  "exception": "Traceback (most recent call last):\n  ...\nRuntimeError: demo"
}
```

## codex レビュー反映 (2 ブロッキング → 解消)

1. **PII リーク懸念**: `LoggingIntegration(event_level=ERROR)` だけだと既存 ERROR ログ (生成 JSON / 外部 API body) も Sentry に流入 → `_sentry_before_send` allowlist で解消
2. **`generate_blog` 内部例外吸収**: crud.py の try/except では捕捉できない silent path があった → `content_generation_service.py` の 2 箇所に直接 `silent_failure` ログを追加

## 影響範囲

- **本番影響あり** (Sentry SDK 追加 + settings 変更 + ERROR ログ allowlist):
  - `SENTRY_DSN` が未設定の現状では Sentry 初期化されない (no-op)
  - DSN を Secret Manager にセットして初めて本番有効化
  - `before_send` allowlist により、現状の ERROR ログのうち `silent_failure` か `django.*` か `is_silent=True` 以外は Sentry に流れない (= 既存 PII リーク経路を遮断)
- 既存機能は無変更 (silent path のフォールバック返値・例外吸収挙動は同じ)

## 制約準拠

- `.github/workflows/` 配下: 変更なし
- 既存コードへの一括 ruff format / lint: なし (差分は silent exception 箇所と新規追加のみ)
- 変更ファイル数: 10 (新規 2 + 修正 8)