### PR TITLE
refactor(logging): ログレベル規約を明文化し不適合箇所を修正

### DIFF
--- a/app/analytics/views.py
+++ b/app/analytics/views.py
@@ -109,7 +109,9 @@ def sync_analytics(request):
     try:
         poster_rows = fetch_poster_click_report(settings.GA4_PROPERTY_ID, target_date)
     except Exception:
-        logger.error(
+        # page_view 同期は成功しており poster_click だけ取得失敗で部分継続するため
+        # WARNING に降格 (docs/logging.md 規約: 部分失敗で全体処理が継続する場合)
+        logger.warning(
             'GA4 fetch_poster_click_report failed for date=%s', target_date, exc_info=True,
         )
         poster_rows = []

--- a/app/api_v1/base.py
+++ b/app/api_v1/base.py
@@ -41,7 +41,8 @@ class DatabaseReconnectListMixin:
                 if not self._should_retry_after_disconnect(retry_exc):
                     raise
 
-                logger.warning(
+                # 再接続後も復旧せず 503 を返す本物の障害なので ERROR (docs/logging.md 規約)
+                logger.error(
                     "%s.list returned 503 because the database remained unavailable after reconnect: %s",
                     self.__class__.__name__,
                     retry_exc,

--- a/app/community/views/settings.py
+++ b/app/community/views/settings.py
@@ -290,7 +290,9 @@ class TestWebhookView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
         except requests.Timeout:
             messages.error(request, '通知の送信がタイムアウトしました。')
         except requests.RequestException as e:
-            logger.error(f'Webhook送信エラー: {e}')
+            # ユーザーが入力した Webhook URL の不備など想定内の失敗のため
+            # WARNING に降格 (docs/logging.md 規約: ユーザー操作で直せるものは WARNING)
+            logger.warning(f'Webhook送信エラー: {e}')
             messages.error(request, '通知の送信中にエラーが発生しました。')
 
         return redirect('community:settings')

--- a/app/guide/views.py
+++ b/app/guide/views.py
@@ -243,7 +243,9 @@ def load_markdown_content(path: str) -> tuple[str, dict]:
         return html, frontmatter
 
     except Exception as e:
-        logger.error(f"マークダウンファイルの読み込みに失敗: {e}")
+        # Http404 を返すクライアント起因のエラー (4xx 相当) なので
+        # WARNING に降格 (docs/logging.md 規約)
+        logger.warning(f"マークダウンファイルの読み込みに失敗: {e}")
         raise Http404(f"ガイドページの読み込みに失敗しました: {path}")
 
 

--- a/app/ta_hub/views.py
+++ b/app/ta_hub/views.py
@@ -74,7 +74,8 @@ class IndexView(TemplateView):
             context['vket_achievements'] = self._build_vket_achievements(with_images=True)
         except OperationalError:
             # トップページはRDS瞬断でも静的導線を返し続ける（公開導線だけは維持する判断）。
-            logger.warning(
+            # DB 接続失敗は本物の障害なので ERROR (docs/logging.md 規約)
+            logger.error(
                 "IndexView degraded gracefully because the database was unavailable",
                 exc_info=True,
             )

--- a/app/twitter/x_api.py
+++ b/app/twitter/x_api.py
@@ -180,13 +180,15 @@ def post_tweet(text: str, media_ids: list[str] | None = None) -> PostTweetResult
         return _failure_result(error_body="Blocked in test environment")
 
     if not text:
-        logger.error("Tweet text is empty")
+        # クライアント側バリデーション失敗 (4xx 相当) は WARNING (docs/logging.md 規約)
+        logger.warning("Tweet text is empty")
         return _failure_result(error_body="Tweet text is empty")
 
     validation_errors = validate_tweet_text(text)
     if validation_errors:
         error_body = f"Tweet text violates local validation: {', '.join(validation_errors)}"
-        logger.error(error_body)
+        # クライアント側バリデーション失敗 (4xx 相当) は WARNING (docs/logging.md 規約)
+        logger.warning(error_body)
         return _failure_result(error_body=error_body)
 
     auth = _get_oauth1()

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -97,6 +97,60 @@ jsonPayload.event="user.login" AND jsonPayload.user_id=7
 `structlog.processors.add_log_level` を追加して `severity` キーに
 リマップする処理を追加できる (現状は `level` キーで運用)。
 
+## ログレベル使い分け規約
+
+レベル選択を統一して、Cloud Logging 上のアラート設定 / フィルタリング /
+LLM での自動要約を安定させる。**「ユーザー入力起因のミス」と「サービス側の障害」
+を `WARNING` と `ERROR` で明確に分ける**のが基本方針。
+
+| レベル | 用途 | 例 |
+|--------|------|---|
+| `DEBUG` | 開発時の詳細トレース、本番では非表示 | リクエスト処理の中間結果、SQL クエリ |
+| `INFO` | 正常系の主要イベント | ユーザー登録成功、外部 API 呼び出し成功、同期完了 |
+| `WARNING` | 想定内の異常、ユーザー入力ミス、リトライ中、4xx 相当 | validation 失敗、404 Not Found、リトライ中、Discord Webhook 送信失敗（ユーザー設定の URL ミス） |
+| `ERROR` | 想定外の障害、運用対応が必要、5xx 相当 | DB 接続失敗、必須環境変数欠落、外部 API の予期せぬ 5xx、最終的に処理が失敗 |
+| `CRITICAL` | サービス停止級の障害 | 起動失敗、致命的なデータ破損 |
+
+### 判断フロー
+
+1. **HTTP ステータスで考える**: 4xx を返すなら `WARNING`、5xx を返すなら `ERROR`
+2. **リトライ中か最終失敗か**: リトライ中の警告は `WARNING`、リトライ尽きて最終失敗なら `ERROR`
+3. **ユーザー操作で直せるか**: ユーザー側の設定ミス・入力ミスは `WARNING`、サーバー側の障害は `ERROR`
+4. **処理が継続するか**: 部分失敗で全体処理が継続するなら `WARNING`、処理全体が失敗するなら `ERROR`
+
+### 具体例
+
+```python
+# OK: 4xx 相当（バリデーション失敗）は warning
+logger.warning("Tweet text is empty")
+logger.warning("Image exceeded max size: %d bytes", downloaded)
+logger.warning("validation_failed", user_id=user.id, errors=errors)
+
+# NG: 4xx を error にしない
+logger.error("validation failed")
+
+# OK: 5xx 相当（DB 接続失敗）は error
+logger.error("database_unreachable", db=settings.DATABASES['default']['HOST'])
+logger.error("IndexView degraded gracefully because the database was unavailable",
+             exc_info=True)
+
+# OK: リトライ中は warning、最終失敗は error
+logger.warning("Retrying after transient database disconnect: %s", exc)  # リトライ中
+logger.error("Service unavailable after reconnect: %s", exc)             # 最終失敗
+
+# OK: 部分失敗（処理継続）は warning
+logger.warning("GA4 poster_click report failed; continuing with page report only",
+               exc_info=True)
+```
+
+### 例外時の `logger.exception` について
+
+`try/except` ブロック内で例外を捕捉した場合は `logger.exception(...)` を
+推奨する。`exc_info=True` 相当の挙動で **ERROR レベル**として記録され、
+スタックトレースが自動的に付与される。
+本規約の「warning に降格すべき」判断は `logger.error` のみが対象で、
+`logger.exception` は例外発生時の標準パターンとして変更しない。
+
 ## テスト互換性
 
 `unittest.TestCase.assertLogs(...)` / `pytest.caplog` はどちらも


### PR DESCRIPTION
## 関連
improve-loop W5 #24

## Summary

`docs/logging.md` に**ログレベル使い分け規約**を明文化し、明らかに規約と
合わない 7 箇所を修正。`logger.error` / `logger.warning` の意味を統一して、
Cloud Logging 上のアラート / フィルタ / LLM 自動要約を安定させる。

## 規約 (docs/logging.md に追加)

| レベル | 用途 | 例 |
|--------|------|---|
| `DEBUG` | 詳細トレース、本番非表示 | リクエスト中間結果、SQL |
| `INFO` | 正常系の主要イベント | ユーザー登録成功、同期完了 |
| `WARNING` | 4xx 相当 / リトライ中 / 部分失敗 / ユーザー入力ミス | validation 失敗、404、Webhook URL 不備、リトライ中 |
| `ERROR` | 5xx 相当 / 最終失敗 / DB 接続失敗・必須設定欠落 | DB unreachable、必須環境変数欠落、リトライ尽きて失敗 |
| `CRITICAL` | サービス停止級 | 起動失敗、致命的データ破損 |

**判断フロー**: HTTP ステータスで考える → リトライ中か最終失敗か → ユーザー操作で直せるか → 処理が継続するか

`logger.exception` は例外発生時の標準パターンとして変更しない。

## 修正箇所 (7 箇所 / 6 ファイル)

### ERROR → WARNING (4xx 相当に降格)

| ファイル:行 | 内容 | 理由 |
|---|---|---|
| `app/twitter/x_api.py:183` | "Tweet text is empty" | クライアントバリデーション失敗 |
| `app/twitter/x_api.py:189` | validation_errors | クライアントバリデーション失敗 |
| `app/analytics/views.py:112` | GA4 poster_click 取得失敗 | page_view は成功で処理継続する部分失敗 |
| `app/community/views/settings.py:293` | Discord Webhook 送信失敗 | ユーザー入力 URL 起因の想定内エラー |
| `app/guide/views.py:246` | Markdown 読み込み失敗 | Http404 を返すクライアント起因の 4xx |

### WARNING → ERROR (5xx 相当に昇格)

| ファイル:行 | 内容 | 理由 |
|---|---|---|
| `app/api_v1/base.py:44` | DB 再接続失敗で 503 | 本物の障害、運用対応が必要 |
| `app/ta_hub/views.py:77` | `IndexView` `OperationalError` | DB 接続失敗、本物の障害 |

## 安全策

- `logger.exception` は触っていない (例外時の標準として保持)
- ログメッセージのテキスト本文は変更していない (level の変更のみ)
- 既存テスト (`assertLogs(level=...)`) が参照する箇所には抵触なし
  - twitter の `assertLogs("twitter.x_api", level="ERROR")` は 403 response の path をテストしており、今回降格した path とは別

## Test plan

- [x] `docker exec vrc-ta-hub-app python manage.py test --exclude-tag=external_api` → **1436 tests OK**
- [x] 影響を受ける可能性のあるテスト (twitter / api_v1 / ta_hub / guide) → **44 tests OK**
- [x] api_v1 リトライテストで ERROR レベルに昇格していることをログ出力で確認
  ```
  PersistentConnectFailureRetryingListViewSet.list returned 503 ... [error]
  HandshakeFailureRetryingListViewSet.list returned 503 ... [error]
  ```
- [x] WARNING に降格した箇所は規約通り 4xx 相当 / 部分失敗で全体処理は継続

## 補足

- 変更ファイル数: 7 (docs/logging.md 含む / 制約 8 以下)
- ログメッセージ本文の変更なし
- 既存コードへの一括 ruff format / lint 修正を実施していない
- `.github/workflows/` 配下の変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)