### PR TITLE
ci(cloudbuild): SENTRY_DSN secret + CORS_ALLOWED_ORIGINS env を本番デプロイに追加

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,11 +30,14 @@ steps:
       # FERNET_KEY: community.encrypted_fields の対称暗号化鍵。
       # 未設定だと notification_webhook_url 関連の操作で RuntimeError、
       # migration 0027 が即失敗する。
+      # SENTRY_DSN: 本番エラー監視用。未設定なら Sentry 初期化スキップ
+      # (settings/base.py で空文字ガード済み) なので必須ではないが、観測性のため設定推奨。
       - '--set-secrets'
-      - 'DISCORD_WEBHOOK_URL=DISCORD_WEBHOOK_URL:latest,DISCORD_CLIENT_ID=DISCORD_CLIENT_ID:latest,DISCORD_CLIENT_SECRET=DISCORD_CLIENT_SECRET:latest,DISCORD_REPORT_WEBHOOK_URL=DISCORD_REPORT_WEBHOOK_URL:latest,X_API_KEY=X_API_KEY:latest,X_API_SECRET=X_API_SECRET:latest,X_ACCESS_TOKEN=X_ACCESS_TOKEN:latest,X_ACCESS_TOKEN_SECRET=X_ACCESS_TOKEN_SECRET:latest,FERNET_KEY=FERNET_KEY:latest'
-      # GA4 Data API のプロパティID。--update-env-vars で他の既存環境変数を維持しつつ追加する
+      - 'DISCORD_WEBHOOK_URL=DISCORD_WEBHOOK_URL:latest,DISCORD_CLIENT_ID=DISCORD_CLIENT_ID:latest,DISCORD_CLIENT_SECRET=DISCORD_CLIENT_SECRET:latest,DISCORD_REPORT_WEBHOOK_URL=DISCORD_REPORT_WEBHOOK_URL:latest,X_API_KEY=X_API_KEY:latest,X_API_SECRET=X_API_SECRET:latest,X_ACCESS_TOKEN=X_ACCESS_TOKEN:latest,X_ACCESS_TOKEN_SECRET=X_ACCESS_TOKEN_SECRET:latest,FERNET_KEY=FERNET_KEY:latest,SENTRY_DSN=SENTRY_DSN:latest'
+      # GA4_PROPERTY_ID: GA4 Data API のプロパティID
+      # CORS_ALLOWED_ORIGINS: /api/ への CORS 許可オリジン (CSV)。本番フロントの自オリジン。
       - '--update-env-vars'
-      - 'GA4_PROPERTY_ID=444114283'
+      - 'GA4_PROPERTY_ID=444114283,CORS_ALLOWED_ORIGINS=https://vrc-ta-hub.com'
       - '${_SERVICE_NAME}'
 
   # 旧 `rev-*` タグの掃除のみ実施。カナリア検証用の `canary` タグは deploy-watch スキルが


### PR DESCRIPTION
## Summary

PR #443 (CORS) と PR #458 (Sentry) で実装した機能を本番環境で実際に動作させるための cloudbuild.yaml 更新。

### 変更点

- **`--set-secrets`**: `SENTRY_DSN=SENTRY_DSN:latest` を追加
- **`--update-env-vars`**: `CORS_ALLOWED_ORIGINS=https://vrc-ta-hub.com` を追加

## 事前作業 (実施済み)

```bash
# SENTRY_DSN (placeholder版、本物の DSN は Sentry プロジェクト作成後に差し替え)
echo -n "placeholder-update-later" | gcloud secrets create SENTRY_DSN --data-file=- --project=vrc-ta-hub
gcloud secrets add-iam-policy-binding SENTRY_DSN \
  --member=serviceAccount:332732449600-compute@developer.gserviceaccount.com \
  --role=roles/secretmanager.secretAccessor --project=vrc-ta-hub
```

不正 DSN でも sentry-sdk.init は内部で警告ログのみで例外を投げない。
動作には影響しないため placeholder のまま本番反映可能。
本物の DSN は Sentry プロジェクト作成後に `gcloud secrets versions add` で差し替える。

## Test plan

- [x] settings/base.py の SENTRY_DSN ガード確認 (空文字なら init スキップ、placeholder でも警告のみ)
- [ ] CI 全 pass を確認
- [ ] Cloud Build dev デプロイ pass を確認
- [ ] マージ後に本番デプロイで CORS / Sentry 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)