### PR TITLE
fix(twitter): スライド公開告知に登壇者のXアカウントを含める

### DIFF
--- a/app/twitter/generators/event_intro.py
+++ b/app/twitter/generators/event_intro.py
@@ -7,6 +7,7 @@ from twitter.generators.common import (
     BODY_LINE_CONSTRAINT,
     _build_hashtag_suffix,
     _fit_candidate,
+    _format_speaker_display,
     _sanitize_for_prompt,
 )
 from website.constants import build_site_url
@@ -14,6 +15,7 @@ from website.constants import build_site_url
 
 def _fallback_slide_share_tweet(event_detail) -> str | None:
     community = event_detail.event.community
+    speaker_display = _format_speaker_display(event_detail)
     resources = []
     if event_detail.slide_url or event_detail.slide_file:
         resources.append("スライド")
@@ -23,7 +25,7 @@ def _fallback_slide_share_tweet(event_detail) -> str | None:
     body_lines = [
         (
             f"{_sanitize_for_prompt(community.name)} "
-            f"{_sanitize_for_prompt(event_detail.speaker)}さん"
+            f"{speaker_display}"
             f"「{_sanitize_for_prompt(event_detail.theme)}」"
         ),
         f"{resources_text}が公開されました",
@@ -52,7 +54,7 @@ def generate_slide_share_tweet(event_detail, target_chars=140, validation_feedba
     detail_url = build_site_url(f"/event/detail/{event_detail.pk}/")
 
     name = _sanitize_for_prompt(community.name)
-    speaker = _sanitize_for_prompt(event_detail.speaker)
+    speaker_display = _format_speaker_display(event_detail)
     theme = _sanitize_for_prompt(event_detail.theme)
 
     # 公開リソースの種類をフラグで判定（URLはプロンプトに含めない）
@@ -66,21 +68,21 @@ def generate_slide_share_tweet(event_detail, target_chars=140, validation_feedba
     user_prompt = f"""以下の発表の{resources_text}が公開されたことを伝えるポストを作成してください。
 
 集会名: {name}
-発表者: {speaker}
+発表者: {speaker_display}
 テーマ: {theme}
 公開された資料: {resources_text}
 {validation_feedback}
 
 ## 必須要素（必ず本文に含めること）
 1. 集会名（「{name}」）
-2. 発表者名（敬称は「さん」を付ける）
+2. 発表者（「{speaker_display}」をそのまま記載）
 3. 発表テーマ（「{theme}」をそのまま記載。言い換え・要約禁止）
 4. {resources_text}が公開されたこと
 5. 内容の補足と次のアクション（資料を見る・チェックする等）への誘導を**1行にまとめる**（本文3行制約のため別行にしない）
 
 ## 出力フォーマット（本文は3行以内）
 
-{{集会名}} {{発表者}}さん「{{テーマ}}」
+{{集会名}} {{発表者}}「{{テーマ}}」
 
 {{resources_text}}が公開されました
 {{内容補足 + 閲覧誘導を1行に統合}}

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -2648,6 +2648,91 @@ class TweetGeneratorTest(TestCase):
         self.assertNotIn("ツイート", user_prompt)
         self.assertIn("スライド・動画", user_prompt)
 
+    @patch("twitter.signals.threading.Thread")
+    @patch("twitter.tweet_generator._call_llm")
+    def test_generate_slide_share_tweet_includes_applicant_x_account(self, mock_llm, _mock_thread):
+        """スライド共有告知のプロンプトに申請者の X アカウントを含める"""
+        mock_llm.return_value = "スライド公開テスト"
+        applicant = CustomUser.objects.create_user(
+            user_name="slide_speaker",
+            email="slide_speaker@example.com",
+            password="testpassword",
+            x_account="speaker_vr",
+        )
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type="LT",
+            status="approved",
+            speaker="テスト太郎",
+            theme="Pythonのテスト技法",
+            start_time=datetime.time(22, 15),
+            slide_url="https://example.com/slides",
+            applicant=applicant,
+        )
+
+        from twitter.tweet_generator import generate_slide_share_tweet
+        generate_slide_share_tweet(detail)
+
+        _, user_prompt = mock_llm.call_args[0]
+        self.assertIn("発表者: テスト太郎さん（@speaker_vr）", user_prompt)
+        self.assertIn("発表者（「テスト太郎さん（@speaker_vr）」をそのまま記載）", user_prompt)
+
+    @patch("twitter.signals.threading.Thread")
+    @patch("twitter.tweet_generator._call_llm")
+    def test_generate_slide_share_tweet_uses_name_only_without_applicant_x_account(self, mock_llm, _mock_thread):
+        """申請者や X アカウントがないスライド告知は従来どおり名前だけを使う"""
+        mock_llm.return_value = "スライド公開テスト"
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type="LT",
+            status="approved",
+            speaker="テスト太郎",
+            theme="Pythonのテスト技法",
+            start_time=datetime.time(22, 15),
+            slide_url="https://example.com/slides",
+        )
+
+        from twitter.tweet_generator import generate_slide_share_tweet
+        generate_slide_share_tweet(detail)
+
+        _, user_prompt = mock_llm.call_args[0]
+        self.assertIn("発表者: テスト太郎さん", user_prompt)
+        self.assertNotIn("@", user_prompt)
+
+    @patch("twitter.signals.threading.Thread")
+    @patch("twitter.tweet_generator._call_llm")
+    def test_slide_share_generator_fallback_includes_applicant_x_account(self, mock_llm, _mock_thread):
+        """LLM 生成失敗時のスライド共有 fallback に申請者の X アカウントを含める"""
+        mock_llm.return_value = "\n".join(["長い本文"] * 20)
+        applicant = CustomUser.objects.create_user(
+            user_name="slide_fallback_speaker",
+            email="slide_fallback_speaker@example.com",
+            password="testpassword",
+            x_account="fallback_vr",
+        )
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type="LT",
+            status="approved",
+            speaker="テスト太郎",
+            theme="Pythonのテスト技法",
+            start_time=datetime.time(22, 15),
+            slide_url="https://example.com/slides",
+            applicant=applicant,
+        )
+        queue = TweetQueue.objects.create(
+            tweet_type="slide_share",
+            community=self.community,
+            event=self.event,
+            event_detail=detail,
+            status="generating",
+        )
+
+        from twitter.tweet_generator import get_generator
+        result = get_generator("slide_share")(queue)
+
+        self.assertIn("テスト太郎さん（@fallback_vr）", result)
+
     @patch("twitter.utils._call_llm")
     def test_generate_tweet_uses_post_terminology_in_prompt(self, mock_llm):
         """テンプレートベース生成のプロンプトがX/ポスト表記に統一されている"""


### PR DESCRIPTION
## なぜこの変更が必要か

LT 告知・当日リマインダーは PR #408（コミット `f4ede7a`, 2026-06-09）で登壇者の登録Xアカウントを `テスト太郎さん（@speaker_vr）` 形式で含めるようになっていたが、**スライド資料公開告知（slide_share）だけ同じアップデートが未適用** だった。

実投稿: https://x.com/vrc_ta_hub/status/2067774405762326795 でも「Rerrahさん」のみで `@` アカウントが付かず、登壇者本人にXの通知が届きにくい状態。また3種告知の登壇者表記が非対称になっていた。

Closes #482

## 変更内容

- `app/twitter/generators/event_intro.py`
  - 既存ヘルパー `_format_speaker_display`（`common.py:181-188`）を import
  - `_fallback_slide_share_tweet`: `{speaker}さん` 直書きを `speaker_display` に置き換え
  - `generate_slide_share_tweet`: `speaker = _sanitize_for_prompt(...)` を `speaker_display = _format_speaker_display(...)` に差し替え、プロンプト文言・必須要素・出力フォーマットを LT 告知 (`lt_tweet.py`) に揃え、「{発表者}さん」の二重出力を防止
- `app/twitter/tests/test_auto_tweet.py` に 3 本追加（LT 側 #408 の対応テストと同パターン）
  - `test_generate_slide_share_tweet_includes_applicant_x_account`
  - `test_generate_slide_share_tweet_uses_name_only_without_applicant_x_account`
  - `test_slide_share_generator_fallback_includes_applicant_x_account`

### 期待される表示

| 状況 | 出力 |
|------|------|
| `applicant` あり + `x_account` 登録済み | `テスト太郎さん（@speaker_vr）` |
| `applicant` なし or `x_account` 空文字 | `テスト太郎さん`（従来通り、`@` を含まない） |

## 意思決定

### 採用アプローチ
- 既存ヘルパー `_format_speaker_display` の流用。理由: LT 告知 (#408) で既に同じ仕様で動作しており、副作用がない・テスト済みで枯れている

### 却下した代替案
- `EventDetail` に `speaker_x_account` フィールドを新規追加 → 却下: マイグレーションコストに見合うメリットがなく、`CustomUser.x_account` を Single Source of Truth にすべき
- LLM 出力後に `@xxx` を文字列追記 → 却下: 140字制約のもとで決定的な fit が崩れる / プロンプト内で表現する方が出力が安定する

### トレードオフ
- プロンプト文言を LT 側と統一 > 細部の文言差: 3種告知の運用一貫性を優先

## テスト

### 自動テスト

```bash
docker compose -f docker-compose.yaml -f docker-compose.test.yml run --rm test \
  python manage.py test twitter.tests.test_auto_tweet.TweetGeneratorTest -v 2
```

結果: **19 tests OK**（追加 3 件 + 既存 16 件、リグレッションなし）

### 既知の既存問題（本変更とは無関係）

`twitter.tests.test_auto_tweet.UploadMediaFunctionTest` の 5 件が fail しているが、本変更を `git stash` した main 同等の状態でも同じ 5 件が fail することを確認済み。別 Issue として切り出すかは検討余地あり。

## 参考

- 先行 PR: #408 `fix: LT告知に登壇者のXアカウントを含める`
- 先行コミット: `f4ede7a`
- ヘルパー: `app/twitter/generators/common.py:181-188 _format_speaker_display`
- LT 側参考実装: `app/twitter/generators/lt_tweet.py`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)