### PR TITLE
fix: migration自動適用を導入しない方針を固定

### DIFF
--- a/app/website/tests/test_cloudbuild_config.py
+++ b/app/website/tests/test_cloudbuild_config.py
@@ -43,3 +43,15 @@ class CloudBuildConfigTest(SimpleTestCase):
             self.assertIn("'--memory'", config)
             self.assertIn("'1Gi'", config)
             self.assertNotIn("'512Mi'", config)
+
+    def test_cloud_build_does_not_run_django_migrations(self):
+        """Cloud Build は Django migration を自動実行しない。
+
+        本番 schema の変更は人間が影響を確認し、デプロイ前に手動で適用する。
+        判断記録: docs/research/issue-464-cloud-run-job-migration.md
+        """
+        for cloudbuild in self.cloudbuild_configs:
+            self.assertNotIn('manage.py,migrate', cloudbuild)
+            self.assertNotIn('manage.py migrate', cloudbuild)
+            self.assertNotIn('jobs execute vrc-ta-hub-migrate', cloudbuild)
+            self.assertNotIn('jobs deploy vrc-ta-hub-migrate', cloudbuild)

--- a/docs/research/issue-464-cloud-run-job-migration.md
+++ b/docs/research/issue-464-cloud-run-job-migration.md
@@ -8,6 +8,15 @@
 
 この決定により Issue #464（cloudbuild.yaml への自動適用ステップ追加）はクローズする。以下は調査時の事実関係と、却下した案の記録。
 
+## 今回の対応範囲
+
+Issue #464 の直接案は `cloudbuild.yaml` / `cloudbuild-dev.yaml` の変更を必要とするが、これらは CI/CD と本番デプロイに直結する保護対象ファイルである。加えて、上記のオーナー判断により自動 migration は導入しない。
+
+そのため今回の変更は、Cloud Build の設定変更ではなく、次の 2 点に限定する。
+
+1. 自動 migration を入れない判断と手動適用の運用を、この調査文書に残す。
+2. `app/website/tests/test_cloudbuild_config.py` で、production/dev の Cloud Build 定義が Django migration を自動実行しないことを検知する。
+
 ## 背景
 
 2026-06-10 の本番反映で、アプリケーションコードが新しい Django migration を前提に起動した一方、本番 DB へ `manage.py migrate` が適用されておらず、`/event/list/` が 500 を返した。
@@ -28,6 +37,7 @@
 - `cloudbuild-dev.yaml` は Kaniko で `latest` イメージを build/push した後、`gcloud run deploy` で dev Service を更新する。
 - 両方とも `manage.py migrate` を含まない。これは**意図された構成**（上記の決定どおり）。
 - `docs/migration-rollback.md` に、Cloud Run Job `vrc-ta-hub-migrate` を手動 execute する手順が記載されている。
+- `app/website/tests/test_cloudbuild_config.py` は、Cloud Build 定義に `manage.py migrate` や `vrc-ta-hub-migrate` の自動 execute/deploy が入っていないことを確認する。
 
 ## 運用手順（正）
 
@@ -38,6 +48,12 @@
 3. `showmigrations` で適用状態を確認してから Cloud Run のデプロイ・トラフィック切替に進む。
 
 再発防止は「自動化」ではなく、この手順をデプロイ時のチェックリストとして徹底することで行う。
+
+## 検証方針
+
+- Cloud Build 定義そのものは保護対象のため変更しない。
+- 既存の設定テストに、production/dev の Cloud Build が migration を自動実行しないことを追加する。
+- テストで「自動 migration が入っていないこと」と「この判断記録への参照」を残し、将来の変更時に意図的な設計判断が必要になるようにする。
 
 ## 却下した案
 


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: [#464](https://github.com/noricha-vr/vrc-ta-hub/issues/464)「cloudbuild.yaml に Django migration 自動適用ステップを追加」
- 必要性: この Issue で報告された問題・要望により、VRC技術学術Hub が期待動作や要件を満たせないため、修正・対応が必要です。
- 対応意図: Issue の直接案は Cloud Build に migration 実行ステップを追加するものですが、今回の制約では `cloudbuild*.yaml` は変更禁止です。さらに既存のオーナー判断として、自動 migration は導入せず、人間がデプロイ前に確認して手動適用する運用が正とされていました。そのため、設定変更ではなく判断記録の補強と回帰防止テストで対応しました。

## 変更内容

- `docs/research/issue-464-cloud-run-job-migration.md` に、Issue #464 の対応範囲を追記しました。
- `cloudbuild.yaml` / `cloudbuild-dev.yaml` は保護対象かつ方針上も変更しないため、調査文書でその判断を明文化しました。
- `app/website/tests/test_cloudbuild_config.py` に、production/dev の Cloud Build が Django migration を自動実行しないことを検知するテストを追加しました。
- コミット: `a3f6722 fix: migration自動適用を導入しない方針を固定`

## 意思決定

### 採用アプローチ
Issue の直接案は Cloud Build に migration 実行ステップを追加するものですが、今回の制約では `cloudbuild*.yaml` は変更禁止です。さらに既存のオーナー判断として、自動 migration は導入せず、人間がデプロイ前に確認して手動適用する運用が正とされていました。そのため、設定変更ではなく判断記録の補強と回帰防止テストで対応しました。

### トレードオフ または 却下した代替案
Cloud Run Job を Cloud Build 内で自動実行する案は、migration 失敗時に旧 revision を維持しやすい利点がありますが、保護対象ファイルの変更が必要で、予期しない schema 変更のリスクもあります。supervisor 起動時の `manage.py migrate` も、複数 instance/revision の競合や失敗時の原因追跡が難しいため採用しませんでした。

### 残課題やリスク
- Cloud Build への自動 migration 実装は行っていません。保護対象ファイルを変更せず、既存の「手動 migration 運用」を明文化・テスト固定する対応です。
- 実際の本番 migration 適用や Cloud Run Job の IAM/Secret 権限検証は、今回のローカル検証対象外です。


## テスト

- `docker run --rm -v /Users/ms25/worktrees/vrc-ta-hub:/code:ro --tmpfs /code/app/logs ... vrc-ta-hub-vrc-ta-hub:latest python manage.py test website.tests.test_cloudbuild_config --noinput`
  - 結果: 4 tests OK
- `uv run ruff check app/website/tests/test_cloudbuild_config.py`
  - 結果: All checks passed
- `git diff --check`
  - 結果: 問題なし

---
🤖 Generated with [Codex](https://Codex.com/Codex)
