### PR TITLE
fix(event): PDFサムネイル生成のメモリ使用量を抑制

### DIFF
--- a/app/event/services/content_generation_service.py
+++ b/app/event/services/content_generation_service.py
@@ -52,7 +52,8 @@ def apply_blog_output_to_event_detail(event_detail: EventDetail, blog_output: Bl
     event_detail.h1 = blog_output.title
     event_detail.contents = blog_output.text
     event_detail.meta_description = blog_output.meta_description
-    ensure_pdf_thumbnail(event_detail)
+    if not event_detail.thumbnail_image:
+        ensure_pdf_thumbnail(event_detail)
     return True
 
 

--- a/app/event/services/media_service.py
+++ b/app/event/services/media_service.py
@@ -14,6 +14,23 @@ from event.thumbnail import crop_to_slide_thumbnail_aspect_ratio
 
 logger = logging.getLogger(__name__)
 
+PDF_THUMBNAIL_MAX_RENDER_SCALE = 2.0
+PDF_THUMBNAIL_MAX_LONG_EDGE_PX = 1600
+
+
+def _get_pdf_thumbnail_render_scale(page) -> float:
+    """PDFページの長辺が上限を超えないレンダリング倍率を返す."""
+    try:
+        width, height = page.get_size()
+        long_edge = max(float(width), float(height))
+    except (AttributeError, TypeError, ValueError):
+        return PDF_THUMBNAIL_MAX_RENDER_SCALE
+
+    if long_edge <= 0:
+        return PDF_THUMBNAIL_MAX_RENDER_SCALE
+
+    return min(PDF_THUMBNAIL_MAX_RENDER_SCALE, PDF_THUMBNAIL_MAX_LONG_EDGE_PX / long_edge)
+
 
 def ensure_pdf_thumbnail(event_detail: EventDetail, *, save: bool = False, overwrite: bool = False) -> bool:
     """PDFの先頭ページから未設定のサムネイル画像を作成する.
@@ -41,7 +58,7 @@ def ensure_pdf_thumbnail(event_detail: EventDetail, *, save: bool = False, overw
         try:
             page = pdf[0]
             try:
-                bitmap = page.render(scale=2.0)
+                bitmap = page.render(scale=_get_pdf_thumbnail_render_scale(page))
                 try:
                     image = crop_to_slide_thumbnail_aspect_ratio(bitmap.to_pil().convert('RGB'))
                 finally:

--- a/app/event/tests/test_generate_blog.py
+++ b/app/event/tests/test_generate_blog.py
@@ -307,6 +307,34 @@ class TestGenerateBlog(TestCase):
         mock_pdf_document.assert_called_once()
 
     @patch("event.services.media_service.pdfium.PdfDocument")
+    def test_ensure_pdf_thumbnail_uses_default_scale_for_normal_page(self, mock_pdf_document):
+        """通常サイズのPDFは既存の最大倍率でレンダリングする."""
+        event_detail = self.create_event_detail(slide_file=True)
+        mock_page = mock_pdf_document.return_value.__getitem__.return_value
+        mock_page.get_size.return_value = (600, 400)
+        image = Image.new("RGB", (120, 90), color="white")
+        mock_page.render.return_value.to_pil.return_value = image
+
+        result = ensure_pdf_thumbnail(event_detail)
+
+        self.assertTrue(result)
+        mock_page.render.assert_called_once_with(scale=2.0)
+
+    @patch("event.services.media_service.pdfium.PdfDocument")
+    def test_ensure_pdf_thumbnail_limits_scale_for_large_page(self, mock_pdf_document):
+        """巨大なPDFページはレンダリング長辺が過大にならない倍率に抑える."""
+        event_detail = self.create_event_detail(slide_file=True)
+        mock_page = mock_pdf_document.return_value.__getitem__.return_value
+        mock_page.get_size.return_value = (4000, 2000)
+        image = Image.new("RGB", (1600, 800), color="white")
+        mock_page.render.return_value.to_pil.return_value = image
+
+        result = ensure_pdf_thumbnail(event_detail)
+
+        self.assertTrue(result)
+        mock_page.render.assert_called_once_with(scale=0.4)
+
+    @patch("event.services.media_service.pdfium.PdfDocument")
     def test_ensure_pdf_thumbnail_skips_when_already_set(self, mock_pdf_document):
         """既存サムネイルがある場合はPDFレンダリングしない."""
         event_detail = self.create_event_detail(slide_file=True)
@@ -347,6 +375,40 @@ class TestGenerateBlog(TestCase):
     @patch("event.services.content_generation_service.ensure_pdf_thumbnail")
     def test_apply_blog_output_sets_article_and_thumbnail(self, mock_ensure_pdf_thumbnail):
         """記事生成結果を反映するときに未設定サムネイルも補完する."""
+        event_detail = self.create_event_detail(slide_file=True)
+        blog_output = BlogOutput(
+            title="生成タイトル",
+            meta_description="生成ディスクリプション",
+            text="生成本文",
+        )
+
+        result = apply_blog_output_to_event_detail(event_detail, blog_output)
+
+        self.assertTrue(result)
+        self.assertEqual(event_detail.h1, "生成タイトル")
+        self.assertEqual(event_detail.contents, "生成本文")
+        self.assertEqual(event_detail.meta_description, "生成ディスクリプション")
+        mock_ensure_pdf_thumbnail.assert_called_once_with(event_detail)
+
+    @patch("event.services.content_generation_service.ensure_pdf_thumbnail")
+    def test_apply_blog_output_skips_thumbnail_generation_when_already_set(self, mock_ensure_pdf_thumbnail):
+        """既存サムネイルがある記事反映ではPDFレンダリングを再実行しない."""
+        event_detail = self.create_event_detail(slide_file=True)
+        event_detail.thumbnail_image = "thumbnail/existing.jpg"
+        blog_output = BlogOutput(
+            title="生成タイトル",
+            meta_description="生成ディスクリプション",
+            text="生成本文",
+        )
+
+        result = apply_blog_output_to_event_detail(event_detail, blog_output)
+
+        self.assertTrue(result)
+        mock_ensure_pdf_thumbnail.assert_not_called()
+
+    @patch("event.services.content_generation_service.ensure_pdf_thumbnail", return_value=False)
+    def test_apply_blog_output_succeeds_when_thumbnail_generation_fails(self, mock_ensure_pdf_thumbnail):
+        """PDFサムネイル生成失敗時も記事フィールドの反映は成功させる."""
         event_detail = self.create_event_detail(slide_file=True)
         blog_output = BlogOutput(
             title="生成タイトル",

--- a/app/website/tests/test_cloudbuild_config.py
+++ b/app/website/tests/test_cloudbuild_config.py
@@ -11,6 +11,10 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 class CloudBuildConfigTest(SimpleTestCase):
     def setUp(self):
         self.cloudbuild = (REPO_ROOT / 'cloudbuild.yaml').read_text()
+        self.cloudbuild_configs = [self.cloudbuild]
+        cloudbuild_dev_path = REPO_ROOT / 'cloudbuild-dev.yaml'
+        if cloudbuild_dev_path.exists():
+            self.cloudbuild_configs.append(cloudbuild_dev_path.read_text())
 
     def test_production_deploy_does_not_auto_assign_traffic_tag(self):
         """Cloud Build はカナリアタグ付与を行わない。タグ運用は deploy-watch に集約する。
@@ -32,3 +36,10 @@ class CloudBuildConfigTest(SimpleTestCase):
         """旧 `rev-*` タグの掃除処理は維持する（残骸タグ削減のため）。"""
         self.assertIn("grep '^rev-'", self.cloudbuild)
         self.assertIn("--remove-tags", self.cloudbuild)
+
+    def test_cloud_run_memory_limit_is_1gib(self):
+        """記事生成時のPDF処理に備えCloud Runメモリ上限を1GiBにする."""
+        for config in self.cloudbuild_configs:
+            self.assertIn("'--memory'", config)
+            self.assertIn("'1Gi'", config)
+            self.assertNotIn("'512Mi'", config)

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -17,7 +17,7 @@ steps:
       - '--cpu'
       - '1'
       - '--memory'
-      - '512Mi'
+      - '1Gi'
       - '--region'
       - 'asia-northeast1'
       - '--image'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
       - '--cpu'
       - '1'
       - '--memory'
-      - '512Mi'
+      - '1Gi'
       - '--region'
       - 'asia-northeast1'
       - '--image'


### PR DESCRIPTION
## なぜこの変更が必要か

Issue #475 では、発表詳細 ID 723 の記事生成中に Cloud Run のメモリ上限 512Mi を超過し、`Memory limit of 512 MiB exceeded with 514 MiB used` でリクエストが 503 になっていた。

該当処理は PDF から記事生成用の情報を扱いつつ、記事反映時に PDF 先頭ページのサムネイル生成も行うため、Cloud Run の 512Mi 設定では余裕が小さい。特に PDF ページサイズが大きい場合、`pypdfium2` のレンダリング bitmap と PIL 変換が瞬間的にメモリを消費する。

## 変更内容

- Cloud Run のメモリ上限を本番・dev ともに `1Gi` へ引き上げ
- PDFサムネイル生成時のレンダリング長辺を 1600px 相当に制限
- 既存サムネイルがある記事反映では PDF 再レンダリングを skip
- サムネイル生成失敗時も記事本文の反映が成功することをテストで固定
- Cloud Build のメモリ設定テストを追加

## 意思決定

### 採用アプローチ

- `1Gi` への引き上げを採用。今回の観測値は 512Mi に対して 514Mi で、短期の再発防止に最も効くため。
- 併せて PDF レンダリング長辺を制限。メモリ増強だけでは巨大PDFに対する上限が残るため。

### 今回入れないこと

- PDF本文抽出のページ数・文字数上限は入れない。ユーザー指定で「3以外」を実装対象としたため。
- LLMモデル、プロンプト、uWSGI設定、Cloud Run CPU設定は変更しない。

## テスト

- [x] `docker compose exec vrc-ta-hub python manage.py test event.tests.test_generate_blog website.tests.test_cloudbuild_config`
- [x] `git diff --check`
- [x] `rg -n "512Mi|1Gi|--memory" cloudbuild.yaml cloudbuild-dev.yaml`

補足: `docker compose exec vrc-ta-hub python manage.py test event.tests` は既存の別問題で失敗。
`event.tests.test_recurrence_llm_generation.TestRecurrenceLLMGeneration.test_real_llm_generation_for_monthly_pattern` が `RecurrenceService._get_japanese_weekday` 不在で `AttributeError`。

Closes #475