### PR TITLE
fix(notice): プレーンURLのlinkify と 見出しサイズ調整

### DIFF
--- a/app/event/services/markdown_processor.py
+++ b/app/event/services/markdown_processor.py
@@ -28,6 +28,7 @@ _YOUTUBE_PATTERNS = (
     (r'https?://www\.youtube\.com/watch\?v=([a-zA-Z0-9_-]+)', r'https://www.youtube.com/embed/\1'),
     (r'https?://youtu\.be/([a-zA-Z0-9_-]+)', r'https://www.youtube.com/embed/\1'),
 )
+_PLAIN_URL_PATTERN = re.compile(r'https?://[^\s<>"\']+[^\s<>"\'.,;:!?)）」】]')
 
 _LIST_PREFIXES = ('- ', '* ', '+ ', '1. ', '2. ', '3. ')
 _EMOJI_PATTERN = r'[\U0001F300-\U0001F9FF\u200d\u2600-\u26FF\u2700-\u27BF]'
@@ -150,6 +151,27 @@ def _wrap_youtube_urls_with_anchor(text: str) -> tuple[str, bool]:
     return text, modified
 
 
+def _linkify_plain_urls(soup: BeautifulSoup) -> None:
+    """段落・リスト・見出し内の平文 URL を <a> タグに変換する.
+
+    YouTube URL は既に <a> 化済みなので重複処理しない。
+    既存の <a> / <code> / <pre> の中は触らない。
+    """
+    targets = soup.find_all(['p', 'li', 'h1', 'h2', 'h3', 'h4', 'blockquote'])
+    for elem in targets:
+        for text_node in list(elem.find_all(string=True)):
+            if text_node.find_parent(['a', 'code', 'pre']):
+                continue
+            if not _PLAIN_URL_PATTERN.search(str(text_node)):
+                continue
+            replacement = _PLAIN_URL_PATTERN.sub(
+                lambda m: f'<a href="{m.group(0)}">{m.group(0)}</a>',
+                str(text_node),
+            )
+            new_nodes = BeautifulSoup(replacement, 'html.parser')
+            text_node.replace_with(new_nodes)
+
+
 def _convert_youtube_anchors_to_iframes(soup: BeautifulSoup) -> None:
     """YouTube 形式の <a href> を埋め込み iframe に置き換える."""
     for link in soup.find_all('a', href=True):
@@ -234,6 +256,7 @@ def convert_markdown(markdown_text: str, auto_format: bool = False) -> str:
     _apply_table_classes(soup)
     _linkify_youtube_urls_in_text(soup)
     _convert_youtube_anchors_to_iframes(soup)
+    _linkify_plain_urls(soup)
     _remove_disallowed_iframes(soup)
 
     html = str(soup)

--- a/app/event/tests/test_convert_markdown.py
+++ b/app/event/tests/test_convert_markdown.py
@@ -204,6 +204,60 @@ class TestYouTubeEmbed(TestCase):
         self.assertIn("youtube.com/embed/dQw4w9WgXcQ", html)
 
 
+class TestPlainUrlLinkify(TestCase):
+    """平文URLの自動リンク化（linkify）テスト"""
+
+    def test_plain_https_url_wrapped_in_anchor(self):
+        """段落内の平文 https URL が <a> タグでラップされる"""
+        html = convert_markdown("詳細はこちら https://vrc-ta-hub.com/vket/1/apply/ です")
+        self.assertIn('<a href="https://vrc-ta-hub.com/vket/1/apply/"', html)
+        self.assertIn('>https://vrc-ta-hub.com/vket/1/apply/</a>', html)
+
+    def test_plain_http_url_wrapped_in_anchor(self):
+        """http スキームの平文 URL も <a> 化される"""
+        html = convert_markdown("legacy http://example.com/page link")
+        self.assertIn('<a href="http://example.com/page"', html)
+
+    def test_url_in_list_item_linkified(self):
+        """リスト項目内の平文 URL も <a> 化される"""
+        html = convert_markdown("- https://example.com/foo\n- 通常テキスト")
+        self.assertIn('<a href="https://example.com/foo"', html)
+
+    def test_existing_markdown_link_not_double_wrapped(self):
+        """既に Markdown リンク記法で書かれた URL は二重ラップされない"""
+        html = convert_markdown("[サイト](https://example.com) を見て")
+        self.assertEqual(html.count('<a href="https://example.com"'), 1)
+
+    def test_url_in_code_block_not_linkified(self):
+        """コードブロック内の URL は <a> 化されない"""
+        markdown_text = "```\nhttps://example.com/code\n```"
+        html = convert_markdown(markdown_text)
+        self.assertIn("https://example.com/code", html)
+        self.assertNotIn('<a href="https://example.com/code"', html)
+
+    def test_url_in_inline_code_not_linkified(self):
+        """インラインコード内の URL は <a> 化されない"""
+        html = convert_markdown("Use `https://example.com/api` here")
+        self.assertNotIn('<a href="https://example.com/api"', html)
+
+    def test_trailing_punctuation_excluded_from_url(self):
+        """URL 末尾の句読点はリンクから除外される"""
+        html = convert_markdown("見て https://example.com/page. 続き")
+        self.assertIn('<a href="https://example.com/page"', html)
+        self.assertNotIn('<a href="https://example.com/page."', html)
+
+    def test_youtube_url_still_becomes_iframe(self):
+        """YouTube URL は linkify ではなく iframe 化される（既存仕様維持）"""
+        html = convert_markdown("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        self.assertIn("<iframe", html)
+        self.assertIn("youtube.com/embed/dQw4w9WgXcQ", html)
+
+    def test_url_in_heading_linkified(self):
+        """見出し内の平文 URL も <a> 化される"""
+        html = convert_markdown("## See https://example.com/info")
+        self.assertIn('<a href="https://example.com/info"', html)
+
+
 class TestIframeSrcRestriction(TestCase):
     """iframeのsrc属性制限テスト（XSS対策）"""
 

--- a/app/vket/templates/vket/ack_notice.html
+++ b/app/vket/templates/vket/ack_notice.html
@@ -4,6 +4,22 @@
     <title>お知らせ確認 - VRChat 技術・学術系イベントHub</title>
 {% endblock %}
 {% block main %}
+    <style>
+        .notice-body h1,
+        .notice-body h2,
+        .notice-body h3,
+        .notice-body h4 {
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+        }
+        .notice-body h1 { font-size: 1.35rem; }
+        .notice-body h2 { font-size: 1.2rem; }
+        .notice-body h3 { font-size: 1.1rem; }
+        .notice-body h4 { font-size: 1rem; }
+        .notice-body p { margin-bottom: 0.75rem; }
+        .notice-body a { word-break: break-all; }
+    </style>
     <div class="container my-4" style="max-width: 600px;">
         <div class="text-center py-5">
             {% if already_acked %}
@@ -27,7 +43,7 @@
                         <i class="fas fa-calendar me-1"></i>
                         {{ notice.created_at|date:"Y年n月j日 H:i" }}
                     </div>
-                    <div class="border-top pt-3">{{ notice.body|markdown }}</div>
+                    <div class="border-top pt-3 notice-body">{{ notice.body|markdown }}</div>
                 </div>
             </div>
 

--- a/app/vket/templates/vket/notice_list.html
+++ b/app/vket/templates/vket/notice_list.html
@@ -4,6 +4,22 @@
     <title>{{ collaboration.name }} お知らせ - VRChat 技術・学術系イベントHub</title>
 {% endblock %}
 {% block main %}
+    <style>
+        .notice-body h1,
+        .notice-body h2,
+        .notice-body h3,
+        .notice-body h4 {
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+        }
+        .notice-body h1 { font-size: 1.35rem; }
+        .notice-body h2 { font-size: 1.2rem; }
+        .notice-body h3 { font-size: 1.1rem; }
+        .notice-body h4 { font-size: 1rem; }
+        .notice-body p { margin-bottom: 0.75rem; }
+        .notice-body a { word-break: break-all; }
+    </style>
     <div class="container my-4" style="max-width: 860px;">
         {% include 'ta_hub/messages.html' %}
 
@@ -57,7 +73,7 @@
                         <div id="notice-{{ receipt.notice.id }}" class="accordion-collapse collapse"
                              data-bs-parent="#noticeAccordion">
                             <div class="accordion-body">
-                                <div>{{ receipt.notice.body|markdown }}</div>
+                                <div class="notice-body">{{ receipt.notice.body|markdown }}</div>
                                 {% if receipt.notice.requires_ack and not receipt.acknowledged_at %}
                                     <div class="mt-3">
                                         <a href="{% url 'vket:ack_notice' receipt.ack_token %}"


### PR DESCRIPTION
## 背景

Vket お知らせページ (`/vket/<id>/notices/` および ack ページ) で次の 2 つの表示問題があった：

1. **本文中の URL が `<a>` 化されない** — お知らせ本文に `https://vrc-ta-hub.com/vket/1/apply/` のような URL をプレーンで書いても、リンクにならず文字列のまま表示される。
2. **見出し（## など）が極端に大きい** — `convert_markdown` は `<h2>` を CSS クラスなしで出力するため、Bootstrap 既定の 2rem 前後で表示され、本文段落より大幅に大きく可読性が低かった。

## Before / After

| Before | After |
| --- | --- |
| ![notice-before-20260616](https://agent-toolbox-assets.kaisha3.com/uploads/2026/06/dd15ecef5bfc-notice-before-20260616.avif) | ![notice-after-20260616](https://agent-toolbox-assets.kaisha3.com/uploads/2026/06/6b274b72b3f7-notice-after-20260616.avif) |

After では URL が青色リンク化し、見出しも本文と適切な階層差で表示される。

## 変更内容

### 1. `app/event/services/markdown_processor.py`
- `_linkify_plain_urls(soup)` を追加。`p` / `li` / `h1`-`h4` / `blockquote` のテキストノードを走査し、`https?://...` の平文 URL を `<a href="...">...</a>` に変換する。
- `<a>` / `<code>` / `<pre>` 内の URL は対象外（既存リンク・コード保護）。
- URL 末尾の句読点・括弧（`. , ! ? ) ）」 】`）は URL に含めない。
- YouTube URL は既存 `_linkify_youtube_urls_in_text` → `_convert_youtube_anchors_to_iframes` で先に iframe 化されるため、汎用 linkify は影響しない。

### 2. `app/event/tests/test_convert_markdown.py`
- `TestPlainUrlLinkify` を追加（9 件）：プレーン URL の linkify / リスト・見出し内も対象 / コードブロック非対象 / 既存 Markdown リンクと二重化しない / 末尾句読点除外 / YouTube は iframe 維持。

### 3. `app/vket/templates/vket/notice_list.html`, `app/vket/templates/vket/ack_notice.html`
- 本文ラッパーに `.notice-body` クラスを付与し、スコープ付き `<style>` で `h1`〜`h4` のフォントサイズを `1.0`〜`1.35rem` に縮小。
- 長い URL の折り返し（`.notice-body a { word-break: break-all; }`）を追加。

## 検証

- `python manage.py test event.tests.test_convert_markdown` → **57 passed**
- `python manage.py test vket` → **117 passed**
- ローカル Docker (`localhost:8015`) の ack ページで Before/After スクショ撮影、修正後はリンク化＋見出し縮小を確認

## 影響範囲

- 既存の YouTube linkify / iframe 化、サニタイズ（bleach allowed tags）は変更なし。
- `convert_markdown` は `news` / `event` / `vket` / `guide` 等から呼ばれているが、追加処理は「平文 URL を `<a>` 化」のみで HTML 構造を破壊しないため、既存挙動には非破壊。

🤖 Generated with [Claude Code](https://claude.com/claude-code)