### PR TITLE
fix: Discord通知設定に使い方ガイドへの導線を追加

### DIFF
--- a/app/community/templates/community/settings.html
+++ b/app/community/templates/community/settings.html
@@ -82,6 +82,11 @@
                 <h6 class="fw-medium mb-2">
                     <i class="fa-brands fa-discord me-2"></i>Discord通知
                 </h6>
+                <p class="text-muted small mb-3">
+                    Webhook URLの取得方法やメンション設定は、
+                    <a href="/guide/settings/discord/" class="fw-medium">Discord Webhook設定ガイド</a>
+                    をご確認ください。
+                </p>
                 <div class="d-flex gap-2 align-items-stretch">
                     <form method="post" action="{% url 'community:update_webhook' community.pk %}"
                           class="d-flex flex-grow-1 gap-2">

--- a/app/community/tests/test_settings.py
+++ b/app/community/tests/test_settings.py
@@ -360,6 +360,8 @@ class WebhookSettingsTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Discord通知')
+        self.assertContains(response, 'Discord Webhook設定ガイド')
+        self.assertContains(response, '/guide/settings/discord/')
         self.assertContains(response, '以下のタイミングでDiscordに通知を送信します')
         self.assertContains(response, '発表申請があった時')
         self.assertContains(response, '発表資料（スライドURL／PDF）が初めて公開された時')


### PR DESCRIPTION
## なぜこの変更が必要か

集会設定のDiscord通知欄にはWebhook URLの入力欄がありますが、Discord側でWebhook URLをどこから取得するか、メンション設定をどう準備するかが画面上から分かりにくい状態でした。
既存の使い方ガイドに詳しい手順があるため、設定作業中のユーザーがその場で確認できる導線を追加します。

## 変更内容

- `/community/settings/` のDiscord通知セクションに「Discord Webhook設定ガイド」へのリンクを追加
- 既存ガイド `/guide/settings/discord/` をリンク先として利用
- 設定画面の表示テストでリンク文言とURLを確認

## テスト

- `docker compose exec vrc-ta-hub python manage.py test community.tests.test_settings.WebhookSettingsTest.test_settings_page_shows_webhook_section`
- `docker compose exec vrc-ta-hub python manage.py test community.tests.test_settings`
- Playwright CLIで `http://localhost:8015/community/settings/` を確認
  - Discord通知セクションにガイドリンクが表示されること
  - リンククリックで `/guide/settings/discord/` に遷移すること
  - コンソールエラーがないこと

## Screenshot

| Before | After |
|--------|-------|
| ![before-community-discord-guide-link](https://agent-toolbox-assets.kaisha3.com/uploads/2026/06/dce95e0db246-before-community-discord-guide-link.avif) | ![after-community-discord-guide-link](https://agent-toolbox-assets.kaisha3.com/uploads/2026/06/ad45fb8d61b7-after-community-discord-guide-link.avif) |