### PR TITLE
fix: X告知テンプレートにグループURL変数を追加

### DIFF
--- a/app/event/tests/test_rejected_lt_visibility.py
+++ b/app/event/tests/test_rejected_lt_visibility.py
@@ -252,6 +252,19 @@ class TwitterUtilsFilterTest(TweetGenerationPatchMixin, TestCase):
         self.assertNotIn('Pending Twitter Theme', details_text)
         self.assertNotIn('Rejected Twitter Theme', details_text)
 
+    def test_format_event_info_includes_group_url_and_hashtag(self):
+        """format_event_info はテンプレート用の集会URLとハッシュタグも含む"""
+        from twitter.utils import format_event_info
+
+        self.community.group_url = 'https://vrc.group/TEST.1234'
+        self.community.twitter_hashtag = 'VRChat #TechMeetup'
+        self.community.save(update_fields=['group_url', 'twitter_hashtag'])
+
+        event_info = format_event_info(self.event)
+
+        self.assertEqual(event_info['group_url'], 'https://vrc.group/TEST.1234')
+        self.assertEqual(event_info['hashtag'], '#VRChat #TechMeetup')
+
 
 class CalendarUtilsFilterTest(TweetGenerationPatchMixin, TestCase):
     """calendar_utils.py の generate_google_calendar_url で承認済みのみ含むテスト"""

--- a/app/twitter/forms.py
+++ b/app/twitter/forms.py
@@ -13,9 +13,12 @@ class TwitterTemplateForm(forms.ModelForm):
         '{time}～ 開場\n\n'
         '{time}～ {speaker}さん\n'
         '『{theme}』\n\n'
+        '{time}～ {speaker}さん\n'
+        '『{theme}』\n\n'
         'みんな遊びに来てね～😊\n'
-        'Join先・VRCグループ : https://**\n\n'
-        '#VRChat'
+        'Join先・VRCグループ：\n'
+        '{group_url}\n\n'
+        '{hashtag}'
     )
 
     class Meta:
@@ -32,7 +35,7 @@ class TwitterTemplateForm(forms.ModelForm):
             }),
         }
         help_texts = {
-            'template': '利用可能な変数: {event_name}, {date}, {time}, {speaker}, {theme}'
+            'template': '利用可能な変数: {event_name}, {date}, {time}, {speaker}, {theme}, {group_url}, {hashtag}'
         }
 
     def __init__(self, *args, **kwargs):

--- a/app/twitter/migrations/0013_alter_twittertemplate_template.py
+++ b/app/twitter/migrations/0013_alter_twittertemplate_template.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('twitter', '0012_tweetqueue_generation_token'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='twittertemplate',
+            name='template',
+            field=models.TextField(help_text='利用可能な変数: {event_name}, {date}, {time}, {speaker}, {theme}, {group_url}, {hashtag}', verbose_name='テンプレート'),
+        ),
+    ]

--- a/app/twitter/models.py
+++ b/app/twitter/models.py
@@ -9,7 +9,7 @@ class TwitterTemplate(models.Model):
     name = models.CharField('テンプレート名', max_length=255, default="")
     community = models.ForeignKey(Community, on_delete=models.CASCADE, related_name='twitter_template')
     template = models.TextField('テンプレート',
-                                help_text="利用可能な変数: {event_name}, {date}, {time}, {speaker}, {theme}")
+                                help_text="利用可能な変数: {event_name}, {date}, {time}, {speaker}, {theme}, {group_url}, {hashtag}")
 
     def __str__(self):
         return f"X Template for {self.community.name}"

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -2658,6 +2658,8 @@ class TweetGeneratorTest(TestCase):
             "event_name": "Generator Test Community",
             "date": "2026年4月13日(月)",
             "time": "22:00",
+            "group_url": "https://vrc.group/TEST.1234",
+            "hashtag": "#TestMeetup",
             "details": "22:00 - テストテーマ (テスト太郎)",
         })
 
@@ -2667,6 +2669,8 @@ class TweetGeneratorTest(TestCase):
         self.assertNotIn("ツイート", system_prompt)
         self.assertIn("過去のポスト", user_prompt)
         self.assertIn("告知ポスト", user_prompt)
+        self.assertIn("https://vrc.group/TEST.1234", user_prompt)
+        self.assertIn("#TestMeetup", user_prompt)
         self.assertNotIn("告知ツイート", user_prompt)
 
     @patch("twitter.tweet_generator._call_llm")

--- a/app/twitter/tests/test_views.py
+++ b/app/twitter/tests/test_views.py
@@ -209,6 +209,20 @@ class TwitterTemplateCreateViewTest(TestCase):
         # Forbidden (403) を返す
         self.assertEqual(response.status_code, 403)
 
+    def test_create_form_shows_group_url_variable_in_default_template_and_help(self):
+        """新規作成フォームはグループURL変数を初期値とヘルプに表示する"""
+        self.client.login(username='owner_user2', password='testpassword')
+        session = self.client.session
+        session['active_community_id'] = self.community.id
+        session.save()
+
+        response = self.client.get(reverse('twitter:template_create'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '{group_url}')
+        self.assertContains(response, '{hashtag}')
+        self.assertNotContains(response, 'https://**')
+
 
 class TweetEventWithTemplateViewTest(TestCase):
     """TweetEventWithTemplateViewのテスト"""

--- a/app/twitter/utils.py
+++ b/app/twitter/utils.py
@@ -21,7 +21,9 @@ def format_event_info(event):
         "event_name": event.community.name,
         "date": f"{event.date.year}年{event.date.month}月{event.date.day}日({weekday})",
         "time": event.start_time.strftime("%H:%M"),
-        "details": details_text
+        "details": details_text,
+        "group_url": event.community.group_url,
+        "hashtag": " ".join(event.community.hashtag_list),
     }
 
 
@@ -42,6 +44,8 @@ def generate_tweet(template, event_info):
 イベント名: {event_info['event_name']}
 日付: {event_info['date']}
 時間: {event_info['time']}
+グループURL: {event_info.get('group_url', '')}
+ハッシュタグ: {event_info.get('hashtag', '')}
 詳細:
 {event_info['details']}
 


### PR DESCRIPTION
## なぜこの変更が必要か

ローカル main に積まれていた未PR化のコミット (`b1a625d`) を保護するための救済 PR。
別セッションの作業で main に直接コミットされていた変更を、レビュー可能な形でリモートに残す。

## 変更内容

- デフォルト X告知テンプレートの文面を変数中心に更新
- `{group_url}` と `{hashtag}` をヘルプと生成プロンプトに追加
- フォーム表示、プロンプト、イベント情報整形のテストを追加

詳細は `b1a625d` のコミットメッセージ参照:

> デフォルトテンプレートを変数中心の文面に更新し、{group_url} と {hashtag} をヘルプと生成プロンプトへ追加。フォーム表示、プロンプト、イベント情報整形のテストを追加。

## 経緯

- 当該コミットはローカル main に存在していたが origin/main には push されていなかった
- 別作業（特別企画セクション移動）で `main` を `origin/main` に再同期する必要が出たため、変更内容を失わないよう先にこの PR を作成

## テスト

- [x] コミット内に test_rejected_lt_visibility.py / test_auto_tweet.py / test_views.py のテスト追加あり
- [ ] CI 結果待ち

🤖 Generated with [Claude Code](https://claude.com/claude-code)