### PR TITLE
test: test_recurrence_llm_generation を recurrence パッケージ分割後の API に追従

### DIFF
--- a/app/event/tests/test_recurrence_llm_generation.py
+++ b/app/event/tests/test_recurrence_llm_generation.py
@@ -4,6 +4,9 @@ from django.test import TestCase, tag
 from django.contrib.auth import get_user_model
 from community.models import Community
 from event.models import Event, RecurrenceRule
+# 週番号・曜日ヘルパーは PR #454 のリファクタでサービスのメソッドから
+# calculator モジュール関数へ移動したため、モジュール関数を直接使う
+from event.recurrence.calculator import get_japanese_weekday, get_week_of_month
 from event.recurrence_service import RecurrenceService
 
 User = get_user_model()
@@ -68,8 +71,8 @@ class TestRecurrenceLLMGeneration(TestCase):
         
         print("\n=== 実際のLLMが生成した日付 ===")
         for d in dates:
-            weekday_jp = self.service._get_japanese_weekday(d.weekday())
-            week_num = self.service._get_week_of_month(d)
+            weekday_jp = get_japanese_weekday(d.weekday())
+            week_num = get_week_of_month(d)
             print(f"{d} ({weekday_jp}) - 第{week_num}週")
         
         # 期待される第4月曜日
@@ -86,7 +89,7 @@ class TestRecurrenceLLMGeneration(TestCase):
             self.assertEqual(d.weekday(), 0, f"{d} は月曜日ではありません (weekday={d.weekday()})")
             
             # 第4週（その曜日の4回目）であることを確認
-            week_of_month = self.service._get_week_of_month(d)
+            week_of_month = get_week_of_month(d)
             self.assertEqual(week_of_month, 4, f"{d} は第{week_of_month}週ですが、第4週であるべきです")
         
         # 期待される日付と一致することを確認


### PR DESCRIPTION
## なぜこの変更が必要か

`docker compose exec vrc-ta-hub python manage.py test event` を実行すると `test_recurrence_llm_generation` が `AttributeError: 'RecurrenceService' object has no attribute '_get_japanese_weekday'` で常時エラーになっていた。PR #454 のリファクタで週番号・曜日ヘルパーがサービスのプライベートメソッドから `event/recurrence/calculator.py` のモジュール関数へ移動した際、このテストだけ追従が漏れていた（実 LLM 依存テストのため API キーなし環境ではスキップされ、気付きにくかった）。

## 変更内容

- `self.service._get_japanese_weekday` / `self.service._get_week_of_month` の参照を `event.recurrence.calculator` の `get_japanese_weekday` / `get_week_of_month` の直接利用に置換

## 意思決定

### 採用アプローチ
- テストを現行 API に追従させる。理由: `git log -S` で確認した結果、関数削除ではなく PR #454 の意図的なモジュール分割であり、実装側が正。互換シム `recurrence_service.py` も新 API への移行を明記している

### 却下した代替案
- `RecurrenceService` にメソッドを復元 → 却下: リファクタの設計意図（計算ロジックの calculator への集約）に逆行する

## テスト

- [x] `docker compose exec vrc-ta-hub python manage.py test event.tests.test_recurrence_llm_generation` — OK（実 LLM 呼び出し込みで期待日付と完全一致）
- [x] `docker compose exec vrc-ta-hub python manage.py test event` — 453件 OK (skipped=13)

Closes #496

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)