### PR TITLE
fix(runtime): SENTRY_DSN を settings 読み込み前に sanitize + .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Docker ビルドコンテキストから除外するファイル
+# 目的: 機密情報（サービスアカウント鍵・環境変数・セッション等）を
+#       コンテナイメージに焼き込まない。本番 Cloud Run は鍵レス（アタッチ SA）で動くため
+#       これらのファイルはイメージに不要。
+
+# ===== 機密情報: コンテナイメージに絶対に含めない =====
+**/credentials.json
+app/secret/
+.env
+.env.*
+cookies.txt
+.serena/
+
+# ===== ローカル DB =====
+*.sqlite3
+**/*.sqlite3
+
+# ===== Python キャッシュ =====
+__pycache__/
+*.py[cod]
+*.so
+
+# ===== VCS / IDE / ローカル開発ツール =====
+.git/
+.idea/
+.vscode/
+.claude/
+.cursor/
+.codeium/
+.playwright-cli/
+.playwright-mcp/
+.pytest_cache/
+.ruff_cache/
+.venv/
+
+# ===== バックアップ・ダンプ・一時生成物（イメージに不要） =====
+backup/
+dumps/
+r2_bkp/
+artifacts/
+test-results/
+test-emails/
+docs/tmp/

--- a/app/manage.py
+++ b/app/manage.py
@@ -6,6 +6,9 @@ import sys
 
 def main():
     """Run administrative tasks."""
+    from website.runtime_env import sanitize_sentry_dsn_environment
+
+    sanitize_sentry_dsn_environment()
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'website.settings')
     try:
         from django.core.management import execute_from_command_line

--- a/app/website/asgi.py
+++ b/app/website/asgi.py
@@ -15,7 +15,9 @@ from website.middleware import (
     CanonicalCloudRunHostMiddleware,
     install_cloud_run_preview_host_validator,
 )
+from website.runtime_env import sanitize_sentry_dsn_environment
 
+sanitize_sentry_dsn_environment()
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'website.settings')
 # 設定ファイルを触らず、Django の Host 検証まで raw revision host が残った経路だけ救済する。
 install_cloud_run_preview_host_validator()

--- a/app/website/runtime_env.py
+++ b/app/website/runtime_env.py
@@ -1,0 +1,27 @@
+"""Runtime environment normalization for Django entrypoints."""
+
+from __future__ import annotations
+
+import os
+
+
+def sanitize_sentry_dsn_environment() -> None:
+    """Normalize SENTRY_DSN before Django imports settings."""
+    raw_dsn = os.environ.get('SENTRY_DSN')
+    if raw_dsn is None:
+        return
+
+    normalized_dsn = raw_dsn.strip()
+    if not normalized_dsn:
+        os.environ.pop('SENTRY_DSN', None)
+        return
+
+    from sentry_sdk.utils import BadDsn, Dsn
+
+    try:
+        Dsn(normalized_dsn)
+    except BadDsn:
+        os.environ.pop('SENTRY_DSN', None)
+        return
+
+    os.environ['SENTRY_DSN'] = normalized_dsn

--- a/app/website/tests/test_runtime_env.py
+++ b/app/website/tests/test_runtime_env.py
@@ -1,0 +1,39 @@
+"""Runtime environment normalization tests."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from website.runtime_env import sanitize_sentry_dsn_environment
+
+
+class SentryDsnEnvironmentTests(SimpleTestCase):
+    """SENTRY_DSN normalization before settings import."""
+
+    def test_blank_sentry_dsn_is_removed(self):
+        with patch.dict(os.environ, {'SENTRY_DSN': '  \n\t  '}, clear=False):
+            sanitize_sentry_dsn_environment()
+
+            self.assertNotIn('SENTRY_DSN', os.environ)
+
+    def test_sentry_dsn_is_stripped(self):
+        with patch.dict(
+            os.environ,
+            {'SENTRY_DSN': '  https://examplePublicKey@sentry.io/1\n'},
+            clear=False,
+        ):
+            sanitize_sentry_dsn_environment()
+
+            self.assertEqual(
+                os.environ['SENTRY_DSN'],
+                'https://examplePublicKey@sentry.io/1',
+            )
+
+    def test_malformed_sentry_dsn_is_removed(self):
+        with patch.dict(os.environ, {'SENTRY_DSN': 'examplePublicKey@sentry.io/1'}, clear=False):
+            sanitize_sentry_dsn_environment()
+
+            self.assertNotIn('SENTRY_DSN', os.environ)

--- a/app/website/wsgi.py
+++ b/app/website/wsgi.py
@@ -15,7 +15,9 @@ from website.middleware import (
     CanonicalCloudRunHostMiddleware,
     install_cloud_run_preview_host_validator,
 )
+from website.runtime_env import sanitize_sentry_dsn_environment
 
+sanitize_sentry_dsn_environment()
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'website.settings')
 # 設定ファイルを触らず、Django の Host 検証まで raw revision host が残った経路だけ救済する。
 install_cloud_run_preview_host_validator()


### PR DESCRIPTION
## Summary

PR #463 (settings 内での DSN URL scheme チェック) の上位防御層 + コンテナイメージの機密漏洩対策。

### 1. SENTRY_DSN sanitize 層 (entrypoint 前段)

`manage.py` / `wsgi.py` / `asgi.py` で Django settings を読み込む**前**に `sanitize_sentry_dsn_environment()` を呼び、不正な値を環境変数から削除する。これにより:

- placeholder 値や空白文字列が settings.LOGGING 等の構築中に sentry SDK に渡される経路を遮断
- PR #463 のガードが settings 内で効くより前に「無効な DSN を環境から消す」段階で防げる

```python
# app/website/runtime_env.py
def sanitize_sentry_dsn_environment():
    raw = os.environ.get('SENTRY_DSN')
    if raw is None:
        return
    normalized = raw.strip()
    if not normalized:
        os.environ.pop('SENTRY_DSN', None)
        return
    try:
        from sentry_sdk.utils import BadDsn, Dsn
        Dsn(normalized)
    except BadDsn:
        os.environ.pop('SENTRY_DSN', None)
        return
    os.environ['SENTRY_DSN'] = normalized
```

### 2. `.dockerignore` 追加

機密情報がコンテナイメージに焼き込まれるのを防ぐ:

- 機密: `credentials.json` / `.env*` / `cookies.txt` / `.serena/`
- ローカル DB: `*.sqlite3`
- 開発ツール: `.git/` / `.claude/` / `.cursor/` / `.venv/` / `__pycache__/`
- 一時生成物: `backup/` / `dumps/` / `docs/tmp/`

## Test plan

- [x] \`docker exec ... manage.py test website.tests.test_runtime_env\` 3 件 pass
- [x] ローカル \`uvx ruff check app/\` pass
- [ ] CI 全 pass
- [ ] 本番デプロイ時に imageサイズが減ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)