### PR TITLE
fix: お知らせ詳細の閲覧導線を追加する

### DIFF
--- a/app/vket/templates/vket/ack_notice.html
+++ b/app/vket/templates/vket/ack_notice.html
@@ -51,9 +51,15 @@
                 <div class="mt-3 text-muted small">
                     確認日時: {{ receipt.acknowledged_at|date:"Y/m/d H:i" }}
                 </div>
-                <a href="{% url 'vket:status' pk=collaboration_id %}" class="btn btn-primary mt-3">
-                    <i class="fas fa-arrow-right me-1"></i>参加状況ページへ
-                </a>
+                <div class="d-flex justify-content-center gap-2 flex-wrap mt-3">
+                    <a href="{% url 'vket:notice_list' pk=collaboration_id %}?open={{ receipt.notice.id }}"
+                       class="btn btn-outline-secondary">
+                        <i class="fas fa-bell me-1"></i>お知らせ一覧で詳細を見る
+                    </a>
+                    <a href="{% url 'vket:status' pk=collaboration_id %}" class="btn btn-primary">
+                        <i class="fas fa-arrow-right me-1"></i>参加状況ページへ
+                    </a>
+                </div>
             {% else %}
                 <form method="post" class="mt-4">
                     {% csrf_token %}

--- a/app/vket/templates/vket/manage_notice_list.html
+++ b/app/vket/templates/vket/manage_notice_list.html
@@ -1,4 +1,5 @@
 {% extends 'ta_hub/base.html' %}
+{% load markdown_extras %}
 {% block meta %}
     <title>{{ collaboration.name }} お知らせ管理 - VRChat 技術・学術系イベントHub</title>
 {% endblock %}
@@ -33,7 +34,7 @@
                         <th style="min-width: 80px;">要確認</th>
                         <th style="min-width: 100px;">ACK状況</th>
                         <th style="min-width: 130px;">作成日時</th>
-                        <th style="min-width: 80px;">操作</th>
+                        <th style="min-width: 110px;">操作</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -70,21 +71,76 @@
                                 {{ stat.notice.created_at|date:"Y/m/d H:i" }}
                             </td>
                             <td>
-                                <button class="btn btn-sm btn-outline-secondary"
-                                        data-bs-toggle="modal"
-                                        data-bs-target="#noticeEditModal"
-                                        data-notice-id="{{ stat.notice.id }}"
-                                        data-notice-title="{{ stat.notice.title }}"
-                                        data-notice-body="{{ stat.notice.body }}"
-                                        data-edit-url="{% url 'vket:manage_notice_update' collaboration.id stat.notice.id %}">
-                                    <i class="fas fa-edit"></i>
-                                </button>
+                                <div class="btn-group btn-group-sm" role="group" aria-label="お知らせ操作">
+                                    <button class="btn btn-outline-primary"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#noticeDetailModal{{ stat.notice.id }}"
+                                            title="詳細">
+                                        <i class="fas fa-eye"></i>
+                                    </button>
+                                    <button class="btn btn-outline-secondary"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#noticeEditModal"
+                                            data-notice-id="{{ stat.notice.id }}"
+                                            data-notice-title="{{ stat.notice.title }}"
+                                            data-notice-body="{{ stat.notice.body }}"
+                                            data-edit-url="{% url 'vket:manage_notice_update' collaboration.id stat.notice.id %}"
+                                            title="編集">
+                                        <i class="fas fa-edit"></i>
+                                    </button>
+                                </div>
                             </td>
                         </tr>
                     {% endfor %}
                     </tbody>
                 </table>
             </div>
+
+            {% for stat in notice_stats %}
+                <div class="modal fade" id="noticeDetailModal{{ stat.notice.id }}" tabindex="-1"
+                     aria-labelledby="noticeDetailModalLabel{{ stat.notice.id }}" aria-hidden="true">
+                    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="noticeDetailModalLabel{{ stat.notice.id }}">
+                                    <i class="fas fa-bell me-2"></i>{{ stat.notice.title }}
+                                </h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                                <dl class="row small mb-3">
+                                    <dt class="col-sm-3">対象</dt>
+                                    <dd class="col-sm-9">{{ stat.notice.get_target_scope_display }}</dd>
+                                    <dt class="col-sm-3">要確認</dt>
+                                    <dd class="col-sm-9">
+                                        {% if stat.notice.requires_ack %}あり{% else %}なし{% endif %}
+                                    </dd>
+                                    <dt class="col-sm-3">ACK状況</dt>
+                                    <dd class="col-sm-9">
+                                        {% if stat.notice.requires_ack and stat.total > 0 %}
+                                            {{ stat.acked }}/{{ stat.total }}確認
+                                        {% else %}
+                                            <span class="text-muted">--</span>
+                                        {% endif %}
+                                    </dd>
+                                    {% if stat.unacked_community_names %}
+                                        <dt class="col-sm-3">未確認集会</dt>
+                                        <dd class="col-sm-9">{{ stat.unacked_community_names|join:', ' }}</dd>
+                                    {% endif %}
+                                    <dt class="col-sm-3">作成日時</dt>
+                                    <dd class="col-sm-9">{{ stat.notice.created_at|date:"Y/m/d H:i" }}</dd>
+                                </dl>
+                                <div class="border-top pt-3">
+                                    <div class="notice-body">{{ stat.notice.body|markdown }}</div>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">閉じる</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
         {% endif %}
     </div>
 

--- a/app/vket/templates/vket/participation_status.html
+++ b/app/vket/templates/vket/participation_status.html
@@ -101,14 +101,23 @@
                         {% for receipt in latest_notices %}
                             <div class="d-flex justify-content-between align-items-start border-bottom pb-2 mb-2">
                                 <div>
-                                    <div class="fw-bold">{{ receipt.notice.title }}</div>
+                                    <a href="{% url 'vket:notice_list' collaboration.pk %}?open={{ receipt.notice.id }}"
+                                       class="fw-bold text-decoration-none">
+                                        {{ receipt.notice.title }}
+                                    </a>
                                     <div class="text-muted small">{{ receipt.created_at|date:"Y/m/d H:i" }}</div>
                                 </div>
-                                {% if receipt.acknowledged_at %}
-                                    <span class="badge bg-success ms-2">確認済み</span>
-                                {% elif receipt.notice.requires_ack %}
-                                    <span class="badge bg-warning text-dark ms-2">要確認</span>
-                                {% endif %}
+                                <div class="d-flex gap-2 align-items-center ms-2 flex-shrink-0">
+                                    {% if receipt.acknowledged_at %}
+                                        <span class="badge bg-success">確認済み</span>
+                                    {% elif receipt.notice.requires_ack %}
+                                        <span class="badge bg-warning text-dark">要確認</span>
+                                    {% endif %}
+                                    <a href="{% url 'vket:notice_list' collaboration.pk %}?open={{ receipt.notice.id }}"
+                                       class="btn btn-sm btn-outline-secondary">
+                                        詳細
+                                    </a>
+                                </div>
                             </div>
                         {% endfor %}
                     </div>

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -1707,6 +1707,26 @@ class VketNoticeTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context['already_acked'])
 
+    def test_ack_notice_view_links_back_to_open_notice_detail(self):
+        """ACK済み画面から対象のお知らせ詳細を開いた一覧へ戻れる"""
+        receipt = VketNoticeReceipt.objects.create(
+            notice=self.notice,
+            participation=self.participation,
+            acknowledged_at=timezone.now(),
+        )
+
+        response = self.client.get(
+            reverse('vket:ack_notice', kwargs={'ack_token': str(receipt.ack_token)})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        detail_url = (
+            f"{reverse('vket:notice_list', kwargs={'pk': self.collaboration.pk})}"
+            f"?open={self.notice.pk}"
+        )
+        self.assertContains(response, detail_url)
+        self.assertContains(response, 'お知らせ一覧で詳細を見る')
+
     def test_notice_list_view_requires_login(self):
         """お知らせ一覧はログイン必須"""
         response = self.client.get(
@@ -1714,6 +1734,29 @@ class VketNoticeTests(TestCase):
         )
         # ログイン画面にリダイレクト
         self.assertEqual(response.status_code, 302)
+
+    def test_notice_list_view_shows_acked_notice_detail(self):
+        """参加者側一覧はACK済みでもお知らせ本文を開ける"""
+        self.notice.body = '1行目の詳細\n\n"引用" と & 記号を含む本文'
+        self.notice.save(update_fields=['body'])
+        VketNoticeReceipt.objects.create(
+            notice=self.notice,
+            participation=self.participation,
+            acknowledged_at=timezone.now(),
+        )
+
+        self.client.login(username='owner_user2', password='testpass123')
+        response = self.client.get(
+            reverse('vket:notice_list', kwargs={'pk': self.collaboration.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.notice.title)
+        self.assertContains(response, '確認済み')
+        self.assertContains(response, f'data-bs-target="#notice-{self.notice.pk}"')
+        self.assertContains(response, f'id="notice-{self.notice.pk}"')
+        self.assertContains(response, '1行目の詳細')
+        self.assertContains(response, '引用')
 
     def test_manage_notice_list_requires_staff(self):
         """管理用お知らせ一覧はstaff権限が必要"""
@@ -1731,6 +1774,49 @@ class VketNoticeTests(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.notice.title)
+
+    def test_manage_notice_list_shows_acked_notice_detail_modal(self):
+        """管理一覧はACK済みでも全文詳細モーダルを表示する"""
+        self.notice.body = '管理向け詳細本文\n\n"引用" と & 記号を含む本文'
+        self.notice.save(update_fields=['body'])
+        VketNoticeReceipt.objects.create(
+            notice=self.notice,
+            participation=self.participation,
+            acknowledged_at=timezone.now(),
+        )
+
+        self.client.login(username='admin_user2', password='adminpass123')
+        response = self.client.get(
+            reverse('vket:manage_notice_list', kwargs={'pk': self.collaboration.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'noticeDetailModal{self.notice.pk}')
+        self.assertContains(response, '管理向け詳細本文')
+        self.assertContains(response, '引用')
+        self.assertContains(response, '1/1確認')
+        self.assertContains(response, '作成日時')
+
+    def test_status_page_latest_notice_links_to_open_detail(self):
+        """参加状況ページの最新お知らせから対象詳細を開ける"""
+        VketNoticeReceipt.objects.create(
+            notice=self.notice,
+            participation=self.participation,
+            acknowledged_at=timezone.now(),
+        )
+
+        self.client.login(username='owner_user2', password='testpass123')
+        response = self.client.get(
+            reverse('vket:status', kwargs={'pk': self.collaboration.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        detail_url = (
+            f"{reverse('vket:notice_list', kwargs={'pk': self.collaboration.pk})}"
+            f"?open={self.notice.pk}"
+        )
+        self.assertContains(response, detail_url, count=2)
+        self.assertContains(response, '詳細')
 
     def test_notice_create_auto_generates_receipts(self):
         """お知らせ作成時にactive参加者分のReceiptが自動生成される"""


### PR DESCRIPTION
## なぜこの変更が必要か

Vketのお知らせは、一度確認済みにした後も運営・参加者が内容を見返せる必要がある。
しかし管理側では全文詳細を開く専用導線がなく、参加者側もACK後に該当お知らせへ戻る導線と回帰テストが不足していたため、確認後に詳細を再表示できないように見える状態だった。

## 変更内容

- 管理側のお知らせ一覧に読み取り専用の詳細モーダルを追加
- 管理側の操作を「詳細」と「編集」に分け、ACK状況に関係なく本文全文を確認可能に変更
- ACK済み画面から該当お知らせを開いた状態の参加者側一覧へ戻るリンクを追加
- 参加状況ページの最新お知らせから該当詳細へ直接遷移できる導線を追加
- ACK済みでも管理側・参加者側で詳細本文が表示される回帰テストを追加

## 意思決定

### 採用アプローチ
- 管理側は編集モーダルとは別に読み取り専用モーダルを追加。誤編集を避けつつ、本文をその場で確認できるため。
- 参加者側は既存accordionを詳細表示として維持。画面構造を大きく変えず、`?open=<notice_id>` で該当項目を開く導線だけを補強した。

### トレードオフ
- 管理一覧内にお知らせ件数分の詳細モーダルを描画する。件数が極端に多い画面ではHTML量が増えるが、既存の管理画面規模では実装の単純さと壊れにくさを優先した。

## テスト

- [x] `docker compose exec -T vrc-ta-hub python manage.py test vket.tests.test_vket.VketNoticeTests --keepdb`
- [x] `docker compose exec -T vrc-ta-hub python manage.py test vket --keepdb`
- [x] `git diff --check`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)