### PR TITLE
fix: it-infra CORS originを許可

### DIFF
--- a/app/api_v1/tests/test_cors.py
+++ b/app/api_v1/tests/test_cors.py
@@ -1,0 +1,63 @@
+"""公開 API の CORS 許可 Origin を検証する回帰テスト."""
+
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+ALLOWED_ORIGIN = 'https://it-infra-meetup.org'
+UNKNOWN_ORIGIN = 'https://example.invalid'
+PUBLIC_API_URLS = (
+    '/api/v1/event/?format=json',
+    '/api/v1/event_detail/?format=json',
+)
+
+
+@override_settings(
+    CORS_ALLOWED_ORIGINS=[
+        'https://vrc-ta-hub.com',
+        ALLOWED_ORIGIN,
+    ],
+)
+class PublicApiCorsTests(TestCase):
+    """外部連携サイトから公開 API を読めることを検証する."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_public_event_apis_allow_configured_origin_on_get(self):
+        """許可 Origin の GET には Access-Control-Allow-Origin を返す."""
+        for url in PUBLIC_API_URLS:
+            with self.subTest(url=url):
+                response = self.client.get(url, HTTP_ORIGIN=ALLOWED_ORIGIN)
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(
+                    response.get('access-control-allow-origin'),
+                    ALLOWED_ORIGIN,
+                )
+
+    def test_public_event_apis_allow_configured_origin_on_preflight(self):
+        """許可 Origin の OPTIONS preflight に CORS ヘッダーを返す."""
+        for url in PUBLIC_API_URLS:
+            with self.subTest(url=url):
+                response = self.client.options(
+                    url,
+                    HTTP_ORIGIN=ALLOWED_ORIGIN,
+                    HTTP_ACCESS_CONTROL_REQUEST_METHOD='GET',
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(
+                    response.get('access-control-allow-origin'),
+                    ALLOWED_ORIGIN,
+                )
+
+    def test_public_event_apis_do_not_allow_unknown_origin(self):
+        """未許可 Origin には Access-Control-Allow-Origin を返さない."""
+        for url in PUBLIC_API_URLS:
+            with self.subTest(url=url):
+                response = self.client.get(url, HTTP_ORIGIN=UNKNOWN_ORIGIN)
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertIsNone(response.get('access-control-allow-origin'))

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,9 +35,9 @@ steps:
       - '--set-secrets'
       - 'DISCORD_WEBHOOK_URL=DISCORD_WEBHOOK_URL:latest,DISCORD_CLIENT_ID=DISCORD_CLIENT_ID:latest,DISCORD_CLIENT_SECRET=DISCORD_CLIENT_SECRET:latest,DISCORD_REPORT_WEBHOOK_URL=DISCORD_REPORT_WEBHOOK_URL:latest,X_API_KEY=X_API_KEY:latest,X_API_SECRET=X_API_SECRET:latest,X_ACCESS_TOKEN=X_ACCESS_TOKEN:latest,X_ACCESS_TOKEN_SECRET=X_ACCESS_TOKEN_SECRET:latest,FERNET_KEY=FERNET_KEY:latest,SENTRY_DSN=SENTRY_DSN:latest'
       # GA4_PROPERTY_ID: GA4 Data API のプロパティID
-      # CORS_ALLOWED_ORIGINS: /api/ への CORS 許可オリジン (CSV)。本番フロントの自オリジン。
+      # CORS_ALLOWED_ORIGINS: /api/ への CORS 許可オリジン (CSV)。本番フロントと連携サイト。
       - '--update-env-vars'
-      - 'GA4_PROPERTY_ID=444114283,CORS_ALLOWED_ORIGINS=https://vrc-ta-hub.com'
+      - '^|^GA4_PROPERTY_ID=444114283|CORS_ALLOWED_ORIGINS=https://vrc-ta-hub.com,https://it-infra-meetup.org'
       - '${_SERVICE_NAME}'
 
   # 旧 `rev-*` タグの掃除のみ実施。カナリア検証用の `canary` タグは deploy-watch スキルが


### PR DESCRIPTION
## 概要
- Cloud Run デプロイ時の CORS_ALLOWED_ORIGINS に https://it-infra-meetup.org を追加
- カンマ入り env 値が gcloud で分割されないよう --update-env-vars の区切りを ^|^ に変更
- 公開 event / event_detail API の GET / OPTIONS CORS 回帰テストを追加

## 原因
- 本番の CORS_ALLOWED_ORIGINS が https://vrc-ta-hub.com のみに固定され、it-infra-meetup.org からの fetch に Access-Control-Allow-Origin が返っていなかった

## 検証
- docker compose exec -T vrc-ta-hub python manage.py test api_v1.tests.test_cors -v 2
- docker compose exec -T vrc-ta-hub python manage.py check
- docker compose exec -T vrc-ta-hub python manage.py test api_v1.tests.test_event_api api_v1.tests.test_event_detail_api -v 1
- git diff --check