### PR TITLE
fix: ブログ生成のPDF入力メモリ使用量を抑制

### DIFF
--- a/app/event/services/content_generation_service.py
+++ b/app/event/services/content_generation_service.py
@@ -27,6 +27,9 @@ from website.settings import GOOGLE_API_KEY
 
 logger = logging.getLogger(__name__)
 
+MAX_SOURCE_TEXT_CHARS = 120_000
+MAX_PDF_TEXT_PAGES = 30
+
 
 class BlogOutput(BaseModel):
     """ブログ記事の出力形式を定義するPydanticモデル"""
@@ -54,6 +57,65 @@ def apply_blog_output_to_event_detail(event_detail: EventDetail, blog_output: Bl
     event_detail.meta_description = blog_output.meta_description
     ensure_pdf_thumbnail(event_detail)
     return True
+
+
+def _copy_uploaded_file_to_temp_path(uploaded_file, *, suffix: str = '.pdf') -> str:
+    """Copy a Django file to a temp path without loading it all into memory."""
+    temp_file_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+            temp_file_path = temp_file.name
+            uploaded_file.open('rb')
+            for chunk in uploaded_file.chunks():
+                temp_file.write(chunk)
+        return temp_file_path
+    except Exception:
+        if temp_file_path and os.path.exists(temp_file_path):
+            os.unlink(temp_file_path)
+        raise
+    finally:
+        close = getattr(uploaded_file, 'close', None)
+        if callable(close):
+            close()
+
+
+def _limit_source_text(text: str, *, max_chars: int = MAX_SOURCE_TEXT_CHARS) -> str:
+    """Limit extracted source text before it is embedded in an LLM prompt."""
+    if len(text) <= max_chars:
+        return text
+    logger.info("Source text truncated from %d to %d chars", len(text), max_chars)
+    return text[:max_chars]
+
+
+def _extract_pdf_text(temp_file_path: str) -> str:
+    """Extract bounded text from a PDF file for blog generation."""
+    reader = PdfReader(temp_file_path)
+    page_count = len(reader.pages)
+    if page_count > MAX_PDF_TEXT_PAGES:
+        logger.info(
+            "PDF text extraction limited to first %d of %d pages",
+            MAX_PDF_TEXT_PAGES,
+            page_count,
+        )
+
+    page_texts = []
+    current_chars = 0
+    for page_index, page in enumerate(reader.pages):
+        if page_index >= MAX_PDF_TEXT_PAGES:
+            break
+
+        text = page.extract_text() or ""
+        if not text:
+            continue
+
+        remaining_chars = MAX_SOURCE_TEXT_CHARS - current_chars
+        if remaining_chars <= 0:
+            break
+
+        page_texts.append(text[:remaining_chars])
+        current_chars += min(len(text), remaining_chars) + 1
+
+    return "\n".join(page_texts)
 
 
 def generate_blog(event_detail: EventDetail, model=None) -> BlogOutput:
@@ -101,27 +163,23 @@ def generate_blog(event_detail: EventDetail, model=None) -> BlogOutput:
         pdf_url = event_detail.slide_url or (event_detail.slide_file.url if event_detail.slide_file else "")
 
         if event_detail.slide_file:
-            with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as temp_file:
-                event_detail.slide_file.seek(0)
-                temp_file.write(event_detail.slide_file.read())
-                temp_file_path = temp_file.name
-
+            temp_file_path = None
             try:
+                temp_file_path = _copy_uploaded_file_to_temp_path(event_detail.slide_file)
                 # PyPDFを使用してPDFの内容を抽出
-                reader = PdfReader(temp_file_path)
-                pdf_content = "\n".join([page.extract_text() or "" for page in reader.pages])
+                pdf_content = _extract_pdf_text(temp_file_path)
                 logger.info(f"Extracted PDF content: {len(pdf_content)} chars")
             except Exception as e:
                 logger.warning(f"Error loading PDF for EventDetail {event_detail.pk}: {e}")
             finally:
                 # 一時ファイルを確実に削除
-                if 'temp_file_path' in locals() and os.path.exists(temp_file_path):
+                if temp_file_path and os.path.exists(temp_file_path):
                     os.unlink(temp_file_path)
 
         # プロンプトテンプレートを作成
         prompt_text = BLOG_GENERATION_TEMPLATE.format(
-            transcript=transcript or "文字起こしはありません。",  # 空の場合の代替テキスト
-            pdf_content=pdf_content or "PDFコンテンツはありません。",  # 空の場合の代替テキスト
+            transcript=_limit_source_text(transcript) if transcript else "文字起こしはありません。",
+            pdf_content=pdf_content or "PDFコンテンツはありません。",
             date=event_detail.event.date.strftime('%Y年%m月%d日') if hasattr(event_detail.event.date,
                                                                              'strftime') else event_detail.event.date,
             # 日付フォーマット（文字列の場合はそのまま）

--- a/app/event/tests/test_generate_blog.py
+++ b/app/event/tests/test_generate_blog.py
@@ -19,6 +19,9 @@ from event.services.content_generation_service import (
     apply_blog_output_to_event_detail,
     generate_blog,
     get_transcript,
+    _copy_uploaded_file_to_temp_path,
+    _extract_pdf_text,
+    _limit_source_text,
 )
 from event.services.media_service import ensure_pdf_thumbnail
 from event.models import Event, EventDetail
@@ -37,6 +40,65 @@ def _has_non_dummy_env(name: str) -> bool:
 
 HAS_OPENROUTER_API_KEY = _has_non_dummy_env("OPENROUTER_API_KEY")
 HAS_GOOGLE_API_KEY = _has_non_dummy_env("GOOGLE_API_KEY")
+
+
+class ContentGenerationMemoryGuardTest(TestCase):
+    def test_copy_uploaded_file_uses_chunks_without_reading_all(self):
+        class ChunkOnlyFile:
+            def __init__(self):
+                self.opened = False
+                self.closed = False
+
+            def open(self, mode):
+                self.opened = mode == "rb"
+
+            def chunks(self):
+                yield b"%PDF-1.4\n"
+                yield b"%%EOF"
+
+            def read(self):
+                raise AssertionError("read() should not be used for uploaded PDF copies")
+
+            def close(self):
+                self.closed = True
+
+        uploaded_file = ChunkOnlyFile()
+        temp_file_path = _copy_uploaded_file_to_temp_path(uploaded_file)
+        try:
+            with open(temp_file_path, "rb") as copied:
+                self.assertEqual(copied.read(), b"%PDF-1.4\n%%EOF")
+        finally:
+            os.unlink(temp_file_path)
+
+        self.assertTrue(uploaded_file.opened)
+        self.assertTrue(uploaded_file.closed)
+
+    def test_extract_pdf_text_limits_pages_and_chars(self):
+        class FakePage:
+            def __init__(self, text):
+                self.text = text
+
+            def extract_text(self):
+                return self.text
+
+        fake_reader = type(
+            "FakeReader",
+            (),
+            {"pages": [FakePage(f"page-{index}") for index in range(35)]},
+        )
+
+        with (
+            patch("event.services.content_generation_service.PdfReader", return_value=fake_reader),
+            patch("event.services.content_generation_service.MAX_PDF_TEXT_PAGES", 5),
+            patch("event.services.content_generation_service.MAX_SOURCE_TEXT_CHARS", 18),
+        ):
+            text = _extract_pdf_text("/tmp/example.pdf")
+
+        self.assertEqual(text, "page-0\npage-1\npage")
+        self.assertNotIn("page-5", text)
+
+    def test_limit_source_text_truncates_long_transcripts(self):
+        self.assertEqual(_limit_source_text("abcdef", max_chars=3), "abc")
 
 
 @tag('external_api')


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: [#475](https://github.com/noricha-vr/vrc-ta-hub/issues/475)「[fix-flow] VRC技術学術Hub: Memory limit of 512 MiB exceeded with 514 MiB used. Consider increasing the memory limit, see https://cloud.google.com/r」
- 必要性: この Issue で報告された問題・要望により、VRC技術学術Hub が期待動作や要件を満たせないため、修正・対応が必要です。
- 対応意図: Cloud Run のメモリ上限超過は、ブログ生成時に PDF 全体と抽出テキストを一括で扱う経路が原因候補でした。 デプロイ設定でメモリ上限を増やす案は保護対象ファイルの変更が必要になるため、アプリ側で入力処理のメモリ使用量を抑える方針にしました。

## 変更内容

- `app/event/services/content_generation_service.py` で、PDF を `read()` で全量メモリ展開せず `chunks()` で一時ファイルへコピーするよう変更
- PDF テキスト抽出を最大 30 ページ・120,000 文字に制限
- YouTube 文字起こしも LLM プロンプト投入前に 120,000 文字へ制限
- `app/event/tests/test_generate_blog.py` にメモリガード用の単体テストを 3 件追加
- コミット作成済み: `5c8ad95 fix: ブログ生成のPDF入力メモリ使用量を抑制`

## 意思決定

### 採用アプローチ
Cloud Run のメモリ上限超過は、ブログ生成時に PDF 全体と抽出テキストを一括で扱う経路が原因候補でした。  
デプロイ設定でメモリ上限を増やす案は保護対象ファイルの変更が必要になるため、アプリ側で入力処理のメモリ使用量を抑える方針にしました。

### トレードオフ または 却下した代替案
Cloud Run のメモリ上限を上げる案は根本的に余裕を増やせますが、今回はインフラ・デプロイ設定が変更禁止のため却下しました。  
PDF 全ページを使った記事生成より、先頭 30 ページ・120,000 文字に制限するため、非常に長い資料では後半の情報が記事生成に入らない可能性があります。

### 残課題やリスク
実際の Cloud Run OOM はログがメモリ上限超過のみで、対象リクエストや入力ファイルは特定できていません。今回の修正で主要なアプリ側メモリ増加要因は抑制しましたが、再発有無は本番ログで継続確認が必要です。


## テスト

- `docker run --rm ... python manage.py test event.tests.test_generate_blog.ContentGenerationMemoryGuardTest --noinput`: 3 tests OK
- `docker run --rm ... python manage.py test event.tests.test_generate_blog --exclude-tag=external_api --noinput`: 3 tests OK
- `docker run --rm ... python -m ruff check app/event/services/content_generation_service.py app/event/tests/test_generate_blog.py`: All checks passed

---
🤖 Generated with [Codex](https://Codex.com/Codex)
