### PR TITLE
fix(vket): ステージ登録確認ボタンを開催期間最終日まで表示・押下可能にする

### DIFF
--- a/app/vket/templates/vket/participation_status.html
+++ b/app/vket/templates/vket/participation_status.html
@@ -125,7 +125,7 @@
             {% endif %}
 
             {# Vketステージ登録（未登録時のみここに表示） #}
-            {% if participation.progress == 'applied' %}
+            {% if stage_register_open %}
                 <div class="card shadow-sm mb-4 border-warning">
                     <div class="card-body">
                         <h2 class="h5 fw-bold mb-2">
@@ -321,30 +321,6 @@
                 </div>
             {% endif %}
 
-            {# Vketステージ登録（登録済みは最下部に表示） #}
-            {% if participation.stage_registered_at and participation.progress != 'applied' %}
-                <div class="card shadow-sm mb-4 border-success">
-                    <div class="card-body">
-                        <div class="d-flex justify-content-between align-items-center">
-                            <div>
-                                <h2 class="h5 fw-bold mb-0">
-                                    <i class="fas fa-external-link-alt me-2 text-success"></i>Vketステージ登録
-                                </h2>
-                            </div>
-                            <div class="d-flex align-items-center gap-2">
-                                {% if stage_url %}
-                                    <a href="{{ stage_url }}" target="_blank" rel="noopener" class="btn btn-outline-secondary btn-sm">
-                                        <i class="fas fa-external-link-alt me-1"></i>ステージページ
-                                    </a>
-                                {% endif %}
-                                <span class="badge bg-success">
-                                    <i class="fas fa-check me-1"></i>登録済み（{{ participation.stage_registered_at|date:"n/j" }}）
-                                </span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            {% endif %}
         {% endif %}
     </div>
 {% endblock %}

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -2577,9 +2577,68 @@ class VketParticipationStatusTests(TestCase):
         self.assertEqual(self.participation.progress, VketParticipation.Progress.STAGE_REGISTERED)
         self.assertIsNotNone(self.participation.stage_registered_at)
 
-    def test_stage_register_requires_applied(self):
-        """APPLIED 以外ではステージ登録できない"""
+    def test_stage_register_requires_applied_participation(self):
+        """未申請ではステージ登録できない"""
+        self.participation.progress = VketParticipation.Progress.NOT_APPLIED
+        self.participation.save()
+
+        self.client.login(username='status_owner', password='testpass123')
+        self._set_active_community()
+        response = self.client.post(
+            reverse('vket:stage_register', kwargs={'pk': self.collaboration.pk}),
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.participation.refresh_from_db()
+        self.assertEqual(self.participation.progress, VketParticipation.Progress.NOT_APPLIED)
+        self.assertIsNone(self.participation.stage_registered_at)
+        self.assertContains(response, 'ステージ登録は参加申込み後に行ってください。')
+
+    def test_stage_register_records_rehearsal_without_rewinding_progress(self):
+        """REHEARSAL では進捗を戻さずステージ登録日時だけ記録する"""
         self.participation.progress = VketParticipation.Progress.REHEARSAL
+        self.participation.save()
+
+        self.client.login(username='status_owner', password='testpass123')
+        self._set_active_community()
+        response = self.client.post(
+            reverse('vket:stage_register', kwargs={'pk': self.collaboration.pk}),
+            follow=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        self.participation.refresh_from_db()
+        self.assertEqual(self.participation.progress, VketParticipation.Progress.REHEARSAL)
+        self.assertIsNotNone(self.participation.stage_registered_at)
+
+    def test_stage_register_rejects_after_period_end(self):
+        """開催期間終了後はステージ登録日時を記録しない"""
+        today = timezone.localdate()
+        self.collaboration.period_start = today - timedelta(days=7)
+        self.collaboration.period_end = today - timedelta(days=1)
+        self.collaboration.save(update_fields=['period_start', 'period_end'])
+        self.participation.progress = VketParticipation.Progress.APPLIED
+        self.participation.save()
+
+        self.client.login(username='status_owner', password='testpass123')
+        self._set_active_community()
+        response = self.client.post(
+            reverse('vket:stage_register', kwargs={'pk': self.collaboration.pk}),
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.participation.refresh_from_db()
+        self.assertEqual(self.participation.progress, VketParticipation.Progress.APPLIED)
+        self.assertIsNone(self.participation.stage_registered_at)
+        self.assertContains(response, '開催期間終了後はステージ登録を記録できません。')
+
+    def test_stage_register_rejects_duplicate_registration(self):
+        """二重登録では既存の登録日時を上書きしない"""
+        registered_at = timezone.now() - timedelta(days=1)
+        self.participation.progress = VketParticipation.Progress.REHEARSAL
+        self.participation.stage_registered_at = registered_at
         self.participation.save()
 
         self.client.login(username='status_owner', password='testpass123')
@@ -2592,6 +2651,8 @@ class VketParticipationStatusTests(TestCase):
 
         self.participation.refresh_from_db()
         self.assertEqual(self.participation.progress, VketParticipation.Progress.REHEARSAL)
+        self.assertEqual(self.participation.stage_registered_at, registered_at)
+        self.assertContains(response, 'ステージ登録は既に完了しています。')
 
     def test_status_page_shows_stage_banner(self):
         """申請済み時にステージ登録バナーが表示される"""
@@ -2606,8 +2667,8 @@ class VketParticipationStatusTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Vketステージ登録')
 
-    def test_status_page_shows_stage_registered_after_registration(self):
-        """登録済み後も「登録済み」としてカードが表示される"""
+    def test_status_page_hides_stage_register_section_after_registration(self):
+        """登録済み後はステージ登録セクションを表示しない"""
         self.participation.progress = VketParticipation.Progress.STAGE_REGISTERED
         self.participation.stage_registered_at = timezone.now()
         self.participation.save()
@@ -2618,8 +2679,42 @@ class VketParticipationStatusTests(TestCase):
             reverse('vket:status', kwargs={'pk': self.collaboration.pk})
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Vketステージ登録')
-        self.assertContains(response, '登録済み')
+        self.assertFalse(response.context['stage_register_open'])
+        self.assertNotContains(response, 'Vketステージ登録')
+        self.assertNotContains(response, '登録済み（')
+
+    def test_status_page_shows_stage_register_button_for_rehearsal_within_period(self):
+        """期間内のREHEARSAL未登録では登録完了ボタンを表示する"""
+        self.participation.progress = VketParticipation.Progress.REHEARSAL
+        self.participation.save()
+
+        self.client.login(username='status_owner', password='testpass123')
+        self._set_active_community()
+        response = self.client.get(
+            reverse('vket:status', kwargs={'pk': self.collaboration.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['stage_register_open'])
+        self.assertContains(response, '登録完了')
+
+    def test_status_page_hides_stage_register_button_after_period_end(self):
+        """期間終了後の未登録は登録ボタンを出さず未登録バッジだけ表示する"""
+        today = timezone.localdate()
+        self.collaboration.period_start = today - timedelta(days=7)
+        self.collaboration.period_end = today - timedelta(days=1)
+        self.collaboration.save(update_fields=['period_start', 'period_end'])
+        self.participation.progress = VketParticipation.Progress.REHEARSAL
+        self.participation.save()
+
+        self.client.login(username='status_owner', password='testpass123')
+        self._set_active_community()
+        response = self.client.get(
+            reverse('vket:status', kwargs={'pk': self.collaboration.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['stage_register_open'])
+        self.assertNotContains(response, '登録完了')
+        self.assertContains(response, '未登録')
 
 
 class VketStatusRedirectViewTests(TestCase):

--- a/app/vket/views/status.py
+++ b/app/vket/views/status.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import date
+
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Prefetch
@@ -48,6 +50,24 @@ def _resolve_stage_registration_guidance(collaboration: VketCollaboration) -> di
     return VKET_STAGE_REGISTRATION_GUIDANCE_BY_SLUG.get(collaboration.slug, {})
 
 
+def _is_stage_register_open(
+    participation: VketParticipation | None,
+    collaboration: VketCollaboration,
+    current_date: date | None = None,
+) -> bool:
+    if participation is None:
+        return False
+    if participation.stage_registered_at:
+        return False
+    if participation.progress == VketParticipation.Progress.NOT_APPLIED:
+        return False
+    if participation.lifecycle != VketParticipation.Lifecycle.ACTIVE:
+        return False
+
+    current_date = current_date or timezone.localdate()
+    return current_date <= collaboration.period_end
+
+
 class VketStatusRedirectView(LoginRequiredMixin, View):
     """pk なしで最新コラボの参加状況ページにリダイレクト"""
 
@@ -76,14 +96,27 @@ class StageRegisterView(LoginRequiredMixin, View):
             community=community,
         )
 
-        # 申請済みの場合のみ登録可能
-        if participation.progress != VketParticipation.Progress.APPLIED:
+        if participation.progress == VketParticipation.Progress.NOT_APPLIED:
             messages.warning(request, 'ステージ登録は参加申込み後に行ってください。')
             return redirect('vket:status', pk=pk)
+        if participation.stage_registered_at:
+            messages.warning(request, 'ステージ登録は既に完了しています。')
+            return redirect('vket:status', pk=pk)
+        if timezone.localdate() > collaboration.period_end:
+            messages.warning(request, '開催期間終了後はステージ登録を記録できません。')
+            return redirect('vket:status', pk=pk)
+        if not _is_stage_register_open(participation, collaboration):
+            messages.warning(request, '参加中の集会のみステージ登録を記録できます。')
+            return redirect('vket:status', pk=pk)
 
-        participation.progress = VketParticipation.Progress.STAGE_REGISTERED
         participation.stage_registered_at = timezone.now()
-        participation.save(update_fields=['progress', 'stage_registered_at', 'updated_at'])
+        update_fields = ['stage_registered_at', 'updated_at']
+        if participation.progress == VketParticipation.Progress.APPLIED:
+            participation.progress = VketParticipation.Progress.STAGE_REGISTERED
+            update_fields.append('progress')
+        # 運営処理で進んだ進捗は現在の工程を示すため、登録記録時に巻き戻さない。
+        # APPLIED の参加だけ従来どおり STAGE_REGISTERED へ前進させる。
+        participation.save(update_fields=update_fields)
 
         messages.success(request, 'Vketステージ登録完了を記録しました。')
         return redirect('vket:status', pk=pk)
@@ -168,6 +201,7 @@ class ParticipationStatusView(LoginRequiredMixin, View):
                 'is_admin': _is_vket_admin(request.user),
                 'stage_url': _resolve_stage_url(collaboration),
                 'stage_registration_guidance': _resolve_stage_registration_guidance(collaboration),
+                'stage_register_open': _is_stage_register_open(participation, collaboration),
                 'event_details': event_details,
                 **schedule_ctx,
             },


### PR DESCRIPTION
## なぜこの変更が必要か

Vket応募後、主催者は「Vket Stageに登録した」ことを自己申告する「登録完了」ボタンを押す運用だが、LT応募締切・参加申込締切後に運営処理（確定日程入力）が入ると `progress` が `rehearsal` 等へ自動遷移し、テンプレートの `progress == 'applied'` 条件から外れてボタンが消える。未登録の主催者が登録完了を申告できなくなるバグ。

## 変更内容

- `StageRegisterView.post`: `progress != APPLIED` の厳格チェックを撤廃し、「未申請は拒否 / 登録済みは拒否 / `period_end` 超過は拒否」に変更。APPLIED 以外から登録した場合は progress を巻き戻さず `stage_registered_at` のみ記録
- `ParticipationStatusView`: 表示判定 `stage_register_open` をコンテキストに追加（POST 側と共通のヘルパー `_is_stage_register_open` で判定を一元化）
- テンプレート: 登録カードの表示条件を `stage_register_open` に変更。登録済みの場合は「登録済み」カード自体を非表示に（ユーザー指定）
- テスト: REHEARSAL からの登録・期間終了後の拒否・二重登録防止・表示制御の回帰テストを追加

## 意思決定

### 採用アプローチ
- 締切上限は `collaboration.period_end` 当日まで。理由: 「イベント当日まで押せる」という要件に対し、確定日未入力の集会でも安全に動くシンプルな判定のため

### 却下した代替案
- `participation.confirmed_date`（集会個別の当日）ベース → 却下: 未確定時のフォールバック分岐が増え複雑化する割に実益が薄い

### トレードオフ
- 登録記録時に progress を巻き戻さない: 運営が進めた工程表示を壊さないことを優先し、APPLIED のときだけ従来どおり `stage_registered_at` とセットで前進させる

## テスト

- [x] `vket.tests.test_vket` + `vket.tests.test_staff_access` 全117件 OK（docker compose 実行）
- [x] 期間終了後は POST 拒否・ボタン非表示（未登録バッジのみ）を回帰テストで固定

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)