### PR TITLE
feat(event): LT申請の開始時刻を申請順に自動割り当てし、持ち時間の説明を表示

### DIFF
--- a/app/event/forms/lt_application.py
+++ b/app/event/forms/lt_application.py
@@ -99,7 +99,7 @@ class LTApplicationForm(forms.Form):
         min_value=5,
         max_value=60,
         widget=forms.NumberInput(attrs={'class': 'form-control'}),
-        help_text='希望する発表時間を分単位で入力してください（5〜60分）'
+        help_text='発表と質疑応答を含む持ち時間を分単位で入力してください（5〜60分）'
     )
 
     x_account = forms.CharField(

--- a/app/event/templates/event/lt_application_form.html
+++ b/app/event/templates/event/lt_application_form.html
@@ -31,6 +31,7 @@
                             <li>承認または却下の結果はメールでお知らせします</li>
                             <li>発表内容の詳細（スライドや動画）は承認後に編集できます</li>
                         </ul>
+                        <p class="mb-2">1人あたりの持ち時間は {{ community.default_lt_duration }}分（発表+質疑応答を含む）が目安です。発表開始時刻は申請順に自動で割り当てられます。</p>
                         <p class="mb-0">発表後にスライドの登録にご協力をお願いします。</p>
                     </div>
 
@@ -45,6 +46,7 @@
                             </a>
                         </div>
                     {% else %}
+                        {{ next_start_times|json_script:"next-start-times" }}
                         <form method="post">
                             {% csrf_token %}
 
@@ -57,6 +59,7 @@
                                 {% if form.event.help_text %}
                                     <small class="form-text text-muted">{{ form.event.help_text }}</small>
                                 {% endif %}
+                                <div id="next-start-time-hint" class="form-text text-muted" aria-live="polite"></div>
                                 {% if form.event.errors %}
                                     <div class="invalid-feedback d-block">
                                         {% for error in form.event.errors %}{{ error }}{% endfor %}
@@ -173,4 +176,29 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    (() => {
+        const eventSelect = document.getElementById('id_event');
+        const hint = document.getElementById('next-start-time-hint');
+        const startTimesElement = document.getElementById('next-start-times');
+
+        if (!eventSelect || !hint || !startTimesElement) {
+            return;
+        }
+
+        const startTimes = JSON.parse(startTimesElement.textContent);
+        const updateHint = () => {
+            const startTime = startTimes[eventSelect.value];
+            hint.textContent = startTime
+                ? `あなたの発表開始予定: ${startTime} 頃（申請状況により前後します）`
+                : '';
+        };
+
+        eventSelect.addEventListener('change', updateHint);
+        updateHint();
+    })();
+</script>
 {% endblock %}

--- a/app/event/tests/test_lt_application.py
+++ b/app/event/tests/test_lt_application.py
@@ -363,6 +363,28 @@ class LTApplicationFormTest(TweetGenerationPatchMixin, TestCase):
             time(22, 30),
         )
 
+    def test_calc_next_lt_start_time_ignores_lt_ending_before_event_offset(self):
+        """開始前に終了する手動配置LTでもオフセットを下回らない。"""
+        self.assertEqual(
+            _calc_next_lt_start_time(
+                time(21, 0),
+                [(time(20, 0), 30)],
+                30,
+            ),
+            time(21, 30),
+        )
+
+    def test_calc_next_lt_start_time_floors_early_existing_lt_at_offset(self):
+        """既存LTの終了がオフセットより早い場合はオフセットから開始する。"""
+        self.assertEqual(
+            _calc_next_lt_start_time(
+                time(21, 0),
+                [(time(21, 5), 10)],
+                30,
+            ),
+            time(21, 30),
+        )
+
 
 class LTApplicationReviewTest(TweetGenerationPatchMixin, TestCase):
     """LT申請の承認/却下テスト"""

--- a/app/event/tests/test_lt_application.py
+++ b/app/event/tests/test_lt_application.py
@@ -13,6 +13,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
 from event.tests.tweet_generation import TweetGenerationPatchMixin
+from event.views.lt_application import _calc_next_lt_start_time
 from tests.factories import make_community, make_event, make_event_detail
 from user_account.tests.utils import create_discord_linked_user
 
@@ -67,6 +68,14 @@ class LTApplicationFormTest(TweetGenerationPatchMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '発表を申請')
         self.assertContains(response, 'Test Community')
+        self.assertContains(
+            response,
+            '1人あたりの持ち時間は 30分（発表+質疑応答を含む）が目安です。',
+        )
+        self.assertContains(
+            response,
+            '発表と質疑応答を含む持ち時間を分単位で入力してください（5〜60分）',
+        )
 
     def test_lt_application_form_requires_login(self):
         """未ログインユーザーはログインページにリダイレクトされる"""
@@ -213,6 +222,146 @@ class LTApplicationFormTest(TweetGenerationPatchMixin, TestCase):
 
         event_detail = EventDetail.objects.get(event=self.future_event, theme='Offset0')
         self.assertEqual(event_detail.start_time, time(22, 0))
+
+    @patch('event.notifications.send_mail')
+    def test_lt_application_assigns_start_time_after_pending_lt(self, mock_send_mail):
+        """承認待ちLTの終了時刻を次のLTの開始時刻にする。"""
+        mock_send_mail.return_value = 1
+        make_event_detail(
+            self.future_event,
+            theme='First LT',
+            start_time=time(22, 30),
+            duration=15,
+            status='pending',
+        )
+        self.client.login(username='TestUser', password='testpass123')
+        url = reverse('event:lt_application_create', kwargs={'community_pk': self.community.pk})
+
+        self.client.post(url, {
+            'event': self.future_event.pk,
+            'theme': 'Second LT',
+            'speaker': 'Speaker',
+            'duration': 15,
+        })
+        second_lt = EventDetail.objects.get(event=self.future_event, theme='Second LT')
+        self.assertEqual(second_lt.start_time, time(22, 45))
+
+        self.client.post(url, {
+            'event': self.future_event.pk,
+            'theme': 'Third LT',
+            'speaker': 'Speaker',
+            'duration': 15,
+        })
+        third_lt = EventDetail.objects.get(event=self.future_event, theme='Third LT')
+        self.assertEqual(third_lt.start_time, time(23, 0))
+
+    @patch('event.notifications.send_mail')
+    def test_lt_application_ignores_rejected_lt_for_start_time(self, mock_send_mail):
+        """却下済みLTは次の開始時刻の計算対象から除外する。"""
+        mock_send_mail.return_value = 1
+        make_event_detail(
+            self.future_event,
+            theme='Rejected LT',
+            start_time=time(23, 0),
+            duration=15,
+            status='rejected',
+        )
+        self.client.login(username='TestUser', password='testpass123')
+        url = reverse('event:lt_application_create', kwargs={'community_pk': self.community.pk})
+
+        self.client.post(url, {
+            'event': self.future_event.pk,
+            'theme': 'New LT',
+            'speaker': 'Speaker',
+            'duration': 15,
+        })
+
+        new_lt = EventDetail.objects.get(event=self.future_event, theme='New LT')
+        self.assertEqual(new_lt.start_time, time(22, 30))
+
+    @patch('event.notifications.send_mail')
+    def test_lt_application_uses_latest_existing_lt_end_time(self, mock_send_mail):
+        """LT間に空きがあっても最も遅い終了時刻の後に割り当てる。"""
+        mock_send_mail.return_value = 1
+        make_event_detail(
+            self.future_event,
+            theme='Early LT',
+            start_time=time(22, 30),
+            duration=15,
+            status='approved',
+        )
+        make_event_detail(
+            self.future_event,
+            theme='Late LT',
+            start_time=time(23, 20),
+            duration=10,
+            status='approved',
+        )
+        self.client.login(username='TestUser', password='testpass123')
+        url = reverse('event:lt_application_create', kwargs={'community_pk': self.community.pk})
+
+        self.client.post(url, {
+            'event': self.future_event.pk,
+            'theme': 'New LT',
+            'speaker': 'Speaker',
+            'duration': 15,
+        })
+
+        new_lt = EventDetail.objects.get(event=self.future_event, theme='New LT')
+        self.assertEqual(new_lt.start_time, time(23, 30))
+
+    @patch('event.notifications.send_mail')
+    def test_lt_application_handles_start_time_across_midnight(self, mock_send_mail):
+        """日付をまたぐLTでもイベント開始時刻からの経過時間で順序付ける。"""
+        mock_send_mail.return_value = 1
+        overnight_event = make_event(
+            self.community,
+            event_date=date.today() + timedelta(days=8),
+            start_time=time(23, 50),
+        )
+        make_event_detail(
+            overnight_event,
+            theme='Overnight LT',
+            start_time=time(23, 50),
+            duration=30,
+            status='pending',
+        )
+        self.client.login(username='TestUser', password='testpass123')
+        url = reverse('event:lt_application_create', kwargs={'community_pk': self.community.pk})
+
+        self.client.post(url, {
+            'event': overnight_event.pk,
+            'theme': 'After Midnight LT',
+            'speaker': 'Speaker',
+            'duration': 15,
+        })
+
+        new_lt = EventDetail.objects.get(event=overnight_event, theme='After Midnight LT')
+        self.assertEqual(new_lt.start_time, time(0, 20))
+
+    def test_lt_application_context_includes_next_start_times(self):
+        """画面用コンテキストに開催日ごとの開始予定時刻を含める。"""
+        make_event_detail(
+            self.future_event,
+            theme='Existing LT',
+            start_time=time(22, 30),
+            duration=15,
+            status='approved',
+        )
+        self.client.login(username='TestUser', password='testpass123')
+        url = reverse('event:lt_application_create', kwargs={'community_pk': self.community.pk})
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.context['next_start_times'][self.future_event.pk], '22:45')
+        self.assertContains(response, 'id="next-start-times"')
+
+    def test_calc_next_lt_start_time_uses_offset_without_existing_lt(self):
+        """既存LTがない場合は従来どおりオフセット後を返す。"""
+        self.assertEqual(
+            _calc_next_lt_start_time(time(22, 0), [], 30),
+            time(22, 30),
+        )
 
 
 class LTApplicationReviewTest(TweetGenerationPatchMixin, TestCase):

--- a/app/event/views/lt_application.py
+++ b/app/event/views/lt_application.py
@@ -1,5 +1,6 @@
 import logging
-from datetime import datetime, timedelta
+from collections.abc import Iterable
+from datetime import datetime, time, timedelta
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -10,12 +11,12 @@ from django.views.generic import FormView, TemplateView, View
 
 from community.models import Community
 from event.forms import LTApplicationForm, LTApplicationReviewForm
-from event.models import EventDetail
+from event.models import Event, EventDetail
 
 logger = logging.getLogger(__name__)
 
 
-def _calc_lt_start_time(event_start_time, offset_minutes):
+def _calc_lt_start_time(event_start_time: time, offset_minutes: int) -> time:
     """集会の start_time に offset(分) を加算した time を返す。
 
     datetime.time は加算非対応のため、datetime.combine で日付を仮置きして演算する。
@@ -23,6 +24,25 @@ def _calc_lt_start_time(event_start_time, offset_minutes):
     """
     base = datetime.combine(datetime.today(), event_start_time)
     return (base + timedelta(minutes=offset_minutes)).time()
+
+
+def _calc_next_lt_start_time(
+    event_start_time: time,
+    existing_lt_slots: Iterable[tuple[time, int]],
+    offset_minutes: int,
+) -> time:
+    """既存LTの終了後、またはオフセット後の次の開始時刻を返す。"""
+    slots = list(existing_lt_slots)
+    if not slots:
+        return _calc_lt_start_time(event_start_time, offset_minutes)
+
+    event_start_minutes = event_start_time.hour * 60 + event_start_time.minute
+    latest_end_minutes = max(
+        ((start_time.hour * 60 + start_time.minute - event_start_minutes) % (24 * 60))
+        + duration
+        for start_time, duration in slots
+    )
+    return _calc_lt_start_time(event_start_time, latest_end_minutes)
 
 
 class LTApplicationCreateView(LoginRequiredMixin, FormView):
@@ -43,17 +63,40 @@ class LTApplicationCreateView(LoginRequiredMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['community'] = self.community
+        event_queryset = context['form'].fields['event'].queryset
+        offset = self.community.lt_start_offset_minutes or 0
+        context['next_start_times'] = {
+            event.pk: _calc_next_lt_start_time(
+                event.start_time,
+                EventDetail.objects.filter(
+                    event=event,
+                    detail_type='LT',
+                    status__in=['pending', 'approved'],
+                ).values_list('start_time', 'duration'),
+                offset,
+            ).strftime('%H:%M')
+            for event in event_queryset
+        }
         return context
 
     def form_valid(self, form):
-        # EventDetailを作成
         event = form.cleaned_data['event']
         offset = self.community.lt_start_offset_minutes or 0
-        lt_start = _calc_lt_start_time(event.start_time, offset)
         speaker = form.cleaned_data['speaker']
         x_account = form.cleaned_data.get('x_account', '')
 
         with transaction.atomic():
+            event = Event.objects.select_for_update().get(pk=event.pk)
+            lt_start = _calc_next_lt_start_time(
+                event.start_time,
+                EventDetail.objects.filter(
+                    event=event,
+                    detail_type='LT',
+                    status__in=['pending', 'approved'],
+                ).values_list('start_time', 'duration'),
+                offset,
+            )
+
             # speaker / x_account を user 側にも反映（LT 申込フォームをプロフィール更新の経路として扱う）
             user = self.request.user
             update_fields = []

--- a/app/event/views/lt_application.py
+++ b/app/event/views/lt_application.py
@@ -5,6 +5,7 @@ from datetime import datetime, time, timedelta
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
+from django.db.models import Prefetch
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import FormView, TemplateView, View
@@ -31,18 +32,33 @@ def _calc_next_lt_start_time(
     existing_lt_slots: Iterable[tuple[time, int]],
     offset_minutes: int,
 ) -> time:
-    """既存LTの終了後、またはオフセット後の次の開始時刻を返す。"""
+    """既存LTの終了後、またはオフセット後の次の開始時刻を返す。
+
+    開始時刻との差分は24時間で循環し、循環後の差分が12時間を超える場合は
+    イベント開始前に手動配置されたLTとして負の経過時間に補正する。
+    """
     slots = list(existing_lt_slots)
     if not slots:
         return _calc_lt_start_time(event_start_time, offset_minutes)
 
     event_start_minutes = event_start_time.hour * 60 + event_start_time.minute
-    latest_end_minutes = max(
-        ((start_time.hour * 60 + start_time.minute - event_start_minutes) % (24 * 60))
-        + duration
-        for start_time, duration in slots
+    slot_end_minutes = []
+    for start_time, duration in slots:
+        wrapped_delta = (
+            start_time.hour * 60 + start_time.minute - event_start_minutes
+        ) % (24 * 60)
+        delta_minutes = (
+            wrapped_delta - (24 * 60)
+            if wrapped_delta > 12 * 60
+            else wrapped_delta
+        )
+        slot_end_minutes.append(delta_minutes + duration)
+
+    latest_end_minutes = max(slot_end_minutes)
+    return _calc_lt_start_time(
+        event_start_time,
+        max(latest_end_minutes, offset_minutes),
     )
-    return _calc_lt_start_time(event_start_time, latest_end_minutes)
 
 
 class LTApplicationCreateView(LoginRequiredMixin, FormView):
@@ -64,18 +80,22 @@ class LTApplicationCreateView(LoginRequiredMixin, FormView):
         context = super().get_context_data(**kwargs)
         context['community'] = self.community
         event_queryset = context['form'].fields['event'].queryset
+        lt_prefetch = Prefetch(
+            'details',
+            queryset=EventDetail.objects.filter(
+                detail_type='LT',
+                status__in=['pending', 'approved'],
+            ),
+            to_attr='lt_slots',
+        )
         offset = self.community.lt_start_offset_minutes or 0
         context['next_start_times'] = {
             event.pk: _calc_next_lt_start_time(
                 event.start_time,
-                EventDetail.objects.filter(
-                    event=event,
-                    detail_type='LT',
-                    status__in=['pending', 'approved'],
-                ).values_list('start_time', 'duration'),
+                ((slot.start_time, slot.duration) for slot in event.lt_slots),
                 offset,
             ).strftime('%H:%M')
-            for event in event_queryset
+            for event in event_queryset.prefetch_related(lt_prefetch)
         }
         return context
 


### PR DESCRIPTION
## なぜこの変更が必要か

通常の LT 申請画面（/event/apply/）では、同じイベントに何人申請しても全員に同じ開始時刻（イベント開始 + オフセット）が割り当てられ、主催者が毎回手動で時刻を調整していた。また申請者側には「持ち時間（発表+質疑応答を含む）」の説明がなく、自分の発表がいつ始まるのかも申請時点では分からなかった。PR #501（Vket 側の LT 時刻改善）に続く、通常申請フローへの展開。

## 変更内容

- 申請時の開始時刻を「既存 LT（pending/approved）の最終終了時刻」から自動計算（`app/event/views/lt_application.py`）。既存 LT がなければ従来どおりイベント開始 + オフセット。rejected は数えない
- 申請フォームに「1人あたりの持ち時間は◯分（発表+質疑応答を含む）が目安です。発表開始時刻は申請順に自動で割り当てられます」の説明を追加し、duration の help_text も持ち時間の定義に更新
- 開催日 select に連動して「あなたの発表開始予定: HH:MM 頃」ヒントを表示（`json_script` + JS）
- 同時申請の競合は Event の `select_for_update` で直列化

## 意思決定

### 採用アプローチ
- 「max(既存 LT の終了時刻)」基準を採用。理由: 主催者が手動で間隔を調整済みでも正しく末尾に接続できる（件数×持ち時間の積算だと手動調整とズレる）

### 却下した代替案
- 申請フォームに開始時刻の入力欄を設ける → 却下: 申請者間の調整コストが発生し、時刻の前後逆転（Vket で発生した問題）を再生産する

### トレードオフ
- 24h 循環（23:50 開始等）は既存 `_calc_lt_start_time` の慣例を踏襲しつつ、循環差分が12時間を超える場合は「イベント開始前の手動配置」とみなす補正を追加（21:00 開始イベントの 20:00 配置 LT が「23時間後」扱いになり翌日へジャンプするのを防止）

### 技術的負債
- 申請連打の件数上限・主催者通知のレート制限は未対応（既存挙動。セキュリティレビューで LOW 判定、別 Issue 化候補）
- 却下で空いた枠への詰め直しはスコープ外（主催者が編集画面で調整する現行運用を維持）

## テスト

- [x] `event.tests` 459件 全パス（自動割当の新規テスト9件含む: 既存なし回帰 / 2人目・3人目の増分 / rejected 除外 / 手動調整済み間隔 / 24h 循環 / 前倒し配置 / offset フロア / context 値）
- [x] ブラウザ QA（localhost:8015）: 3人分の申請を連続実行し、DB 上の start_time が 22:00 → 22:15 → 22:30 と自動インクリメントされることを確認

## 動作確認: 申請者が増えると開始時刻がインクリメントされる様子

Event 開始 22:00、持ち時間 15分（community.default_lt_duration）、オフセット 0分。

| 申請 | フォームの「発表開始予定」表示 | 作成された EventDetail.start_time |
|------|------------------------------|-----------------------------------|
| 1人目 | 22:00 頃 | 22:00 |
| 2人目 | 22:15 頃 | 22:15 |
| 3人目 | 22:30 頃 | 22:30 |

**1人目申請前**（持ち時間の説明 + 開始予定 22:00）:
![1人目](https://agent-toolbox-assets.kaisha3.com/uploads/2026/07/726990f866db-10-lt-apply-form-info-20260715-020855.avif)

**2人目申請時**（開始予定が 22:15 に自動更新）:
![2人目](https://agent-toolbox-assets.kaisha3.com/uploads/2026/07/e8bfd71065f1-11-lt-apply-second-hint-20260715-020934.avif)

**3人目申請時**（開始予定が 22:30 に自動更新）:
![3人目](https://agent-toolbox-assets.kaisha3.com/uploads/2026/07/d63ad46ccda8-12-lt-apply-third-hint-20260715-020958.avif)

**申請後の主催者管理画面**（3件が 22:00 / 22:15 / 22:30 で並ぶ）:
![一覧](https://agent-toolbox-assets.kaisha3.com/uploads/2026/07/aa183c8e4bda-13-lt-apply-list-times-20260715-021050.avif)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)