### PR TITLE
fix: LT申請フォームの x_account help_text を告知自動投稿の説明に更新

### DIFF
--- a/app/event/forms/lt_application.py
+++ b/app/event/forms/lt_application.py
@@ -98,7 +98,7 @@ class LTApplicationForm(forms.Form):
             'placeholder': 'noricha_vr',
             'autocomplete': 'off',
         }),
-        help_text='任意。@ や https://x.com/ のURLでもOK。アカウント情報にも保存されます。'
+        help_text='発表が登録されると、Hub の X アカウントから告知を自動投稿します。告知にあなたの X ID（@ID）を含めるため、入力にご協力ください。https://x.com/ の URL でも OK。アカウント情報にも保存され、次回以降の入力は不要です。'
     )
 
     additional_info = forms.CharField(


### PR DESCRIPTION
## なぜこの変更が必要か

LT申請者の X アカウント入力率が低いと、Hub の X アカウントからの告知自動投稿に登壇者の @ID を含められない。現在の help_text「任意。@ や https://x.com/ のURLでもOK。」では入力するメリットが伝わらないため、告知に使われる目的を明示して入力を促す。

## 変更内容

- `LTApplicationForm.x_account` の help_text を「発表が登録されると、Hub の X アカウントから告知を自動投稿します。告知にあなたの X ID（@ID）を含めるため、入力にご協力ください。https://x.com/ の URL でも OK。アカウント情報にも保存され、次回以降の入力は不要です。」に変更（1箇所のみ）

## テスト

- [x] `python3 -m py_compile` 成功
- [x] diff で help_text 文字列1箇所のみの変更であることを確認（フィールド・バリデーション・保存挙動は不変）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)