### PR TITLE
fix: Cloud Run deterministic URL 形式のタグ付きホストを許可

### DIFF
--- a/app/website/middleware.py
+++ b/app/website/middleware.py
@@ -32,9 +32,14 @@ def _build_cloud_run_preview_host_pattern_source() -> str:
         re.escape(service_name)
         for service_name in _build_cloud_run_service_names()
     )
+    # Cloud Run の URL は2形式ある（サービス名ホワイトリストは両形式で維持する）:
+    #   旧: {tag---}{service}-{hash}-{region略号}.a.run.app
+    #   新: {tag---}{service}-{project番号}.{region}.run.app (deterministic URL)
+    # https://cloud.google.com/run/docs/triggering/https-request#deterministic
     return (
-        rf'^(?:[a-z0-9-]+---)?(?:{service_names})-[a-z0-9]+-[a-z0-9]+'
-        rf'\.a\.run\.app(?::\d+)?$'
+        rf'^(?:[a-z0-9-]+---)?(?:{service_names})-'
+        rf'(?:[a-z0-9]+-[a-z0-9]+\.a|\d+\.[a-z0-9-]+)'
+        rf'\.run\.app(?::\d+)?$'
     )
 
 

--- a/app/website/tests/test_host_middleware.py
+++ b/app/website/tests/test_host_middleware.py
@@ -69,6 +69,35 @@ class CanonicalCloudRunHostMiddlewareTest(SimpleTestCase):
     @override_settings(
         ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
     )
+    def test_cloud_run_deterministic_url_host_validator_allows_supported_service(self):
+        """新形式 deterministic URL の canary タグ付きホストで get_host() が通る（Issue #493）。"""
+        install_cloud_run_preview_host_validator()
+        request = self.request_factory.get(
+            '/healthz/',
+            HTTP_HOST='canary---vrc-ta-hub-332732449600.asia-northeast1.run.app',
+        )
+
+        self.assertEqual(
+            request.get_host(),
+            'canary---vrc-ta-hub-332732449600.asia-northeast1.run.app',
+        )
+
+    @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+    )
+    def test_cloud_run_deterministic_url_host_validator_rejects_other_service(self):
+        install_cloud_run_preview_host_validator()
+        request = self.request_factory.get(
+            '/healthz/',
+            HTTP_HOST='canary---other-service-332732449600.asia-northeast1.run.app',
+        )
+
+        with self.assertRaises(DisallowedHost):
+            request.get_host()
+
+    @override_settings(
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+    )
     def test_middleware_initialization_installs_preview_host_validator(self):
         original_validate_host = request_module.validate_host
         request_module.validate_host = _ORIGINAL_VALIDATE_HOST

--- a/app/website/tests/test_host_settings.py
+++ b/app/website/tests/test_host_settings.py
@@ -121,6 +121,58 @@ class AllowedHostsSettingsTest(SimpleTestCase):
             pattern,
         )
 
+    def test_cloud_run_preview_host_pattern_matches_deterministic_url_format(self):
+        """新形式 deterministic URL（{service}-{project番号}.{region}.run.app）も通る。
+
+        本番で `canary---vrc-ta-hub-332732449600.asia-northeast1.run.app` が
+        DisallowedHost になった回帰テスト（Issue #493）。
+        """
+        pattern = _build_cloud_run_preview_host_pattern()
+
+        self.assertRegex(
+            'canary---vrc-ta-hub-332732449600.asia-northeast1.run.app',
+            pattern,
+        )
+        self.assertRegex(
+            'vrc-ta-hub-332732449600.asia-northeast1.run.app',
+            pattern,
+        )
+        self.assertRegex(
+            'rev-24d1224---vrc-ta-hub-dev-332732449600.asia-northeast1.run.app',
+            pattern,
+        )
+        self.assertNotRegex(
+            'canary---other-service-332732449600.asia-northeast1.run.app',
+            pattern,
+        )
+        self.assertNotRegex(
+            'rev-24d1224---other-vrc-ta-hub-332732449600.asia-northeast1.run.app',
+            pattern,
+        )
+        # project 番号部が数字以外（旧形式 hash 相当）は新形式として通さない
+        self.assertNotRegex(
+            'vrc-ta-hub-mhbhtr6sha.asia-northeast1.run.app',
+            pattern,
+        )
+
+    @override_settings(
+        ROOT_URLCONF=__name__,
+        ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],
+        MIDDLEWARE=[
+            'website.middleware.CanonicalCloudRunHostMiddleware',
+            'django.middleware.common.CommonMiddleware',
+        ],
+    )
+    def test_cloud_run_deterministic_url_canary_host_is_canonicalized(self):
+        """新形式 URL の canary タグ付きリクエストが 200 で canonical host に寄る。"""
+        response = self.client.get(
+            '/healthz/',
+            HTTP_HOST='canary---vrc-ta-hub-332732449600.asia-northeast1.run.app',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), 'vrc-ta-hub.com')
+
     @override_settings(
         ROOT_URLCONF=__name__,
         ALLOWED_HOSTS=['testserver', 'localhost', '127.0.0.1', 'vrc-ta-hub.com'],

--- a/nginx-app.conf
+++ b/nginx-app.conf
@@ -4,7 +4,7 @@
 # Django に raw run.app host が届かないようにする。参照: PR #193（Cloud Run preview host を nginx 前段で正規化した理由）
 map $http_host $django_upstream_host {
     default $http_host;
-    ~^(?:[a-z0-9-]+---)?(?:vrc\-ta\-hub|vrc\-ta\-hub\-dev)-[a-z0-9]+-[a-z0-9]+\.a\.run\.app(?::\d+)?$ vrc-ta-hub.com;
+    ~^(?:[a-z0-9-]+---)?(?:vrc\-ta\-hub|vrc\-ta\-hub\-dev)-(?:[a-z0-9]+-[a-z0-9]+\.a|\d+\.[a-z0-9-]+)\.run\.app(?::\d+)?$ vrc-ta-hub.com;
 }
 
 # the upstream component nginx needs to connect to


### PR DESCRIPTION
## なぜこの変更が必要か

本番で `canary---vrc-ta-hub-332732449600.asia-northeast1.run.app` へのアクセスが `DisallowedHost` になっていた（FixFlow incident、最終観測 2026-07-04）。既存の `CanonicalCloudRunHostMiddleware` の preview host パターンは旧形式 `{service}-{hash}-{region略号}.a.run.app` のみ対応で、Cloud Run の新形式 deterministic URL `{service}-{project番号}.{region}.run.app` が漏れていた。deploy-watch のカナリア検証（`canary` タグ）がこの URL を直接叩くため、修正が必要。

## 変更内容

- `_build_cloud_run_preview_host_pattern_source` に deterministic URL 形式の分岐 `\d+\.[a-z0-9-]+\.run\.app` を追加
- `nginx-app.conf` の map 正規表現を同期（`test_nginx_config` がパターン一致を検証している）
- パターン・`request.get_host()`・エンドツーエンド正規化（canary タグ / rev タグ / 他サービス拒否）の回帰テストを追加

## 意思決定

### 採用アプローチ
- 既存のサービス名ホワイトリスト方式を維持したままパターンに新形式の分岐を追加。理由: middleware / nginx / WSGI / ASGI が単一のパターン生成関数を共有しており、1箇所の修正で全層に効く

### 却下した代替案
- `ALLOWED_HOSTS` に `.run.app` ワイルドカード追加 → 却下: 他人の Cloud Run サービスの Host も通してしまい全開放になる
- タグ名（`canary` / `rev-*`）の静的列挙 → 却下: `rev-{sha}` タグが動的なため列挙不能

### トレードオフ
- 正規表現の複雑化 > 全開放リスク: 新旧2形式の分岐を1つの正規表現に持つが、`test_nginx_config` で nginx との同期を機械検証している

## テスト

- [x] `docker compose exec vrc-ta-hub python manage.py test website` — 70件 OK
- [x] 新形式 canary ホストで `request.get_host()` が通り、canonical host `vrc-ta-hub.com` へ正規化されることを確認
- [x] 他サービス名（`other-service` / `other-vrc-ta-hub`）は引き続き拒否されることを確認

Closes #493

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)