### PR TITLE
chore(ci): requirements.lock 切替 + mypy warn-only job 追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,10 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          cache-dependency-glob: "requirements.txt"
+          cache-dependency-glob: "requirements.lock"
 
-      - name: Install dependencies
-        run: uv pip install --system -r requirements.txt
+      - name: Install dependencies (locked)
+        run: uv pip sync --system requirements.lock
 
       - name: Run tests with coverage
         working-directory: app
@@ -74,3 +74,33 @@ jobs:
           # coverage 設定は ../pyproject.toml の [tool.coverage] を参照
           coverage run --rcfile=../pyproject.toml manage.py test --exclude-tag=external_api --noinput
           coverage report --rcfile=../pyproject.toml
+
+  mypy:
+    needs: lint
+    runs-on: ubuntu-latest
+    # warn-only: 型エラーがあっても CI は失敗させない (docs/mypy.md 参照)
+    continue-on-error: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "requirements.lock"
+
+      - name: Install dependencies (locked)
+        run: uv pip sync --system requirements.lock
+
+      - name: Run mypy (warn-only, app/event/services/)
+        working-directory: app
+        run: |
+          # Phase 1: event/services/ のみ。docs/mypy.md の段階導入計画参照
+          mypy event/services/ --config-file ../pyproject.toml || true


### PR DESCRIPTION
## Summary

過去 2 セッションの保守性改善で、`.github/workflows/` の更新は `gh` CLI workflow scope 制限のため別 PR に分離していたぶんを一括反映。

### 変更点

1. **`requirements.lock` 切替** (PR #437 のフォローアップ)
   - `uv pip install --system -r requirements.txt` → `uv pip sync --system requirements.lock`
   - `cache-dependency-glob` も `requirements.lock` に変更
   - 依存の依存まで完全固定 (サプライチェーン攻撃防止)

2. **mypy warn-only job 追加** (PR #457 のフォローアップ)
   - `continue-on-error: true` で警告のみ
   - Phase 1 として `app/event/services/` のみ対象 (`docs/mypy.md` 参照)

## Test plan

- [x] ローカルで `uvx ruff==0.11.6 check app/` pass を確認
- [x] `requirements.lock` 存在確認 (PR #437 で生成済み)
- [x] mypy & django-stubs が `requirements.lock` に含まれることを確認
- [ ] CI で test job / mypy job が pass することを GitHub Actions 上で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)