### PR TITLE
fix: LT資料アップロード依頼メールのリンクが404になる問題を修正

### DIFF
--- a/app/event/tests/test_material_upload_reminders.py
+++ b/app/event/tests/test_material_upload_reminders.py
@@ -191,6 +191,40 @@ class MaterialUploadReminderTest(TweetGenerationPatchMixin, TestCase):
         self.assertIn(f"/account/lt-applications/{detail.pk}/edit/", message.body)
         self.assertNotIn("締切", message.body)
 
+    def test_vket_recipient_can_open_edit_url_from_email(self):
+        detail = self.create_detail("vket_link")
+        recipient = detail.applicant
+        detail.applicant = None
+        detail.save(update_fields=["applicant"])
+        collaboration = VketCollaboration.objects.create(
+            slug="vket-reminder-link",
+            name="Vket Reminder Link",
+            period_start=self.target_date,
+            period_end=self.target_date + timedelta(days=1),
+            registration_deadline=self.target_date - timedelta(days=10),
+            lt_deadline=self.target_date - timedelta(days=5),
+        )
+        participation = VketParticipation.objects.create(
+            collaboration=collaboration,
+            community=self.community,
+            applied_by=recipient,
+        )
+        VketPresentation.objects.create(
+            participation=participation,
+            status=VketPresentation.Status.CONFIRMED,
+            published_event_detail=detail,
+        )
+
+        send_material_upload_reminders(
+            target_date=self.target_date,
+            decision_service=StubDecisionService(),
+        )
+
+        edit_path = reverse("account:lt_application_edit", kwargs={"pk": detail.pk})
+        self.assertIn(edit_path, mail.outbox[0].body)
+        self.client.force_login(recipient)
+        self.assertEqual(self.client.get(edit_path).status_code, 200)
+
     def test_email_falls_back_to_display_label_when_display_name_is_blank(self):
         self.create_detail("fallback", display_name="")
 

--- a/app/event/tests/test_slide_reminders.py
+++ b/app/event/tests/test_slide_reminders.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from community.models import Community
 from event.models import Event, EventDetail, MaterialUploadReminderLog
 from event.slide_reminders import process_slide_publication_reminders
+from vket.models import VketCollaboration, VketParticipation, VketPresentation
 
 User = get_user_model()
 
@@ -73,6 +74,35 @@ class SlideReminderTestCase(TestCase):
         self.assertIn(reverse('account:lt_application_edit', kwargs={'pk': detail.pk}), mail.outbox[0].body)
         detail.material_upload_reminder_log.refresh_from_db()
         self.assertIsNotNone(detail.material_upload_reminder_log.follow_up_sent_at)
+
+    def test_vket_recipient_can_open_edit_url_from_email(self):
+        detail = self.create_detail(applicant=None)
+        collaboration = VketCollaboration.objects.create(
+            slug='slide-reminder-vket',
+            name='Slide Reminder Vket',
+            period_start=date(2026, 5, 29),
+            period_end=date(2026, 5, 30),
+            registration_deadline=date(2026, 5, 1),
+            lt_deadline=date(2026, 5, 15),
+        )
+        participation = VketParticipation.objects.create(
+            collaboration=collaboration,
+            community=self.community,
+            applied_by=self.applicant,
+        )
+        VketPresentation.objects.create(
+            participation=participation,
+            status=VketPresentation.Status.CONFIRMED,
+            published_event_detail=detail,
+        )
+
+        result = process_slide_publication_reminders(now=self.now)
+
+        self.assertEqual(result.sent, 1)
+        edit_path = reverse('account:lt_application_edit', kwargs={'pk': detail.pk})
+        self.assertIn(edit_path, mail.outbox[0].body)
+        self.client.force_login(self.applicant)
+        self.assertEqual(self.client.get(edit_path).status_code, 200)
 
     def test_process_does_not_send_twice(self):
         self.create_detail()

--- a/app/user_account/tests/test_lt_application_views.py
+++ b/app/user_account/tests/test_lt_application_views.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from community.models import Community
 from event.models import Event, EventDetail
 from user_account.tests.utils import create_discord_linked_user
+from vket.models import VketCollaboration, VketParticipation, VketPresentation
 
 
 class LTApplicationViewTestBase(TestCase):
@@ -99,6 +100,36 @@ class LTApplicationViewTestBase(TestCase):
         self.list_url = reverse('account:lt_application_list')
         self.edit_url = reverse('account:lt_application_edit', kwargs={'pk': self.my_application.pk})
 
+    def create_vket_application(self):
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            theme='Vket Theme',
+            speaker='applicant',
+            start_time=time(23, 0),
+            duration=15,
+            status='approved',
+        )
+        collaboration = VketCollaboration.objects.create(
+            slug='view-test-vket',
+            name='View Test Vket',
+            period_start=date(2026, 3, 1),
+            period_end=date(2026, 3, 2),
+            registration_deadline=date(2026, 2, 1),
+            lt_deadline=date(2026, 2, 15),
+        )
+        participation = VketParticipation.objects.create(
+            collaboration=collaboration,
+            community=self.community,
+            applied_by=self.user,
+        )
+        VketPresentation.objects.create(
+            participation=participation,
+            published_event_detail=detail,
+            status=VketPresentation.Status.CONFIRMED,
+        )
+        return detail
+
 
 class LTApplicationListViewTests(LTApplicationViewTestBase):
     """LT申請一覧ビューのテスト"""
@@ -138,6 +169,14 @@ class LTApplicationListViewTests(LTApplicationViewTestBase):
         response = self.client.get(self.list_url)
         self.assertContains(response, 'テスト却下理由')
 
+    def test_vket_application_is_shown_to_applied_by_user(self):
+        detail = self.create_vket_application()
+        self.client.login(username='applicant', password='testpass123')
+
+        response = self.client.get(self.list_url)
+
+        self.assertIn(detail, response.context['applications'])
+
 
 class LTApplicationEditViewTests(LTApplicationViewTestBase):
     """LT申請編集ビューのテスト"""
@@ -161,6 +200,22 @@ class LTApplicationEditViewTests(LTApplicationViewTestBase):
         self.client.login(username='applicant', password='testpass123')
         other_edit_url = reverse('account:lt_application_edit', kwargs={'pk': self.other_application.pk})
         response = self.client.get(other_edit_url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_vket_applied_by_user_can_edit_application(self):
+        detail = self.create_vket_application()
+        self.client.login(username='applicant', password='testpass123')
+
+        response = self.client.get(reverse('account:lt_application_edit', kwargs={'pk': detail.pk}))
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_unrelated_user_cannot_edit_vket_application(self):
+        detail = self.create_vket_application()
+        self.client.login(username='other_user', password='testpass123')
+
+        response = self.client.get(reverse('account:lt_application_edit', kwargs={'pk': detail.pk}))
+
         self.assertEqual(response.status_code, 404)
 
     def test_save_theme_and_speaker(self):

--- a/app/user_account/view_modules/lt_applications.py
+++ b/app/user_account/view_modules/lt_applications.py
@@ -14,6 +14,19 @@ from event.models import EventDetail
 logger = logging.getLogger(__name__)
 
 
+def _owned_lt_condition(user) -> Q:
+    """ユーザーが自分のLTとして扱える条件。
+
+    リマインドメールの受信者選定（event.material_upload_reminders.get_material_reminder_recipient）
+    と整合させる: applicant 本人、または applicant 未設定の Vket 由来発表の申請者本人。
+    一覧と編集で条件が食い違うと「一覧に出るのに編集で404」の乖離バグになるため必ず共用する。
+    """
+    return Q(applicant=user) | Q(
+        applicant__isnull=True,
+        vket_presentations__participation__applied_by=user,
+    )
+
+
 class LTApplicationListView(LoginRequiredMixin, ListView):
     """LT申請一覧ページ."""
 
@@ -22,11 +35,7 @@ class LTApplicationListView(LoginRequiredMixin, ListView):
 
     def get_queryset(self):
         return EventDetail.objects.filter(
-            Q(applicant=self.request.user)
-            | Q(
-                applicant__isnull=True,
-                vket_presentations__participation__applied_by=self.request.user,
-            ),
+            _owned_lt_condition(self.request.user),
             detail_type='LT',
         ).select_related('event', 'event__community').distinct().order_by('-event__date', '-created_at')
 
@@ -41,11 +50,7 @@ class LTApplicationEditView(LoginRequiredMixin, UpdateView):
 
     def get_queryset(self):
         return EventDetail.objects.filter(
-            Q(applicant=self.request.user)
-            | Q(
-                applicant__isnull=True,
-                vket_presentations__participation__applied_by=self.request.user,
-            ),
+            _owned_lt_condition(self.request.user),
             detail_type='LT',
         ).exclude(status='rejected').select_related('event', 'event__community').distinct()
 

--- a/app/user_account/view_modules/lt_applications.py
+++ b/app/user_account/view_modules/lt_applications.py
@@ -4,6 +4,7 @@ import logging
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Q
 from django.urls import reverse
 from django.views.generic import ListView, UpdateView
 
@@ -21,9 +22,13 @@ class LTApplicationListView(LoginRequiredMixin, ListView):
 
     def get_queryset(self):
         return EventDetail.objects.filter(
-            applicant=self.request.user,
+            Q(applicant=self.request.user)
+            | Q(
+                applicant__isnull=True,
+                vket_presentations__participation__applied_by=self.request.user,
+            ),
             detail_type='LT',
-        ).select_related('event', 'event__community').order_by('-event__date', '-created_at')
+        ).select_related('event', 'event__community').distinct().order_by('-event__date', '-created_at')
 
 
 class LTApplicationEditView(LoginRequiredMixin, UpdateView):
@@ -36,9 +41,13 @@ class LTApplicationEditView(LoginRequiredMixin, UpdateView):
 
     def get_queryset(self):
         return EventDetail.objects.filter(
-            applicant=self.request.user,
+            Q(applicant=self.request.user)
+            | Q(
+                applicant__isnull=True,
+                vket_presentations__participation__applied_by=self.request.user,
+            ),
             detail_type='LT',
-        ).exclude(status='rejected').select_related('event', 'event__community')
+        ).exclude(status='rejected').select_related('event', 'event__community').distinct()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/app/vket/migrations/0010_backfill_vket_event_detail_applicant.py
+++ b/app/vket/migrations/0010_backfill_vket_event_detail_applicant.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+
+def backfill_vket_event_detail_applicant(apps, schema_editor):
+    """Vket由来の発表詳細へ申請者を補完する。"""
+    EventDetail = apps.get_model("event", "EventDetail")
+    VketPresentation = apps.get_model("vket", "VketPresentation")
+
+    detail_ids = EventDetail.objects.filter(
+        applicant__isnull=True,
+        vket_presentations__participation__applied_by__isnull=False,
+    ).values_list("pk", flat=True).distinct()
+
+    for detail_id in detail_ids.iterator():
+        presentation = (
+            VketPresentation.objects.filter(
+                published_event_detail_id=detail_id,
+                participation__applied_by__isnull=False,
+            )
+            .order_by("order", "pk")
+            .first()
+        )
+        if presentation:
+            EventDetail.objects.filter(
+                pk=detail_id,
+                applicant__isnull=True,
+            ).update(applicant_id=presentation.participation.applied_by_id)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("vket", "0009_alter_vketcollaboration_lt_deadline_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_vket_event_detail_applicant,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/app/vket/services.py
+++ b/app/vket/services.py
@@ -143,6 +143,7 @@ def sync_participation_publication(
     ).select_related("published_event_detail"):
         detail_defaults = {
             "event": event,
+            "applicant": participation.applied_by,
             "theme": presentation.theme,
             "speaker": presentation.speaker,
             "start_time": (
@@ -159,8 +160,14 @@ def sync_participation_publication(
             detail = presentation.published_event_detail
             dirty_fields = []
             for field_name, value in detail_defaults.items():
-                current_value = detail.event_id if field_name == "event" else getattr(detail, field_name)
-                expected_value = value.pk if field_name == "event" else value
+                if field_name == "applicant" and value is None:
+                    continue
+                if field_name in {"event", "applicant"}:
+                    current_value = getattr(detail, f"{field_name}_id")
+                    expected_value = value.pk if value else None
+                else:
+                    current_value = getattr(detail, field_name)
+                    expected_value = value
                 if current_value != expected_value:
                     setattr(detail, field_name, value)
                     dirty_fields.append(field_name)

--- a/app/vket/services.py
+++ b/app/vket/services.py
@@ -160,6 +160,8 @@ def sync_participation_publication(
             detail = presentation.published_event_detail
             dirty_fields = []
             for field_name, value in detail_defaults.items():
+                # applied_by の解除（None化）では既存 applicant を保持する。
+                # 担当者が外れても登壇者本人の編集導線を失わせないため。非Noneなら Vket 側を正として上書きする。
                 if field_name == "applicant" and value is None:
                     continue
                 if field_name in {"event", "applicant"}:

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -1,8 +1,10 @@
 """Vketコラボ機能のテスト."""
 
 from datetime import time, timedelta
+from importlib import import_module
 
 from django.contrib.auth import get_user_model
+from django.apps import apps
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.test import Client, TestCase
@@ -19,6 +21,7 @@ from vket.models import (
     VketParticipation,
     VketPresentation,
 )
+from vket.services import sync_participation_publication
 from vket.views.helpers import _build_schedule_context
 
 
@@ -1274,6 +1277,108 @@ class VketManageViewsTests(TestCase):
         self.assertEqual(Event.objects.filter(community=community).count(), 1)
         self.assertEqual(presentation.published_event_detail.event_id, existing_event.pk)
         self.assertEqual(presentation.published_event_detail.start_time.strftime('%H:%M'), '22:30')
+
+    def test_sync_participation_publication_sets_applicant_on_new_detail(self):
+        """公開同期で新規EventDetailへVket申請者を設定する。"""
+        self.participation1.applied_by = self.normal_user
+        self.participation1.save(update_fields=['applied_by'])
+        presentation = VketPresentation.objects.create(
+            participation=self.participation1,
+            order=0,
+            speaker='Vket発表者',
+            theme='Vketテーマ',
+            status=VketPresentation.Status.CONFIRMED,
+        )
+
+        sync_participation_publication(self.participation1)
+
+        presentation.refresh_from_db()
+        self.assertEqual(presentation.published_event_detail.applicant, self.normal_user)
+
+    def test_sync_participation_publication_backfills_applicant_on_existing_detail(self):
+        """再同期で既存EventDetailの未設定申請者を補完する。"""
+        self.participation1.applied_by = self.normal_user
+        self.participation1.save(update_fields=['applied_by'])
+        detail = EventDetail.objects.create(
+            event=self.event1,
+            detail_type='LT',
+            speaker='Vket発表者',
+            theme='Vketテーマ',
+            start_time='21:00',
+            duration=30,
+            status='approved',
+        )
+        VketPresentation.objects.create(
+            participation=self.participation1,
+            order=0,
+            speaker='Vket発表者',
+            theme='Vketテーマ',
+            status=VketPresentation.Status.CONFIRMED,
+            published_event_detail=detail,
+        )
+
+        sync_participation_publication(self.participation1)
+
+        detail.refresh_from_db()
+        self.assertEqual(detail.applicant, self.normal_user)
+
+    def test_sync_participation_publication_keeps_applicant_when_applied_by_is_none(self):
+        """Vket申請者が未設定でも既存EventDetailの申請者を保持する。"""
+        detail = EventDetail.objects.create(
+            event=self.event1,
+            detail_type='LT',
+            speaker='既存発表者',
+            theme='既存テーマ',
+            start_time='21:00',
+            duration=30,
+            status='approved',
+            applicant=self.normal_user,
+        )
+        VketPresentation.objects.create(
+            participation=self.participation1,
+            order=0,
+            speaker='既存発表者',
+            theme='既存テーマ',
+            status=VketPresentation.Status.CONFIRMED,
+            published_event_detail=detail,
+        )
+
+        sync_participation_publication(self.participation1)
+
+        detail.refresh_from_db()
+        self.assertEqual(detail.applicant, self.normal_user)
+
+    def test_vket_applicant_backfill_uses_first_ordered_presentation(self):
+        """移行処理は表示順が先のVket発表に紐づく申請者を設定する。"""
+        detail = EventDetail.objects.create(
+            event=self.event1,
+            detail_type='LT',
+            speaker='移行対象',
+            theme='移行テーマ',
+            start_time='21:00',
+            duration=30,
+            status='approved',
+        )
+        self.participation1.applied_by = self.normal_user
+        self.participation1.save(update_fields=['applied_by'])
+        self.participation2.applied_by = self.superuser
+        self.participation2.save(update_fields=['applied_by'])
+        VketPresentation.objects.create(
+            participation=self.participation1,
+            published_event_detail=detail,
+            order=1,
+        )
+        VketPresentation.objects.create(
+            participation=self.participation2,
+            published_event_detail=detail,
+            order=0,
+        )
+
+        migration = import_module('vket.migrations.0010_backfill_vket_event_detail_applicant')
+        migration.backfill_vket_event_detail_applicant(apps, None)
+
+        detail.refresh_from_db()
+        self.assertEqual(detail.applicant, self.superuser)
 
     def test_manage_participation_update_approves_existing_pending_detail(self):
         """既存のpending EventDetailは確定時にapprovedへ同期される"""


### PR DESCRIPTION
## なぜこの変更が必要か

LT登壇者に発表翌日に送信している「発表資料アップロードのお願い」メール（および1週間後のリマインドメール）のリンクを開くと404になる、との報告がセキュリティ集会のkumamaさんからあった（2026-07-11開催回、7/12送信分）。

調査の結果、メールのURL（`/account/lt-applications/<pk>/edit/`）自体は登壇者向け編集画面として正しいが、**Vket経由で公開されたEventDetailはapplicant（申請者）が未設定のまま作成される**ため、編集画面の本人フィルタ `applicant=request.user` で必ず404になることが判明。メール受信者の選定ロジック（`get_material_reminder_recipient`）はVketの`participation.applied_by`にフォールバックするのに、編集画面の権限判定はそれを知らない、という不整合が根本原因。

本番DBで確認済み: 該当2件はいずれも`vket_presentation`連携ありのapplicant=None。同条件のバックフィル対象は37件。

## 変更内容

- `vket/services.py`: 公開同期（`sync_participation_publication`）で `applicant=participation.applied_by` を設定（新規作成・再同期の両方。applied_byのNone化では既存applicantを保持）
- `vket/migrations/0010`: 既存のVket由来EventDetail（applicant未設定・本番37件）へのバックフィル data migration
- `user_account/view_modules/lt_applications.py`: LT申請一覧・編集のquerysetを受信者選定ロジックと整合（`applicant`本人 OR `applicant`未設定かつVket申請者本人）。条件は`_owned_lt_condition`に共通化
- 再発防止テスト: メール本文のURLに受信者本人でアクセスして200になるE2Eテストを翌日メール・リマインドメール両方に追加（既存テストは「本文にURL文字列が含まれる」ことしか検証しておらず、この穴を検知できなかった）

## 意思決定

### 採用アプローチ
- データ整合（applicant設定+バックフィル）+ 権限整合（queryset拡張）の両輪。理由: どちらか片方だと、バックフィル漏れや今後の新経路で同型バグが再発する

### 却下した代替案
- メールのリンク先を `/event/detail/<pk>/update/` に差し替え → 却下: 権限判定（`can_manage_event_detail`）も`applicant_id == user.id`を要求するため解決にならず、かつ登壇者が開始時間・発表時間・記事種別まで編集できてしまう
- 管理者用承認ページURLの誤用という当初仮説 → 調査で否定（メールは一貫して`account:lt_application_edit`を使用）

### トレードオフ
- 再同期はapplied_byの非None値でapplicantを上書きする（Vket由来detailはVket側を正とする）。管理者が手動でapplicantを別ユーザーに付け替えた場合は再同期で戻る点に注意

## テスト

- [x] `docker compose exec vrc-ta-hub python manage.py test vket user_account.tests.test_lt_application_views event.tests.test_material_upload_reminders event.tests.test_slide_reminders` → 184件 OK
- [x] migration適用OK（ローカル）
- [x] 本番URLルート確認: 未ログインは404ではなくログインへ302（curl）
- [x] ローカル /code-review 実施、CONFIRMED指摘（Q条件重複・理由コメント欠如）を修正済み

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)