### PR TITLE
security(docker): .dockerignore 追加でサービスアカウント鍵のイメージ焼き込みを防止

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Docker ビルドコンテキストから除外するファイル
+# 目的: 機密情報（サービスアカウント鍵・環境変数・セッション等）を
+#       コンテナイメージに焼き込まない。本番 Cloud Run は鍵レス（アタッチ SA）で動くため
+#       これらのファイルはイメージに不要。
+
+# ===== 機密情報: コンテナイメージに絶対に含めない =====
+**/credentials.json
+app/secret/
+.env
+.env.*
+cookies.txt
+.serena/
+
+# ===== ローカル DB =====
+*.sqlite3
+**/*.sqlite3
+
+# ===== Python キャッシュ =====
+__pycache__/
+*.py[cod]
+*.so
+
+# ===== VCS / IDE / ローカル開発ツール =====
+.git/
+.idea/
+.vscode/
+.claude/
+.cursor/
+.codeium/
+.playwright-cli/
+.playwright-mcp/
+.pytest_cache/
+.ruff_cache/
+.venv/
+
+# ===== バックアップ・ダンプ・一時生成物（イメージに不要） =====
+backup/
+dumps/
+r2_bkp/
+artifacts/
+test-results/
+test-emails/
+docs/tmp/


### PR DESCRIPTION
## 背景

脆弱性診断で、本番コンテナイメージに**本物の GCP サービスアカウント秘密鍵が焼き込まれている**ことが判明した。

- `Dockerfile:45` の `COPY ./app /app` でビルドコンテキスト全体をコピー
- `.dockerignore` が存在しないため `app/credentials.json` / `app/secret/credentials.json`（実鍵）が除外されず混入
- 実証: `vrc-ta-hub:latest` / `vrc-ta-hub-dev:latest` 内に `/app/credentials.json`（`BEGIN PRIVATE KEY` を含む実鍵）が存在することを確認

該当の鍵は `roles/editor` を持つ Compute Engine デフォルト SA のもので、漏洩時の影響が大きい。

## 変更内容

`.dockerignore` を新規追加し、ビルドコンテキストから以下を除外する。

- 機密情報: `**/credentials.json`, `app/secret/`, `.env*`, `cookies.txt`, `.serena/`
- ローカル DB: `*.sqlite3`
- Python キャッシュ / VCS / IDE / ローカル開発ツール
- バックアップ・ダンプ・一時生成物

Dockerfile が `COPY` する `app` / `docs` / `requirements*` / `uwsgi*` / `nginx-app.conf` / `supervisor-app.conf` は除外していない（ビルドに影響なし）。本番 Cloud Run は鍵レス（アタッチ SA + metadata server）で動作するため、鍵ファイルはイメージに不要。

## 検証

- ✅ 焼き込み実証: `docker run` で `vrc-ta-hub:latest` 内に実鍵が存在することを確認
- ✅ 除外パターン確認: `**/credentials.json` + `app/secret/` が両鍵ファイルにマッチ
- ✅ 誤除外なし: Dockerfile の COPY 対象を除外していないことを目視確認

## 関連対応（このPR外で実施済み）

焼き込まれていた旧鍵 `e8eb8758...` はローテーション済み:

- 同一 SA で新鍵 `b3591b50...` を発行・ローカル配置、GA4 実アクセスで動作確認
- 旧鍵を無効化 → 削除。旧鍵での GA4 アクセスが **401 Unauthenticated** で拒否されることを実証
- → 過去イメージに焼き込まれた旧鍵はもう使用不可

🤖 Generated with [Claude Code](https://claude.com/claude-code)