### PR TITLE
feat: デバッグ用ログインスキップを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ HTTP_HOST=localhost
 CSRF_TRUSTED_ORIGIN=http://localhost:8015
 HTTP_X_FORWARDED_PROTO=http  # ローカル開発はhttp、本番は設定不要（nginxが付加）
 
+# AIエージェントのローカル確認用ログインスキップ（DEBUG=True の時だけ有効）
+DEBUG_LOGIN_SKIP=false
+DEBUG_LOGIN_SKIP_USER_NAME=ai_agent
+DEBUG_LOGIN_SKIP_USER_EMAIL=ai-agent@example.local
+
 # CORS 許可オリジン (カンマ区切り)。本番は https://vrc-ta-hub.com 等
 # ローカル開発 (DEBUG=True) では localhost / 127.0.0.1 の任意ポートが自動許可されるため未設定でも可
 CORS_ALLOWED_ORIGINS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,19 @@ docker compose exec vrc-ta-hub python scripts/generate_custom_events.py
 
 ログインが必要な動作確認時は `.env.local` の `TEST_USER_NAME` と `TEST_USER_PASSWORD` を参照。
 
+### AIエージェント向けログインスキップ
+
+AIエージェントがログイン後ページを確認する場合は、毎回手動ログインせずに `DEBUG_LOGIN_SKIP=true` を使える。
+この機能は `DEBUG=True` の時だけ有効で、未ログインリクエストに staff 権限のデバッグユーザーを割り当てる。
+`DEBUG=False` では `DEBUG_LOGIN_SKIP=true` を設定していても無効。
+
+```bash
+docker compose run --rm --service-ports -e DEBUG_LOGIN_SKIP=true vrc-ta-hub \
+  /bin/sh -c "python manage.py wait_for_db --timeout 90 && python manage.py runserver 0.0.0.0:8080"
+```
+
+デフォルトユーザーは `DEBUG_LOGIN_SKIP_USER_NAME=ai_agent` / `DEBUG_LOGIN_SKIP_USER_EMAIL=ai-agent@example.local`。
+
 ## 環境変数（.env.local）
 - `SECRET_KEY`: Djangoシークレットキー
 - `DEBUG`: デバッグモード設定

--- a/app/user_account/middleware.py
+++ b/app/user_account/middleware.py
@@ -1,7 +1,65 @@
-"""Discord認証を強制するミドルウェア."""
+"""認証補助ミドルウェア."""
+import logging
+
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.shortcuts import redirect
+
 from allauth.socialaccount.models import SocialAccount
+
+logger = logging.getLogger(__name__)
+
+
+class DebugLoginSkipMiddleware:
+    """DEBUG時のみ未ログインリクエストへデバッグユーザーを割り当てる."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if self._should_apply(request):
+            request.user = self._get_or_create_debug_user()
+        return self.get_response(request)
+
+    def _should_apply(self, request):
+        """デバッグログインスキップを適用すべきか判定する."""
+        if not getattr(settings, 'DEBUG', False):
+            return False
+        if not getattr(settings, 'DEBUG_LOGIN_SKIP', False):
+            return False
+        return not request.user.is_authenticated
+
+    def _get_or_create_debug_user(self):
+        """デバッグ用 staff ユーザーを取得または作成する."""
+        User = get_user_model()
+        user_name = settings.DEBUG_LOGIN_SKIP_USER_NAME
+        email = settings.DEBUG_LOGIN_SKIP_USER_EMAIL
+
+        try:
+            user = User.objects.get(user_name=user_name)
+            update_fields = []
+            if not user.is_active:
+                user.is_active = True
+                update_fields.append('is_active')
+            if not user.is_staff:
+                user.is_staff = True
+                update_fields.append('is_staff')
+            if update_fields:
+                user.save(update_fields=update_fields)
+            return user
+        except User.DoesNotExist:
+            user = User(
+                user_name=user_name,
+                email=email,
+                display_name=user_name,
+                is_active=True,
+                is_staff=True,
+                is_superuser=False,
+            )
+            user.set_unusable_password()
+            user.save()
+            logger.debug('Debug login skip user created: %s', user_name)
+            return user
 
 
 class DiscordAuthRequiredMiddleware:

--- a/app/user_account/tests/test_middleware.py
+++ b/app/user_account/tests/test_middleware.py
@@ -8,6 +8,70 @@ from allauth.socialaccount.models import SocialAccount
 User = get_user_model()
 
 
+class DebugLoginSkipMiddlewareTests(TestCase):
+    """DebugLoginSkipMiddlewareのテストクラス."""
+
+    def setUp(self):
+        """テスト用のクライアントを準備."""
+        self.client = Client()
+
+    @override_settings(
+        DEBUG=True,
+        DEBUG_LOGIN_SKIP=True,
+        DEBUG_LOGIN_SKIP_USER_NAME='ai_agent',
+        DEBUG_LOGIN_SKIP_USER_EMAIL='ai-agent@example.local',
+        DISCORD_AUTH_REQUIRED=False,
+    )
+    def test_debug_login_skip_allows_protected_page(self):
+        """DEBUG時の明示ONでは未ログインでも保護ページにアクセスできること."""
+        response = self.client.get(reverse('account:settings'))
+
+        self.assertEqual(response.status_code, 200)
+        user = User.objects.get(user_name='ai_agent')
+        self.assertEqual(response.wsgi_request.user, user)
+        self.assertTrue(user.is_active)
+        self.assertTrue(user.is_staff)
+        self.assertFalse(user.is_superuser)
+        self.assertFalse(user.has_usable_password())
+
+    @override_settings(
+        DEBUG=False,
+        DEBUG_LOGIN_SKIP=True,
+        DEBUG_LOGIN_SKIP_USER_NAME='ai_agent',
+        DEBUG_LOGIN_SKIP_USER_EMAIL='ai-agent@example.local',
+        DISCORD_AUTH_REQUIRED=False,
+    )
+    def test_debug_login_skip_is_disabled_when_debug_false(self):
+        """DEBUG=Falseでは明示ONでもログインスキップされないこと."""
+        response = self.client.get(reverse('account:settings'))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/account/login/', response['Location'])
+        self.assertFalse(User.objects.filter(user_name='ai_agent').exists())
+
+    @override_settings(
+        DEBUG=True,
+        DEBUG_LOGIN_SKIP=True,
+        DEBUG_LOGIN_SKIP_USER_NAME='ai_agent',
+        DEBUG_LOGIN_SKIP_USER_EMAIL='ai-agent@example.local',
+        DISCORD_AUTH_REQUIRED=False,
+    )
+    def test_debug_login_skip_does_not_replace_authenticated_user(self):
+        """ログイン済みユーザーはデバッグユーザーで上書きされないこと."""
+        user = User.objects.create_user(
+            user_name='real_user',
+            email='real-user@example.local',
+            password='testpass123',
+        )
+        self.client.login(username='real_user', password='testpass123')
+
+        response = self.client.get(reverse('account:settings'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.wsgi_request.user, user)
+        self.assertFalse(User.objects.filter(user_name='ai_agent').exists())
+
+
 @override_settings(DISCORD_AUTH_REQUIRED=True)
 @tag('external_api')
 class DiscordAuthRequiredMiddlewareTests(TestCase):

--- a/app/website/settings/authentication.py
+++ b/app/website/settings/authentication.py
@@ -5,6 +5,8 @@ SOCIALACCOUNT_* / Discord OAuth プロバイダ設定をまとめる。
 """
 import os
 
+from .base import DEBUG
+
 AUTH_USER_MODEL = 'user_account.CustomUser'
 
 AUTHENTICATION_BACKENDS = [
@@ -53,3 +55,11 @@ SOCIALACCOUNT_FORMS = {
 # ソーシャルアカウントの接続解除（disconnect）を試みた場合のリダイレクト先
 # 削除ボタンはテンプレートで非表示にするが、直接アクセスされた場合の保険
 SOCIALACCOUNT_DISCONNECT_REDIRECT_URL = '/account/settings/'
+
+# AIエージェントのローカル確認用。DEBUG=False では環境変数が true でも無効化する。
+DEBUG_LOGIN_SKIP = DEBUG and os.environ.get('DEBUG_LOGIN_SKIP', '').lower() == 'true'
+DEBUG_LOGIN_SKIP_USER_NAME = os.environ.get('DEBUG_LOGIN_SKIP_USER_NAME', 'ai_agent')
+DEBUG_LOGIN_SKIP_USER_EMAIL = os.environ.get(
+    'DEBUG_LOGIN_SKIP_USER_EMAIL',
+    'ai-agent@example.local',
+)

--- a/app/website/settings/base.py
+++ b/app/website/settings/base.py
@@ -116,6 +116,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'user_account.middleware.DebugLoginSkipMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'allauth.account.middleware.AccountMiddleware',


### PR DESCRIPTION
## なぜこの変更が必要か

AIエージェントがログイン後の画面を動作確認するたびに、毎回ログイン操作が必要になっていた。
ローカル開発・デバッグ時だけログイン済み状態を作れるようにし、保護ページのQAを短時間で再現できるようにする。

## 変更内容

- `DEBUG=True` かつ `DEBUG_LOGIN_SKIP=true` の時だけ有効な `DebugLoginSkipMiddleware` を追加
- 未ログインリクエストに staff 権限のデバッグユーザーを割り当てる設定を追加
- `.env.example` に `DEBUG_LOGIN_SKIP_*` の設定例を追加
- 本番相当の `DEBUG=False` では env が true でも無効になる回帰テストを追加

## 意思決定

### 採用アプローチ
- middleware で `request.user` を割り当てる方式を採用。既存の `LoginRequiredMixin` や各 view の認可処理を個別に触らず、保護ページ全体に効かせられるため。

### 却下した代替案
- `/dev/login/` の専用URLを追加する案は、AIエージェント側に追加操作が残るため今回の課題解決として弱い。
- `DEBUG=True` で常時有効化する案は、ログイン画面自体の確認を阻害するため採用しない。

## テスト

- [x] `docker compose exec vrc-ta-hub python manage.py test user_account.tests.test_middleware`
- [x] `docker compose exec vrc-ta-hub python manage.py test user_account.tests.test_views.SettingsViewTests user_account.tests.test_middleware`
- [x] `docker compose exec vrc-ta-hub python manage.py check`
- [x] `DEBUG_LOGIN_SKIP=true` で `/account/settings/` がログイン画面ではなく「アカウント設定」を表示することを Computer Use で確認

---
🤖 Generated with Codex