### PR TITLE
fix: 確定済み申請の日程choice検証を維持

### DIFF
--- a/app/vket/forms.py
+++ b/app/vket/forms.py
@@ -12,6 +12,15 @@ from event.models import Event
 from .models import VketCollaboration, VketParticipation
 
 
+def _format_participation_date_choice(value: date) -> tuple[str, str]:
+    """参加希望日のフォーム選択肢を表示用ラベル付きで返す"""
+    weekday_jp = ['月', '火', '水', '木', '金', '土', '日']
+    return (
+        value.isoformat(),
+        f'{value.month}/{value.day}({weekday_jp[value.weekday()]})',
+    )
+
+
 def _build_participation_date_choices(
     collaboration: VketCollaboration, community: Community
 ) -> list[tuple[str, str]]:
@@ -29,11 +38,7 @@ def _build_participation_date_choices(
     if not event_dates:
         return []
 
-    weekday_jp = ['月', '火', '水', '木', '金', '土', '日']
-    return [
-        (d.isoformat(), f'{d.month}/{d.day}({weekday_jp[d.weekday()]})')
-        for d in event_dates
-    ]
+    return [_format_participation_date_choice(event_date) for event_date in event_dates]
 
 
 def _build_duration_choices(default_minutes: int) -> list[tuple[int, str]]:
@@ -135,9 +140,20 @@ class VketApplyForm(forms.Form):
         self.participation = participation
         self.permissions = permissions
 
-        self.fields['requested_date'].choices = _build_participation_date_choices(
+        requested_date_choices = _build_participation_date_choices(
             collaboration, community
         )
+        if (
+            not permissions.can_edit_schedule
+            and participation
+            and participation.requested_date
+        ):
+            requested_date_value = participation.requested_date.isoformat()
+            if requested_date_value not in {value for value, _ in requested_date_choices}:
+                requested_date_choices.append(
+                    _format_participation_date_choice(participation.requested_date)
+                )
+        self.fields['requested_date'].choices = requested_date_choices
         self.fields['requested_duration'].choices = _build_duration_choices(
             default_minutes=community.duration
         )

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -753,6 +753,66 @@ class VketApplyFlowTests(TestCase):
             time(23, 50),
         )
 
+    def test_confirmed_participation_without_event_can_update_lt_and_note(self):
+        """Eventがない確定済み参加でも発表と備考を更新できる"""
+        Event.objects.filter(community=self.community).delete()
+        participation = VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            requested_date=self.collaboration.period_start,
+            requested_start_time=time(21, 0),
+            requested_duration=60,
+            confirmed_date=self.collaboration.period_start,
+            confirmed_start_time=time(21, 0),
+            confirmed_duration=60,
+            schedule_confirmed_at=timezone.now(),
+            progress=VketParticipation.Progress.REHEARSAL,
+            applied_by=self.owner,
+        )
+        presentation = VketPresentation.objects.create(
+            participation=participation,
+            order=0,
+            speaker='更新前登壇者',
+            theme='更新前テーマ',
+            requested_start_time=time(21, 30),
+            status=VketPresentation.Status.CONFIRMED,
+        )
+
+        self.client.login(username='owner_user', password='testpass123')
+        self._set_active_community()
+        post_data = {
+            'requested_date': self.collaboration.period_start.isoformat(),
+            'requested_start_time': '23:00',
+            'requested_duration': '90',
+            'organizer_note': 'Eventなしでも更新できる備考',
+        }
+        post_data.update(
+            self._make_formset_data(
+                [{'speaker': '更新後登壇者', 'theme': '更新後テーマ'}],
+                initial_forms=1,
+            )
+        )
+
+        response = self.client.post(
+            reverse('vket:apply', kwargs={'pk': self.collaboration.pk}),
+            data=post_data,
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        participation.refresh_from_db()
+        presentation.refresh_from_db()
+        self.assertEqual(participation.requested_date, self.collaboration.period_start)
+        self.assertEqual(participation.requested_start_time, time(21, 0))
+        self.assertEqual(participation.requested_duration, 60)
+        self.assertEqual(participation.confirmed_date, self.collaboration.period_start)
+        self.assertEqual(participation.confirmed_start_time, time(21, 0))
+        self.assertEqual(participation.confirmed_duration, 60)
+        self.assertEqual(participation.organizer_note, 'Eventなしでも更新できる備考')
+        self.assertEqual(presentation.speaker, '更新後登壇者')
+        self.assertEqual(presentation.theme, '更新後テーマ')
+        self.assertEqual(presentation.requested_start_time, time(21, 30))
+
     def test_confirmed_participation_post_does_not_delete_existing_lt(self):
         """日程確定後はformset DELETEでも既存LTを削除しない"""
         self.client.login(username='owner_user', password='testpass123')

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -4,6 +4,7 @@
 
 ## レポート一覧
 
+- [Issue #499 disabled の参加希望日バリデーション調査](issue-499-disabled-vket-date-validation.md) — Event がない確定済み参加で発表・備考更新が失敗する原因と回帰テスト
 - [Issue #500 Campaign UTM validator migration](issue-500-analytics-campaign-migration.md) — `Campaign.utm_source` / `utm_medium` の validator 定義と migration 履歴の差分、および `AlterField` migration の安全性確認
 - [Issue #356 OpenRouter HTTP-Referer 調査](issue-356-openrouter-http-referer.md) — preview/staging URL が OpenRouter の `HTTP-Referer` に漏れないようにする調査と検証方針
 - [Issue #343 LT申請「追加情報」テンプレート初期値化](issue-343-lt-application-additional-info-initial.md) — LT申請フォームのテンプレート表示を placeholder から initial に変更する調査と検証方針

--- a/docs/research/issue-499-disabled-vket-date-validation.md
+++ b/docs/research/issue-499-disabled-vket-date-validation.md
@@ -1,0 +1,31 @@
+# Issue #499 disabled の参加希望日バリデーション調査
+
+## 原因と観測
+
+`VketApplyForm` はコラボ期間内の `Event` の日付だけを `requested_date` の choices にする。
+日程確定済みの参加は主催者に日程編集を許可しないため、同フィールドは disabled になる。Django は disabled フィールドの POST 値を使わず initial 値を検証するが、choices 検証自体は実行する。そのため、期間内に Event がない集会では、既存の参加希望日が choices に存在せず、発表情報や備考だけの更新もフォーム全体が invalid になる。
+
+## 採用方針
+
+日程編集不可かつ既存参加に `requested_date` がある場合だけ、その日付を choices に補う。既に Event 由来の choices にあれば追加しない。編集可能な状態の choices は従来どおり Event の日付だけであり、主催者が新たに日付を選べる範囲は変わらない。
+
+## 却下した代替案
+
+`requested_date` を常に `required=False` にして clean で既存値へ差し替える案は、編集可能な申請の必須入力・選択肢検証を弱めるため採用しない。日程ロック時に限って既存値を有効な選択肢にする方が、Django の disabled フィールドの検証経路と既存の入力制約を両立できる。
+
+## 検証
+
+`Event` がない集会に確定済みの `VketParticipation` と既存発表を作成し、主催者が備考・発表者・テーマだけを POST する回帰テストを追加する。302 応答、備考と発表の更新、希望日・希望時刻・希望時間・確定日程・既存発表開始時刻の不変を確認する。
+
+実行コマンド:
+
+```bash
+docker run --rm -v "$PWD/app:/code/app" -v "$PWD/pyproject.toml:/code/pyproject.toml:ro" \
+  -w /code/app \
+  -e SECRET_KEY=test-secret-key-for-ci -e DEBUG=True -e TESTING=1 \
+  -e ALLOWED_HOSTS=localhost,127.0.0.1 -e CSRF_TRUSTED_ORIGIN=https://localhost \
+  -e GOOGLE_API_KEY=dummy-google-api-key -e GOOGLE_CALENDAR_ID=dummy-calendar-id@group.calendar.google.com \
+  -e GEMINI_API_KEY=dummy-gemini-api-key -e OPENAI_API_KEY=dummy-openai-api-key \
+  -e REQUEST_TOKEN=dummy-request-token -e EMAIL_FILE_PATH=/tmp/emails \
+  vrc-ta-hub-test:latest python manage.py test vket.tests.test_vket.VketApplyFlowTests
+```


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: [#499](https://github.com/noricha-vr/vrc-ta-hub/issues/499)「Vket申請画面: 対応Eventがない場合にdisabledの参加希望日バリデーションが保存全体を巻き添え失敗させる」
- Closes #499
- 必要性: この Issue で報告された問題・要望により、VRC技術学術Hub が期待動作や要件を満たせないため、修正・対応が必要です。
- 対応意図: disabled フィールドでも initial 値の choices 検証は行われるため、編集不可時のみ既存値を有効な選択肢として保持します。編集可能な日程候補は従来どおり Event 由来です。

## 変更内容

- ロック中の既存希望日だけを `requested_date` の選択肢に補完。
- Event 不在・日程確定済みでも発表と備考を更新できる回帰テストを追加。
- 調査記録と索引を追加。
- コミット済み: `8a62380`

## 意思決定

### 採用アプローチ
disabled フィールドでも initial 値の choices 検証は行われるため、編集不可時のみ既存値を有効な選択肢として保持します。編集可能な日程候補は従来どおり Event 由来です。

### トレードオフ または 却下した代替案
`required=False` と clean 時の差し替えは、通常申請の必須・選択肢検証まで弱めるため採用しませんでした。

### 残課題やリスク
なし


## テスト

- `docker run --rm ... python manage.py test vket.tests.test_vket.VketApplyFlowTests --noinput` — 27件成功
- `docker run --rm ... ruff check vket/forms.py vket/tests/test_vket.py` — 成功
- `git diff --check` — 成功
- コードレビュー・セキュリティレビュー・ドキュメント同期確認 — 指摘なし

---
🤖 Generated with [Codex](https://Codex.com/Codex)
