### PR TITLE
fix: settings 直接 import 時も SENTRY_DSN を正規化

### DIFF
--- a/app/website/__init__.py
+++ b/app/website/__init__.py
@@ -1,0 +1,5 @@
+"""Initialize website package runtime environment."""
+
+from website.runtime_env import sanitize_sentry_dsn_environment
+
+sanitize_sentry_dsn_environment()

--- a/app/website/tests/test_runtime_env.py
+++ b/app/website/tests/test_runtime_env.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import os
+import sys
+from importlib import reload
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
+import website
 from website.runtime_env import sanitize_sentry_dsn_environment
 
 
@@ -37,3 +40,11 @@ class SentryDsnEnvironmentTests(SimpleTestCase):
             sanitize_sentry_dsn_environment()
 
             self.assertNotIn('SENTRY_DSN', os.environ)
+
+    def test_package_import_removes_blank_sentry_dsn_before_settings_import(self):
+        with patch.dict(os.environ, {'SENTRY_DSN': '  \n\t  '}, clear=False):
+            reload(sys.modules['website'])
+
+            self.assertNotIn('SENTRY_DSN', os.environ)
+
+        reload(website)


### PR DESCRIPTION
## なぜこの変更が必要か

- VRC技術学術Hub で観測された `sentry_sdk.utils.BadDsn: Unsupported scheme ''` に対する TASK-2061 の自動修正として作成した差分です

## 変更内容

- [app/website/__init__.py](/Users/ms25/worktrees/vrc-ta-hub/app/website/__init__.py) を追加し、`website` パッケージ初期化時に `SENTRY_DSN` を正規化するようにしました。
- [app/website/tests/test_runtime_env.py](/Users/ms25/worktrees/vrc-ta-hub/app/website/tests/test_runtime_env.py) に、`website.settings` 直接 import 前の空白 `SENTRY_DSN` 除去テストを追加しました。
- コミット: `7eefc52 fix: settings 直接 import 時も SENTRY_DSN を正規化`

## 意思決定

### 採用アプローチ
`wsgi.py` / `asgi.py` / `manage.py` 経由では既存 sanitizer が動きますが、`website.settings` を直接 import する経路では settings 読み込み前の正規化が保証されません。  
保護対象の `settings` ファイルには触れず、パッケージ初期化時に既存の `sanitize_sentry_dsn_environment()` を再利用して、Sentry SDK に不正 DSN が渡る前に環境変数を除去します。

### トレードオフ または 却下した代替案
`app/website/settings/base.py` 側で DSN 検証を強化する案が最短ですが、今回の保護対象ファイルに該当するため却下しました。  
代わりに通常アプリケーションコードの `app/website/__init__.py` で settings import 前の共通入口を押さえています。

### 残課題やリスク
なし


## テスト

- `docker run --rm ... python manage.py test website.tests.test_runtime_env -v 2`: 4 tests OK
- `docker run --rm ... -e SENTRY_DSN='  ' ... python -c 'import website.settings; ...'`: `SENTRY_DSN_PRESENT=False` を確認
- `git diff --check`: pass

---
🤖 Generated with [Codex](https://Codex.com/Codex)
