### PR TITLE
fix(vket): 管理画面で公開前発表の開始時刻を更新可能にする

### DIFF
--- a/app/vket/templates/vket/manage.html
+++ b/app/vket/templates/vket/manage.html
@@ -146,10 +146,10 @@
                                             {{ pres.speaker|default:"発表"|truncatechars:8 }}
                                         </span>
                                         <span class="d-flex gap-1 align-items-center">
-                                            {% if pres.published_event_detail %}
+                                            {% if pres.status == 'confirmed' or pres.published_event_detail %}
                                                 <input class="form-control form-control-sm" type="time"
-                                                       name="detail_{{ pres.published_event_detail.id }}_start_time"
-                                                       value="{{ pres.published_event_detail.start_time|date:'H:i' }}"
+                                                       name="pres_{{ pres.pk }}_start_time"
+                                                       value="{% if pres.confirmed_start_time %}{{ pres.confirmed_start_time|date:'H:i' }}{% elif pres.published_event_detail %}{{ pres.published_event_detail.start_time|date:'H:i' }}{% elif pres.requested_start_time %}{{ pres.requested_start_time|date:'H:i' }}{% endif %}"
                                                        step="300"
                                                        style="width: 5.5rem; padding: 0.1rem 0.2rem;">
                                             {% else %}

--- a/app/vket/templates/vket/manage.html
+++ b/app/vket/templates/vket/manage.html
@@ -149,7 +149,7 @@
                                             {% if pres.status == 'confirmed' or pres.published_event_detail %}
                                                 <input class="form-control form-control-sm" type="time"
                                                        name="pres_{{ pres.pk }}_start_time"
-                                                       value="{% if pres.confirmed_start_time %}{{ pres.confirmed_start_time|date:'H:i' }}{% elif pres.published_event_detail %}{{ pres.published_event_detail.start_time|date:'H:i' }}{% elif pres.requested_start_time %}{{ pres.requested_start_time|date:'H:i' }}{% endif %}"
+                                                       value="{% if pres.published_event_detail %}{{ pres.published_event_detail.start_time|date:'H:i' }}{% elif pres.confirmed_start_time %}{{ pres.confirmed_start_time|date:'H:i' }}{% elif pres.requested_start_time %}{{ pres.requested_start_time|date:'H:i' }}{% endif %}"
                                                        step="300"
                                                        style="width: 5.5rem; padding: 0.1rem 0.2rem;">
                                             {% else %}

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -1545,6 +1545,36 @@ class VketManageViewsTests(TestCase):
         self.assertContains(response, 'value="21:30"')
         self.assertNotContains(response, f'name="pres_{draft_pres.pk}_start_time"')
 
+    def test_manage_page_prefers_event_detail_time_for_published_presentation(self):
+        """公開済み発表の入力初期値は公開EventDetailの時刻を優先する"""
+        self.client.login(username='admin_user', password='adminpass123')
+        detail = EventDetail.objects.create(
+            event=self.event1,
+            detail_type='LT',
+            speaker='公開済み登壇者',
+            theme='公開済みテーマ',
+            start_time='22:15',
+            duration=30,
+            status='approved',
+        )
+        presentation = VketPresentation.objects.create(
+            participation=self.participation1,
+            order=0,
+            speaker='公開済み登壇者',
+            theme='公開済みテーマ',
+            confirmed_start_time='21:30',
+            status=VketPresentation.Status.CONFIRMED,
+            published_event_detail=detail,
+        )
+
+        response = self.client.get(
+            reverse('vket:manage', kwargs={'pk': self.collaboration.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'name="pres_{presentation.pk}_start_time"')
+        self.assertContains(response, 'value="22:15"')
+
     def test_manage_page_shows_lt_time_badge(self):
         """管理画面でLT時間バッジが表示される"""
         self.client.login(username='admin_user', password='adminpass123')

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -1319,6 +1319,55 @@ class VketManageViewsTests(TestCase):
         self.assertEqual(foreign_presentation.confirmed_start_time.strftime('%H:%M'), '21:30')
         self.assertEqual(foreign_detail.start_time.strftime('%H:%M'), '21:30')
 
+    def test_manage_participation_update_does_not_sync_foreign_event_detail(self):
+        """同参加の発表でも別イベントのEventDetailは更新しない"""
+        self.client.login(username='admin_user', password='adminpass123')
+        foreign_detail = EventDetail.objects.create(
+            event=self.event2,
+            detail_type='LT',
+            speaker='別イベント登壇者',
+            theme='別イベントテーマ',
+            start_time='21:30',
+            duration=30,
+            status='approved',
+        )
+        presentation = VketPresentation.objects.create(
+            participation=self.participation1,
+            order=0,
+            speaker='不整合登壇者',
+            theme='不整合テーマ',
+            confirmed_start_time='21:30',
+            status=VketPresentation.Status.CONFIRMED,
+            published_event_detail=foreign_detail,
+        )
+        cache_key = get_index_view_cache_key()
+        cache.set(cache_key, {'upcoming_event_details': ['stale']}, 60)
+        new_date = self.collaboration.period_start
+        response = self.client.post(
+            reverse(
+                'vket:manage_participation_update',
+                kwargs={
+                    'pk': self.collaboration.pk,
+                    'participation_id': self.participation1.pk,
+                },
+            ),
+            data={
+                'confirmed_date': new_date.isoformat(),
+                'confirmed_start_time': '21:00',
+                'confirmed_duration': '60',
+                'admin_note': '',
+                f'pres_{presentation.pk}_start_time': '23:00',
+            },
+            follow=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        presentation.refresh_from_db()
+        foreign_detail.refresh_from_db()
+        self.assertEqual(presentation.confirmed_start_time.strftime('%H:%M'), '23:00')
+        self.assertEqual(foreign_detail.start_time.strftime('%H:%M'), '21:30')
+        self.assertIsNotNone(cache.get(cache_key))
+
     def test_manage_update_confirms_draft_presentations(self):
         """確定ボタン押下でDRAFTのLTがCONFIRMEDに一括更新される"""
         self.client.login(username='admin_user', password='adminpass123')

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -1183,16 +1183,67 @@ class VketManageViewsTests(TestCase):
         self.assertIsNone(new_participation.confirmed_date)
         self.assertFalse(new_participation.schedule_adjusted_by_admin)
 
-    def test_manage_participation_update_updates_event_detail_start_time(self):
-        """日程確定時にEventDetailのLT開始時刻が更新される"""
+    def test_manage_participation_update_sets_rehearsal_presentation_start_time(self):
+        """公開前の発表開始時刻はVketPresentationに保存される"""
         self.client.login(username='admin_user', password='adminpass123')
-        # EventDetailを作成
+        participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=Community.objects.create(name='集会C', status='approved', frequency='毎週'),
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time='21:00',
+            confirmed_duration=60,
+        )
+        presentation = VketPresentation.objects.create(
+            participation=participation,
+            order=0,
+            speaker='公開前登壇者',
+            theme='公開前テーマ',
+            requested_start_time='21:30',
+            status=VketPresentation.Status.CONFIRMED,
+        )
+        new_date = self.collaboration.period_start
+        response = self.client.post(
+            reverse(
+                'vket:manage_participation_update',
+                kwargs={
+                    'pk': self.collaboration.pk,
+                    'participation_id': participation.pk,
+                },
+            ),
+            data={
+                'confirmed_date': new_date.isoformat(),
+                'confirmed_start_time': '21:00',
+                'confirmed_duration': '60',
+                'admin_note': '',
+                f'pres_{presentation.pk}_start_time': '22:15',
+            },
+            follow=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        presentation.refresh_from_db()
+        self.assertEqual(presentation.confirmed_start_time.strftime('%H:%M'), '22:15')
+        self.assertIsNone(presentation.published_event_detail_id)
+
+    def test_manage_participation_update_updates_published_presentation_start_time(self):
+        """公開済み発表の開始時刻はVketPresentationとEventDetailに同期される"""
+        self.client.login(username='admin_user', password='adminpass123')
         detail = EventDetail.objects.create(
             event=self.event1,
             detail_type='LT',
+            speaker='公開済み登壇者',
+            theme='公開済みテーマ',
             start_time='21:30',
             duration=30,
             status='approved',
+        )
+        presentation = VketPresentation.objects.create(
+            participation=self.participation1,
+            order=0,
+            speaker='公開済み登壇者',
+            theme='公開済みテーマ',
+            status=VketPresentation.Status.CONFIRMED,
+            published_event_detail=detail,
         )
         cache_key = get_index_view_cache_key()
         cache.set(cache_key, {'upcoming_event_details': ['stale']}, 60)
@@ -1210,26 +1261,38 @@ class VketManageViewsTests(TestCase):
                 'confirmed_start_time': '21:00',
                 'confirmed_duration': '60',
                 'admin_note': '',
-                f'detail_{detail.pk}_start_time': '22:15',
+                f'pres_{presentation.pk}_start_time': '22:15',
             },
             follow=False,
         )
         self.assertEqual(response.status_code, 302)
 
+        presentation.refresh_from_db()
         detail.refresh_from_db()
+        self.assertEqual(presentation.confirmed_start_time.strftime('%H:%M'), '22:15')
         self.assertEqual(detail.start_time.strftime('%H:%M'), '22:15')
         self.assertIsNone(cache.get(cache_key))
 
-    def test_manage_participation_update_rejects_foreign_event_detail(self):
-        """別のイベントのEventDetailは更新できない"""
+    def test_manage_participation_update_rejects_foreign_presentation(self):
+        """別参加の発表開始時刻は更新できない"""
         self.client.login(username='admin_user', password='adminpass123')
-        # event2に属するdetailをevent1の参加で更新しようとする
         foreign_detail = EventDetail.objects.create(
             event=self.event2,
             detail_type='LT',
+            speaker='別参加登壇者',
+            theme='別参加テーマ',
             start_time='21:30',
             duration=30,
             status='approved',
+        )
+        foreign_presentation = VketPresentation.objects.create(
+            participation=self.participation2,
+            order=0,
+            speaker='別参加登壇者',
+            theme='別参加テーマ',
+            confirmed_start_time='21:30',
+            status=VketPresentation.Status.CONFIRMED,
+            published_event_detail=foreign_detail,
         )
         new_date = self.collaboration.period_start
         response = self.client.post(
@@ -1245,14 +1308,15 @@ class VketManageViewsTests(TestCase):
                 'confirmed_start_time': '21:00',
                 'confirmed_duration': '60',
                 'admin_note': '',
-                f'detail_{foreign_detail.pk}_start_time': '23:00',
+                f'pres_{foreign_presentation.pk}_start_time': '23:00',
             },
             follow=False,
         )
         self.assertEqual(response.status_code, 302)
 
-        # 別イベントのdetailは更新されない
+        foreign_presentation.refresh_from_db()
         foreign_detail.refresh_from_db()
+        self.assertEqual(foreign_presentation.confirmed_start_time.strftime('%H:%M'), '21:30')
         self.assertEqual(foreign_detail.start_time.strftime('%H:%M'), '21:30')
 
     def test_manage_update_confirms_draft_presentations(self):
@@ -1303,6 +1367,45 @@ class VketManageViewsTests(TestCase):
         confirmed_pres.refresh_from_db()
         self.assertEqual(draft_pres.status, VketPresentation.Status.CONFIRMED)
         self.assertEqual(confirmed_pres.status, VketPresentation.Status.CONFIRMED)
+
+    def test_manage_update_ignores_posted_start_time_for_initial_draft_presentation(self):
+        """DRAFT発表の開始時刻は同一POSTで送られても更新しない"""
+        self.client.login(username='admin_user', password='adminpass123')
+        participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=Community.objects.create(name='集会E', status='approved', frequency='毎週'),
+            requested_date=self.collaboration.period_start,
+            requested_start_time='22:00',
+            requested_duration=60,
+        )
+        draft_pres = VketPresentation.objects.create(
+            participation=participation,
+            order=0,
+            speaker='DRAFT登壇者',
+            theme='DRAFTテーマ',
+            status=VketPresentation.Status.DRAFT,
+        )
+
+        new_date = self.collaboration.period_start + timedelta(days=1)
+        self.client.post(
+            reverse(
+                'vket:manage_participation_update',
+                kwargs={
+                    'pk': self.collaboration.pk,
+                    'participation_id': participation.pk,
+                },
+            ),
+            data={
+                'confirmed_date': new_date.isoformat(),
+                'confirmed_start_time': '22:00',
+                'confirmed_duration': '60',
+                f'pres_{draft_pres.pk}_start_time': '22:15',
+            },
+        )
+
+        draft_pres.refresh_from_db()
+        self.assertEqual(draft_pres.status, VketPresentation.Status.CONFIRMED)
+        self.assertIsNone(draft_pres.confirmed_start_time)
 
     def test_manage_update_creates_event_detail_for_new_presentation(self):
         """確定ボタンでpublished_event_detailがないCONFIRMED LTにEventDetailが作成される"""
@@ -1357,6 +1460,41 @@ class VketManageViewsTests(TestCase):
         self.assertContains(response, 'DRAFT登壇者')
         self.assertContains(response, '申請中')
         self.assertContains(response, 'badge bg-warning')
+
+    def test_manage_page_shows_time_input_for_rehearsal_confirmed_presentation(self):
+        """公開前のCONFIRMED発表には開始時刻入力欄を表示する"""
+        self.client.login(username='admin_user', password='adminpass123')
+        participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=Community.objects.create(name='集会C', status='approved', frequency='毎週'),
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time='21:00',
+            confirmed_duration=60,
+        )
+        draft_pres = VketPresentation.objects.create(
+            participation=participation,
+            order=0,
+            speaker='申請中登壇者',
+            theme='申請中テーマ',
+            status=VketPresentation.Status.DRAFT,
+        )
+        confirmed_pres = VketPresentation.objects.create(
+            participation=participation,
+            order=1,
+            speaker='確定済み登壇者',
+            theme='確定済みテーマ',
+            requested_start_time='21:30',
+            status=VketPresentation.Status.CONFIRMED,
+        )
+
+        response = self.client.get(
+            reverse('vket:manage', kwargs={'pk': self.collaboration.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'name="pres_{confirmed_pres.pk}_start_time"')
+        self.assertContains(response, 'value="21:30"')
+        self.assertNotContains(response, f'name="pres_{draft_pres.pk}_start_time"')
 
     def test_manage_page_shows_lt_time_badge(self):
         """管理画面でLT時間バッジが表示される"""

--- a/app/vket/views/manage.py
+++ b/app/vket/views/manage.py
@@ -273,6 +273,13 @@ class ManageParticipationUpdateView(LoginRequiredMixin, AuthenticatedForbiddenMi
                     pres.save(update_fields=['confirmed_start_time', 'updated_at'])
 
                     if pres.published_event_detail_id:
+                        if pres.published_event_detail.event_id != participation.published_event_id:
+                            logger.warning(
+                                'VketPresentation #%d の EventDetail #%d は参加の公開イベントに属していません',
+                                pres_id,
+                                pres.published_event_detail_id,
+                            )
+                            continue
                         pres.published_event_detail.start_time = new_time
                         pres.published_event_detail.save(update_fields=['start_time', 'updated_at'])
                         changed_index_detail = True

--- a/app/vket/views/manage.py
+++ b/app/vket/views/manage.py
@@ -212,6 +212,20 @@ class ManageParticipationUpdateView(LoginRequiredMixin, AuthenticatedForbiddenMi
             ]
         )
 
+        pres_pattern = re.compile(r'^pres_(\d+)_start_time$')
+        pres_updates = {}
+        for key, value in request.POST.items():
+            m = pres_pattern.match(key)
+            if m and value:
+                pres_updates[int(m.group(1))] = value
+
+        allowed_presentation_ids = set(
+            participation.presentations.filter(
+                pk__in=pres_updates.keys(),
+                status=VketPresentation.Status.CONFIRMED,
+            ).values_list('id', flat=True)
+        )
+
         # DRAFT のLTを一括確定
         participation.presentations.filter(
             status=VketPresentation.Status.DRAFT,
@@ -237,30 +251,33 @@ class ManageParticipationUpdateView(LoginRequiredMixin, AuthenticatedForbiddenMi
                 pres.save(update_fields=['published_event_detail', 'updated_at'])
                 changed_index_detail = True
 
-        # EventDetailのLT開始時刻を更新
-        detail_pattern = re.compile(r'^detail_(\d+)_start_time$')
-        detail_updates = {}
-        for key, value in request.POST.items():
-            m = detail_pattern.match(key)
-            if m and value:
-                detail_updates[int(m.group(1))] = value
+        # 発表ごとの確定開始時刻を更新し、公開済みなら EventDetail にも同期する
+        if pres_updates:
+            allowed_presentations = {
+                pres.pk: pres
+                for pres in participation.presentations.select_related(
+                    'published_event_detail'
+                ).filter(
+                    pk__in=allowed_presentation_ids,
+                    status=VketPresentation.Status.CONFIRMED,
+                )
+            }
 
-        if detail_updates:
-            allowed_detail_ids = set(
-                EventDetail.objects.filter(
-                    event=participation.published_event
-                ).values_list('id', flat=True)
-            ) if participation.published_event else set()
-
-            for detail_id, time_str in detail_updates.items():
-                if detail_id not in allowed_detail_ids:
+            for pres_id, time_str in pres_updates.items():
+                pres = allowed_presentations.get(pres_id)
+                if pres is None:
                     continue
                 try:
                     new_time = datetime.strptime(time_str, '%H:%M').time()
-                    updated_count = EventDetail.objects.filter(pk=detail_id).update(start_time=new_time)
-                    changed_index_detail = changed_index_detail or updated_count > 0
+                    pres.confirmed_start_time = new_time
+                    pres.save(update_fields=['confirmed_start_time', 'updated_at'])
+
+                    if pres.published_event_detail_id:
+                        pres.published_event_detail.start_time = new_time
+                        pres.published_event_detail.save(update_fields=['start_time', 'updated_at'])
+                        changed_index_detail = True
                 except (ValueError, KeyError):
-                    logger.warning('EventDetail #%d の start_time パース失敗: %s', detail_id, time_str)
+                    logger.warning('VketPresentation #%d の start_time パース失敗: %s', pres_id, time_str)
 
         if changed_index_detail:
             clear_index_view_cache()


### PR DESCRIPTION
## 概要
- Vket管理画面の発表開始時刻入力を `EventDetail` ID ベースから `VketPresentation` ID ベースへ変更
- 公開前の `CONFIRMED` 発表でも `VketPresentation.confirmed_start_time` を更新できるようにした
- 公開済み発表では `EventDetail.start_time` も同時に同期
- `published_event_detail` が別イベントを指す不整合データでは、別イベント側の `EventDetail` を更新しない
- DRAFT発表は同一POSTで時刻が送られても更新対象外にして、確定前の時刻操作を防止

## 理由
公開前の発表には `published_event_detail` が存在しないため、既存の表示条件では time input が出ず開始時刻を調整できなかった。公開処理は `VketPresentation.confirmed_start_time` を優先して `EventDetail.start_time` を作成する設計なので、公開前の保存先も同フィールドへ揃える。

レビューで指摘された旧実装の `EventDetail.event` 所属検証も維持し、presentation 経由の同期でも別イベントの detail を誤更新しないようにした。

## テスト
- `DB_PORT=33306 APP_PORT=18015 STORAGE_PORT=19000 STORAGE_CONSOLE_PORT=19001 docker compose run --rm -e DB_NAME=vrc_ta_hub -e DB_USER=dev_user -e DB_PASSWORD=dev_password -e DB_HOST=db vrc-ta-hub python manage.py test vket`（126件OK）
- `http://localhost:18015/` の HEAD が `200 OK`
- デバッグ管理者セッションで `http://localhost:18015/vket/1/manage/` を表示確認

## レビュー
- team-vote: code-reviewer / security-checker / impact-reviewer の3観点で確認
- code-reviewer の必須指摘（EventDetail所属検証）と Codex の P2 指摘（公開済み表示時刻の優先順位）を追加コミットで対応済み

## 補足
- 確認用データとログイン済みセッションはローカルDBのみで作成
- LLMモデルや外部API設定の変更なし