### PR TITLE
feat: 発表締切後の申請受付に対応

### DIFF
--- a/app/vket/templates/vket/apply.html
+++ b/app/vket/templates/vket/apply.html
@@ -39,13 +39,19 @@
         {% if participation.is_schedule_confirmed and permissions.can_edit_lt %}
             <div class="alert alert-warning">
                 <i class="fas fa-lock me-1"></i>
-                発表開始時刻は日程確定済みのため編集できません。登壇者名・テーマ・備考は発表締切まで更新できます。
+                発表開始時刻は日程確定済みのため編集できません。登壇者名・テーマ・備考は発表情報の受付期間中に更新できます。
+            </div>
+        {% endif %}
+        {% if is_late_lt_submission %}
+            <div class="alert alert-warning">
+                <i class="fas fa-clock me-1"></i>
+                発表情報（Step 2）の締切後です。保存した発表は申請中として受け付け、運営の確認後に確定・公開されます。
             </div>
         {% endif %}
         {% if not permissions.can_edit_lt %}
             <div class="alert alert-warning">
                 <i class="fas fa-lock me-1"></i>
-                発表情報（Step 2）は締切を過ぎているため編集できません。
+                発表情報（Step 2）は受付期間外のため編集できません。
             </div>
         {% endif %}
 

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -260,6 +260,150 @@ class VketApplyFlowTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context['can_apply'])
 
+    def test_apply_accepts_late_lt_submission_as_draft_for_existing_participation(self):
+        """発表締切後も既存参加団体の発表情報は申請中で保存できる"""
+        today = timezone.localdate()
+        self.collaboration.registration_deadline = today - timedelta(days=3)
+        self.collaboration.lt_deadline = today - timedelta(days=1)
+        self.collaboration.phase = VketCollaboration.Phase.ANNOUNCEMENT
+        self.collaboration.save()
+        participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            requested_date=self.collaboration.period_start,
+            requested_start_time=time(21, 0),
+            requested_duration=60,
+            progress=VketParticipation.Progress.APPLIED,
+            applied_by=self.owner,
+        )
+
+        self.client.login(username='owner_user', password='testpass123')
+        self._set_active_community()
+
+        response = self.client.get(reverse('vket:apply', kwargs={'pk': self.collaboration.pk}))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['permissions'].can_edit_lt)
+        self.assertTrue(response.context['is_late_lt_submission'])
+        self.assertContains(response, '運営の確認後に確定・公開されます。')
+
+        post_data = {
+            'requested_date': self.collaboration.period_start.isoformat(),
+            'requested_start_time': '21:00',
+            'requested_duration': '60',
+            'organizer_note': '締切後の追記',
+        }
+        post_data.update(
+            self._make_formset_data([
+                {'speaker': '締切後登壇者', 'theme': '締切後テーマ'}
+            ])
+        )
+
+        response = self.client.post(
+            reverse('vket:apply', kwargs={'pk': self.collaboration.pk}),
+            data=post_data,
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        participation.refresh_from_db()
+        presentation = VketPresentation.objects.get(participation=participation)
+        self.assertEqual(participation.organizer_note, '締切後の追記')
+        self.assertEqual(presentation.speaker, '締切後登壇者')
+        self.assertEqual(presentation.status, VketPresentation.Status.DRAFT)
+
+    def test_late_lt_update_resets_confirmed_presentation_to_draft(self):
+        """締切後に確定済み発表を更新した場合は申請中に戻す"""
+        today = timezone.localdate()
+        self.collaboration.registration_deadline = today - timedelta(days=3)
+        self.collaboration.lt_deadline = today - timedelta(days=1)
+        self.collaboration.phase = VketCollaboration.Phase.ANNOUNCEMENT
+        self.collaboration.save()
+        participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            requested_date=self.collaboration.period_start,
+            requested_start_time=time(21, 0),
+            requested_duration=60,
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time=time(21, 0),
+            confirmed_duration=60,
+            schedule_confirmed_at=timezone.now(),
+            progress=VketParticipation.Progress.REHEARSAL,
+            applied_by=self.owner,
+        )
+        presentation = VketPresentation.objects.create(
+            participation=participation,
+            order=0,
+            speaker='確定済み登壇者',
+            theme='確定済みテーマ',
+            requested_start_time=time(21, 30),
+            status=VketPresentation.Status.CONFIRMED,
+        )
+
+        self.client.login(username='owner_user', password='testpass123')
+        self._set_active_community()
+
+        post_data = {
+            'requested_date': self.collaboration.period_start.isoformat(),
+            'requested_start_time': '23:00',
+            'requested_duration': '90',
+            'organizer_note': '締切後更新',
+        }
+        post_data.update(
+            self._make_formset_data(
+                [
+                    {
+                        'speaker': '更新後登壇者',
+                        'theme': '更新後テーマ',
+                        'lt_start_time': '23:30',
+                    }
+                ],
+                initial_forms=1,
+            )
+        )
+
+        response = self.client.post(
+            reverse('vket:apply', kwargs={'pk': self.collaboration.pk}),
+            data=post_data,
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        presentation.refresh_from_db()
+        self.assertEqual(presentation.speaker, '更新後登壇者')
+        self.assertEqual(presentation.theme, '更新後テーマ')
+        self.assertEqual(presentation.requested_start_time.strftime('%H:%M'), '21:30')
+        self.assertEqual(presentation.status, VketPresentation.Status.DRAFT)
+
+    def test_apply_blocks_lt_submission_after_event_period(self):
+        """開催期間後は発表情報も編集不可にする"""
+        today = timezone.localdate()
+        self.collaboration.period_start = today - timedelta(days=8)
+        self.collaboration.period_end = today - timedelta(days=1)
+        self.collaboration.registration_deadline = today - timedelta(days=7)
+        self.collaboration.lt_deadline = today - timedelta(days=2)
+        self.collaboration.phase = VketCollaboration.Phase.ANNOUNCEMENT
+        self.collaboration.save()
+        VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            requested_date=self.collaboration.period_start,
+            requested_start_time=time(21, 0),
+            requested_duration=60,
+            progress=VketParticipation.Progress.APPLIED,
+            applied_by=self.owner,
+        )
+
+        self.client.login(username='owner_user', password='testpass123')
+        self._set_active_community()
+
+        response = self.client.get(reverse('vket:apply', kwargs={'pk': self.collaboration.pk}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['permissions'].can_edit_lt)
+        self.assertFalse(response.context['is_late_lt_submission'])
+        self.assertContains(response, '発表情報（Step 2）は受付期間外のため編集できません。')
+
     def test_status_page_shows_register_complete_guidance(self):
         """参加状況画面で登録後の次アクションが明示される"""
         self.collaboration.slug = 'vket-2026-summer'
@@ -2678,6 +2822,28 @@ class VketPublishViewTests(TestCase):
         # EventDetail が作成され、start_time に requested_start_time が使われていること
         detail = EventDetail.objects.get(event=event)
         self.assertEqual(detail.start_time.strftime('%H:%M'), '21:30')
+
+    def test_publish_skips_draft_presentation(self):
+        """申請中の発表は公開処理でEventDetailにしない"""
+        VketPresentation.objects.create(
+            participation=self.participation,
+            order=0,
+            speaker='申請中登壇者',
+            theme='申請中テーマ',
+            requested_start_time=time(21, 30),
+            status=VketPresentation.Status.DRAFT,
+        )
+
+        self.client.login(username='admin_pub', password='adminpass123')
+        response = self.client.post(
+            reverse('vket:manage_publish', kwargs={'pk': self.collaboration.pk}),
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.participation.refresh_from_db()
+        self.assertIsNotNone(self.participation.published_event_id)
+        self.assertFalse(EventDetail.objects.filter(speaker='申請中登壇者').exists())
 
     def test_publish_clears_index_cache_when_updating_existing_event_detail(self):
         """公開処理で既存EventDetailをbulk updateした場合もトップページキャッシュを削除する"""

--- a/app/vket/views/apply.py
+++ b/app/vket/views/apply.py
@@ -71,6 +71,10 @@ class ApplyView(LoginRequiredMixin, View):
                 'form': form,
                 'formset': formset,
                 'permissions': permissions,
+                'is_late_lt_submission': self._is_late_lt_submission(
+                    collaboration,
+                    permissions,
+                ),
                 **schedule_ctx,
             },
         )
@@ -128,6 +132,10 @@ class ApplyView(LoginRequiredMixin, View):
                     'form': form,
                     'formset': formset,
                     'permissions': permissions,
+                    'is_late_lt_submission': self._is_late_lt_submission(
+                        collaboration,
+                        permissions,
+                    ),
                     **schedule_ctx,
                 },
             )
@@ -155,6 +163,10 @@ class ApplyView(LoginRequiredMixin, View):
                     'form': form,
                     'formset': formset,
                     'permissions': permissions,
+                    'is_late_lt_submission': self._is_late_lt_submission(
+                        collaboration,
+                        permissions,
+                    ),
                 },
             )
 
@@ -194,6 +206,14 @@ class ApplyView(LoginRequiredMixin, View):
     def _is_schedule_locked(participation: VketParticipation | None) -> bool:
         """主催者向けの日程・LT開始時刻を固定する状態なら True を返す"""
         return bool(participation and participation.is_schedule_confirmed)
+
+    @staticmethod
+    def _is_late_lt_submission(
+        collaboration: VketCollaboration,
+        permissions: VketApplyPermissions,
+    ) -> bool:
+        """発表情報締切後も申請として受け付けている状態なら True を返す"""
+        return permissions.can_edit_lt and timezone.localdate() > collaboration.lt_deadline
 
     def _apply_permissions_for_participation(
         self,
@@ -277,10 +297,19 @@ class ApplyView(LoginRequiredMixin, View):
 
         # プレゼンテーション情報をVketPresentationに保存（formset）
         if permissions.can_edit_lt:
+            is_late_lt_submission = self._is_late_lt_submission(collaboration, permissions)
             if self._is_schedule_locked(participation):
-                self._save_locked_presentations(participation, formset_data)
+                self._save_locked_presentations(
+                    participation,
+                    formset_data,
+                    is_late_lt_submission=is_late_lt_submission,
+                )
             else:
-                self._save_editable_presentations(participation, formset_data)
+                self._save_editable_presentations(
+                    participation,
+                    formset_data,
+                    is_late_lt_submission=is_late_lt_submission,
+                )
 
         return participation
 
@@ -288,6 +317,8 @@ class ApplyView(LoginRequiredMixin, View):
         self,
         participation: VketParticipation,
         formset_data: list[dict],
+        *,
+        is_late_lt_submission: bool = False,
     ) -> None:
         """確定前のLT情報を通常どおり保存する"""
         saved_orders = set()
@@ -299,14 +330,17 @@ class ApplyView(LoginRequiredMixin, View):
             theme = (row.get('theme') or '').strip()
             if not speaker and not theme:
                 continue
+            defaults = {
+                'speaker': speaker,
+                'theme': theme,
+                'requested_start_time': row.get('lt_start_time'),
+            }
+            if is_late_lt_submission:
+                defaults['status'] = VketPresentation.Status.DRAFT
             VketPresentation.objects.update_or_create(
                 participation=participation,
                 order=order,
-                defaults={
-                    'speaker': speaker,
-                    'theme': theme,
-                    'requested_start_time': row.get('lt_start_time'),
-                },
+                defaults=defaults,
             )
             saved_orders.add(order)
             order += 1
@@ -319,6 +353,8 @@ class ApplyView(LoginRequiredMixin, View):
         self,
         participation: VketParticipation,
         formset_data: list[dict],
+        *,
+        is_late_lt_submission: bool = False,
     ) -> None:
         """確定後は既存LTの削除と開始時刻変更を拒否して保存する"""
         existing_by_order = {
@@ -340,7 +376,11 @@ class ApplyView(LoginRequiredMixin, View):
             if existing:
                 existing.speaker = speaker
                 existing.theme = theme
-                existing.save(update_fields=['speaker', 'theme', 'updated_at'])
+                update_fields = ['speaker', 'theme', 'updated_at']
+                if is_late_lt_submission:
+                    existing.status = VketPresentation.Status.DRAFT
+                    update_fields.append('status')
+                existing.save(update_fields=update_fields)
                 continue
 
             VketPresentation.objects.create(
@@ -349,5 +389,6 @@ class ApplyView(LoginRequiredMixin, View):
                 speaker=speaker,
                 theme=theme,
                 requested_start_time=row.get('lt_start_time'),
+                status=VketPresentation.Status.DRAFT,
             )
             next_order += 1

--- a/app/vket/views/helpers.py
+++ b/app/vket/views/helpers.py
@@ -73,11 +73,12 @@ def _apply_permissions_for_user(user, collaboration: VketCollaboration) -> VketA
         and collaboration.phase == VketCollaboration.Phase.ENTRY_OPEN
     )
 
-    # LT情報編集: 受付〜LT回収フェーズかつLT締切内
-    can_edit_lt = today <= collaboration.lt_deadline and collaboration.phase in {
+    # LT情報編集: 受付開始後から告知確認中まで、開催期間中は申請として受け付ける
+    can_edit_lt = today <= collaboration.period_end and collaboration.phase in {
         VketCollaboration.Phase.ENTRY_OPEN,
         VketCollaboration.Phase.SCHEDULING,
         VketCollaboration.Phase.LT_COLLECTION,
+        VketCollaboration.Phase.ANNOUNCEMENT,
     }
 
     return VketApplyPermissions(can_edit_schedule=can_edit_schedule, can_edit_lt=can_edit_lt)


### PR DESCRIPTION
## 概要
Vケットの発表登録で締切を過ぎた団体が多い運用に対応するため、参加日程の締切後でも発表情報だけは申請として受け付けられるようにしました。

## 変更内容
- 参加日程の編集締切後も、発表情報は開催期間終了まで登録可能に変更
- 締切後に保存された発表は `draft` として保持し、管理画面で日程確定時に `confirmed` へ昇格
- 締切後に既存の確定済み発表を更新した場合も、再確認が必要になるよう `draft` へ戻す
- 申請画面に締切後申請の注意文を表示
- 公開処理では `confirmed` の発表だけを公開対象にする既存挙動をテストで固定

## 方針
システム上の締切を発表当日まで延長するのではなく、締切後は「申請中」として受け付け、管理者の確認で確定する形にしました。既存の `draft` / `confirmed` を使うため、DBスキーマ変更はありません。

## 検証
- `docker compose exec vrc-ta-hub python manage.py test vket.tests.test_vket.VketApplyFlowTests vket.tests.test_vket.VketPublishViewTests`
- `docker compose exec vrc-ta-hub python manage.py test vket`
- Computer Useでローカル確認
  - 締切後の参加者として発表申請を保存し、発表が `draft` になることを確認
  - 管理画面に「申請中」として表示されることを確認
  - 管理画面の「確定」操作後、発表が `confirmed`、参加進捗が `rehearsal` になることを確認
