### PR TITLE
fix: 権限不足の例外化を回帰テストで防止

### DIFF
--- a/app/ta_hub/tests/test_access_mixins.py
+++ b/app/ta_hub/tests/test_access_mixins.py
@@ -1,8 +1,9 @@
 from django.contrib.auth import get_user_model
-from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
+from django.urls import URLPattern, URLResolver, get_resolver
 from django.views import View
 
 from ta_hub.access_mixins import AuthenticatedForbiddenMixin
@@ -61,3 +62,30 @@ class AuthenticatedForbiddenMixinTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b'ok')
+
+    def test_urlconf_user_passes_views_do_not_use_default_permission_denial(self):
+        """URLConf の権限ビューが PermissionDenied 経路に戻らないことを保証する."""
+        risky_views = []
+
+        def walk(patterns, route_prefix=""):
+            for pattern in patterns:
+                if isinstance(pattern, URLResolver):
+                    walk(pattern.url_patterns, route_prefix + str(pattern.pattern))
+                    continue
+                if not isinstance(pattern, URLPattern):
+                    continue
+
+                view_class = getattr(pattern.callback, "view_class", None)
+                if not view_class or not issubclass(view_class, UserPassesTestMixin):
+                    continue
+
+                handler_owner = view_class.handle_no_permission.__qualname__
+                if handler_owner.startswith("AccessMixin."):
+                    risky_views.append(
+                        f"{route_prefix}{pattern.pattern} -> "
+                        f"{view_class.__module__}.{view_class.__name__}"
+                    )
+
+        walk(get_resolver().url_patterns)
+
+        self.assertEqual(risky_views, [])


### PR DESCRIPTION
## なぜこの変更が必要か

- VRC技術学術Hub で観測された `raise PermissionDenied(self.get_permission_denied_message())` に対する TASK-2056 の自動修正として作成した差分です

## 変更内容

- [app/ta_hub/tests/test_access_mixins.py](/Users/ms25/worktrees/vrc-ta-hub/app/ta_hub/tests/test_access_mixins.py) に URLConf 全体の回帰テストを追加
- `UserPassesTestMixin` を使う全 CBV が、Django 標準の `AccessMixin.handle_no_permission` に解決されないことを検証
- 認証済みユーザーの通常の権限不足が `PermissionDenied` 例外として error_reporting に記録される退行を防止
- 保護対象ファイルは変更なし
- コミット: `ec3de68 fix: 権限不足の例外化を回帰テストで防止`

## 意思決定

### 採用アプローチ
観測ログは `UserPassesTestMixin` の標準 `handle_no_permission` が `PermissionDenied` を投げたケースでした。現行コードでは `AuthenticatedForbiddenMixin` により主要 URLConf は回避済みだったため、挙動を無理に変えず、URLConf 全体を検査する回帰テストで再発を防ぐ方針にしました。

### トレードオフ または 却下した代替案
個別ビューへ追加修正する案も検討しましたが、現行 URLConf の検査では標準 `AccessMixin.handle_no_permission` に落ちるビューは見つかりませんでした。そのため、不要な実装変更ではなく、将来のビュー追加・ミックスイン順序変更で同じ例外経路に戻ることを検出するテストを採用しました。

### 残課題やリスク
本番の発生 URL は観測ログに含まれていなかったため、今回の対応は現行 URLConf 全体に対する再発防止です。現行コード上で同じ `PermissionDenied` 経路に解決される対象は検出されていません。


## テスト

`docker run --rm -v /Users/ms25/worktrees/vrc-ta-hub/app:/code/app ... python manage.py test ta_hub.tests.test_access_mixins event_calendar.tests.test_views`
結果: 10 tests OK。Django/allauth の既存 warning 4 件のみ。

---
🤖 Generated with [Codex](https://Codex.com/Codex)
