### PR TITLE
feat(event): 発表申請ページに発表後のスライド登録依頼を追記

### DIFF
--- a/app/event/templates/event/lt_application_form.html
+++ b/app/event/templates/event/lt_application_form.html
@@ -26,11 +26,12 @@
                     <div class="alert alert-info mb-4">
                         <h5 class="alert-heading"><i class="bi bi-info-circle me-2"></i>申請について</h5>
                         <p class="mb-2">発表の申請は、主催者の承認後に正式に登録されます。</p>
-                        <ul class="mb-0">
+                        <ul class="mb-2">
                             <li>申請後、主催者にメールで通知されます</li>
                             <li>承認または却下の結果はメールでお知らせします</li>
                             <li>発表内容の詳細（スライドや動画）は承認後に編集できます</li>
                         </ul>
+                        <p class="mb-0">発表後にスライドの登録にご協力をお願いします。</p>
                     </div>
 
                     {% if not form.fields.event.queryset.exists %}


### PR DESCRIPTION
## Summary

- 発表申請フォーム（`/event/apply/<community_pk>/`）の「申請について」案内に、登壇後のスライド登録協力を依頼する一文を追加
- 既存リストの直下に `<p class="mb-0">発表後にスライドの登録にご協力をお願いします。</p>` を配置（リスト側は `mb-0` → `mb-2` に変更して余白を調整）
- アーカイブ価値・SEO 強化のため、発表後のスライド共有率を上げることが目的

## Screenshot

![申請ページに追記された文言](https://agent-toolbox-assets.kaisha3.com/uploads/2026/06/aab7c75753df-01-event-apply-slide-request-20260626-221529.avif)

## Test plan

- [x] ローカル `http://localhost:8015/event/apply/2/` でログイン後、案内ブロックに新しい一文が想定どおり表示されることを確認
- [x] 既存リストとの余白・タイポ・絵文字混入なしを確認
- [ ] レビュー後マージ → 本番反映でユーザー視認確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)