### PR TITLE
refactor(ta_hub): 特別企画を Vket期間中は予定発表の下に出し分け

### DIFF
--- a/app/ta_hub/templates/ta_hub/index.html
+++ b/app/ta_hub/templates/ta_hub/index.html
@@ -380,8 +380,8 @@
     </section>
     <!-- X(Twitter) follow banner end -->
 
-    <!-- special events section -->
-    {% if special_events %}
+    <!-- special events section (Vket期間外: 予定発表一覧の上に表示) -->
+    {% if special_events and not show_vket_notice %}
         <section class="bg-white py-5">
             <div class="container">
                 <div class="row featurette text-center text-primary mb-4">
@@ -687,6 +687,97 @@
                 <div class="text-center mt-4">
                     <a href="{% url 'event:detail_history' %}" class="btn btn-primary btn-hover-press mt-3">
                         <i class="bi bi-clock-history me-2"></i>過去の発表一覧
+                    </a>
+                </div>
+            </div>
+        </section>
+    {% endif %}
+
+    <!-- special events section (Vket期間中: 予定発表一覧の下に表示。Vket特別企画と混同されないため) -->
+    {% if special_events and show_vket_notice %}
+        <section class="bg-white py-5">
+            <div class="container">
+                <div class="row featurette text-center text-primary mb-4">
+                    <h2 class="featurette-heading fw-normal lh-1 fw-bold">
+                        <div class="fs-2">✨ 特別企画</div>
+                    </h2>
+                </div>
+                <p class="text-center text-muted mb-5">
+                    <i class="bi bi-star-fill me-2"></i>
+                    期間限定の特別なイベントをお見逃しなく！
+                </p>
+                <div class="row g-4">
+                    {% regroup special_events by event as special_event_list %}
+                    {% for event_group in special_event_list %}
+                        <div class="col-12 col-md-10 offset-md-1">
+                            {% with first_special=event_group.list|first %}
+                                <a href="{% if first_special and first_special.pk %}{% url 'event:detail' first_special.pk %}{% else %}#{% endif %}"
+                                   class="text-decoration-none d-block">
+                                    <div class="card shadow h-100" style="position: relative;">
+                                        <div class="row g-0">
+                                            <div class="col-md-4">
+                                                {% if event_group.grouper.community.poster_image %}
+                                                    <img src="{{ event_group.grouper.community.poster_image.url|cf_resize:'400' }}"
+                                                         class="img-fluid h-100 w-100"
+                                                         alt="{{ event_group.grouper.community.name }}のポスター"
+                                                         style="object-fit: cover;">
+                                                {% else %}
+                                                    <div class="d-flex align-items-center justify-content-center h-100 bg-light">
+                                                        <i class="bi bi-image text-muted" style="font-size: 3rem;"></i>
+                                                    </div>
+                                                {% endif %}
+                                            </div>
+                                            <div class="col-md-8">
+                                                <div class="card-body">
+                                                    <div class="d-flex justify-content-between align-items-start mb-3">
+                                                        <h3 class="card-title mb-0 font-monospace">{{ event_group.grouper.community.name }}</h3>
+                                                        <span class="badge bg-warning text-dark">特別企画</span>
+                                                    </div>
+                                                    <p class="card-text">
+                                                        <i class="bi bi-calendar3"></i> {{ event_group.grouper.date|date:"Y/m/d" }}
+                                                        <small class="text-muted">（{{ event_group.grouper.date|date_weekday_jp }}）</small><br>
+                                                        <i class="bi bi-clock"></i> {{ event_group.grouper.start_time|time:"H:i" }}<small
+                                                            class="text-muted">（日本時間）</small>
+                                                    </p>
+                                                    <div class="list-group list-group-flush">
+                                                        {% for special in event_group.list %}
+                                                            {% if special and special.id %}
+                                                                <div class="list-group-item border-0 px-0">
+                                                                    <div class="d-flex justify-content-between align-items-start">
+                                                                        <div>
+                                                                            <h5 class="mb-1 fs-5 fw-bold text-primary">
+                                                                                {% if special.h1 %}
+                                                                                    {{ special.h1 }}{% else %}
+                                                                                    {{ special.theme }}{% endif %}
+                                                                            </h5>
+                                                                            {% if special.meta_description %}
+                                                                                <p class="mb-0 text-muted small">{{ special.meta_description|truncatechars:150 }}</p>
+                                                                            {% endif %}
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            {% endif %}
+                                                        {% endfor %}
+                                                    </div>
+                                                    <hr class="my-3">
+                                                    <div class="special-content-excerpt">
+                                                        <p class="text-muted mb-0">
+                                                            {% if event_group.grouper.community.description %}
+                                                                {{ event_group.grouper.community.description|truncatechars:140 }}
+                                                            {% endif %}
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                </a>
+                            {% endwith %}
+                        </div>
+                    {% endfor %}
+                </div>
+                <div class="text-center mt-4">
+                    <a href="{% url 'event:event_log_list' %}" class="btn btn-outline-primary">
+                        <i class="bi bi-list-ul me-2"></i>すべての特別企画・ブログを見る
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
## なぜこの変更が必要か

PR #479 で Vket 2026 Summer のコラボバナーが上部に固定された結果、トップページの
**「✨ 特別企画」セクション**が **「Vketコラボの特別企画」**だとユーザーに誤解される懸念が出てきた。

実際の「✨ 特別企画」は Vket 関連に限らない通常の特別 LT 企画なので、Vket告知期間中だけ
表示位置を下にずらして混同を避ける。

## 変更内容

`show_vket_notice` の真偽で **special_events セクションの表示位置を出し分け**:

| 状態 | 表示位置 |
|---|---|
| `show_vket_notice = True` (Vket告知中) | 📅 予定されている発表一覧 の **下** |
| `show_vket_notice = False` (Vket期間外) | 📅 予定されている発表一覧 の **上**（従来通り） |

実装:
- 既存ブロック (上位置) を `{% if special_events and not show_vket_notice %}` でガード
- 同じブロックの中身を upcoming_event_details の `{% endif %}` 直後に複製し `{% if special_events and show_vket_notice %}` でガード
- 両条件は排他のため二重表示にはならない

## 意思決定

### 採用アプローチ
- **テンプレ内 if 分岐** を採用。`special_events` ブロックを2箇所に書き、`show_vket_notice` で出し分け
- 理由: Vket バナーの期間判定 (`vket_end_datetime`) と同じトリガーで自動的に元位置に戻るため、運用負荷ゼロ

### 却下した代替案
- include で partial 化 → 却下: ファイル追加コストに対して再利用箇所が2箇所しかない
- CSS flex order で表示順入れ替え → 却下: テンプレ可読性が下がり、SEO クローラの DOM 順とも乖離する

### トレードオフ
- テンプレ重複 +93 行 < 運用負荷ゼロ: 期間判定の `vket_end_datetime` を超えた瞬間に自動で元位置に戻るメリットを優先

## スクリーンショット (Vket期間中の表示)

| 全体 (Vket告知 → 実績 → 予定発表 → 特別企画) |
|---|
| ![Vket期間中の DOM 順序](https://agent-toolbox-assets.kaisha3.com/uploads/2026/06/911b11001e55-06-vket-active-fullpage-20260618-212532.avif) |

## テスト

- [x] ローカル (http://localhost:8015/) で Vket期間中 (`show_vket_notice = True`) の DOM 順序を確認
  - VKETコラボ実績カード → 📅 予定発表一覧 → ✨ 特別企画 → 注目イベント
- [x] ✨ 特別企画セクションが DOM 上で 1 箇所だけ出ることを Playwright snapshot で確認
- [x] コンソールエラーなし
- [ ] Vket期間外（`show_vket_notice = False`）の動作はテンプレ条件の論理判定で検証（排他なので動作確実）

🤖 Generated with [Claude Code](https://claude.com/claude-code)