### PR TITLE
fix: sitemap から実在しないURL・認証ページ・priority を除去

### DIFF
--- a/app/sitemap/templates/sitemap/robots.txt
+++ b/app/sitemap/templates/sitemap/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://vrc-ta-hub.com//sitemap.xml
+Sitemap: https://vrc-ta-hub.com/sitemap.xml

--- a/app/sitemap/templates/sitemap/sitemap.xml
+++ b/app/sitemap/templates/sitemap/sitemap.xml
@@ -4,52 +4,32 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
             http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-    <!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
     <url>
         <loc>{{ base_url }}</loc>
-        <priority>1</priority>
     </url>
     <url>
         <loc>{{ base_url }}event/list/</loc>
-        <priority>0.8</priority>
     </url>
     <url>
         <loc>{{ base_url }}community/list/</loc>
-        <priority>0.8</priority>
     </url>
     <url>
         <loc>{{ base_url }}about/</loc>
-        <priority>0.1</priority>
-    </url>
-    <url>
-        <loc>{{ base_url }}event/detail/list/</loc>
-        <priority>0.1</priority>
     </url>
     <url>
         <loc>{{ base_url }}event/detail/history/</loc>
-        <priority>0.1</priority>
-    </url>
-    <url>
-        <loc>{{ base_url }}account/register/</loc>
-        <priority>0.1</priority>
-    </url>
-    <url>
-        <loc>{{ base_url }}account/login/</loc>
-        <priority>0.1</priority>
     </url>
 
     {% for event_detail in event_details %}
         <url>
             <loc>{{ base_url }}event/detail/{{ event_detail.pk }}/</loc>
             <lastmod>{{ event_detail.updated_at|date:"Y-m-d" }}</lastmod>
-            <priority>0.3</priority>
         </url>
     {% endfor %}
     {% for community in communities %}
         <url>
             <loc>{{ base_url }}community/{{ community.pk }}/</loc>
             <lastmod>{{ community.updated_at|date:"Y-m-d" }}</lastmod>
-            <priority>0.3</priority>
         </url>
     {% endfor %}
 </urlset>

--- a/app/sitemap/tests.py
+++ b/app/sitemap/tests.py
@@ -1,11 +1,15 @@
 """sitemap アプリのテスト"""
+import xml.etree.ElementTree as ET
 from datetime import date, time
+from urllib.parse import urlparse
 
 from django.test import Client, TestCase
 from django.urls import reverse
 
 from community.models import Community
 from event.models import Event, EventDetail
+
+SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 
 
 class SitemapViewTestCase(TestCase):
@@ -102,3 +106,83 @@ class RobotsTxtTestCase(TestCase):
         """robots.txt が 200 を返す"""
         response = self.client.get("/robots.txt")
         self.assertEqual(response.status_code, 200)
+
+    def test_robots_txt_sitemap_line_is_clean(self):
+        """robots.txt の Sitemap 行が二重スラッシュを含まない正しい URL であること"""
+        response = self.client.get("/robots.txt")
+        body = response.content.decode("utf-8")
+        self.assertIn("Sitemap: https://vrc-ta-hub.com/sitemap.xml", body)
+        # 過去に含まれていた誤った二重スラッシュが再発しないことを検証
+        self.assertNotIn("//sitemap.xml", body)
+
+
+class SitemapUrlsResolveTestCase(TestCase):
+    """sitemap.xml の全 <loc> が実在する URL であり、実在しない URL が混入していないこと"""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.community = Community.objects.create(
+            name="テスト集会",
+            status="approved",
+            frequency="毎週",
+        )
+        cls.event = Event.objects.create(
+            community=cls.community,
+            date=date(2026, 4, 6),
+            start_time=time(22, 0),
+        )
+        cls.event_detail = EventDetail.objects.create(
+            event=cls.event,
+            theme="テスト発表",
+            speaker="テスト発表者",
+            status="approved",
+            detail_type="LT",
+        )
+        cls.pending_community = Community.objects.create(
+            name="未承認集会",
+            status="pending",
+            frequency="不定期",
+        )
+
+    def setUp(self):
+        self.client = Client()
+
+    def _get_sitemap_response(self):
+        return self.client.get(reverse("sitemap:sitemap"))
+
+    def _extract_locs(self, response):
+        """レスポンス XML から名前空間付きで <loc> 一覧を抽出する"""
+        root = ET.fromstring(response.content)
+        return [loc.text for loc in root.findall("sm:url/sm:loc", SITEMAP_NS)]
+
+    def test_all_loc_urls_return_200(self):
+        """sitemap.xml の全 <loc> が 200 で応答すること（実在しない URL の再発防止）"""
+        response = self._get_sitemap_response()
+        locs = self._extract_locs(response)
+        self.assertGreater(len(locs), 0, "sitemap に <loc> が 1 件も存在しない")
+
+        for loc in locs:
+            # loc は絶対 URL 想定。path 部分だけ取り出して同一クライアントで叩く
+            path = urlparse(loc).path
+            with self.subTest(loc=loc):
+                sub_response = self.client.get(path)
+                self.assertEqual(
+                    sub_response.status_code,
+                    200,
+                    f"sitemap の URL が 200 を返さない: {loc} (path={path})",
+                )
+
+    def test_sitemap_has_no_priority_tag(self):
+        """<priority> タグが完全に除去されていること（Google は無視するので不要）"""
+        response = self._get_sitemap_response()
+        self.assertNotIn(b"<priority>", response.content)
+
+    def test_sitemap_excludes_removed_paths(self):
+        """sitemap から削除したパスが混入していないこと"""
+        response = self._get_sitemap_response()
+        body = response.content.decode("utf-8")
+        # 過去に本番 404 を出した実在しないパス
+        self.assertNotIn("event/detail/list", body)
+        # 認証ページは sitemap に載せない方針
+        self.assertNotIn("account/login", body)
+        self.assertNotIn("account/register", body)


### PR DESCRIPTION
## なぜこの変更が必要か

本番の sitemap.xml に実在しない URL `event/detail/list/`（該当ルーティングなし）がハードコードされており、Google に 404 URL を送信し続けていた（2026-07-15 のデプロイ後サイト全体 200 確認で発見）。Google 公式は sitemap に「live / indexable / canonical な URL のみ」を要求しており、放置すると sitemap 全体の信頼度低下につながる。

## 変更内容

- sitemap.xml テンプレートから `event/detail/list/` を削除（404 の根治）
- 認証ページ `account/login/` `account/register/` を削除（sitemap に載せないのが Google 推奨）
- 全 `<priority>` タグと xml-sitemaps.com 生成コメントを削除（Google は priority を無視）
- robots.txt の `Sitemap:` URL の二重スラッシュを修正（`com//sitemap.xml` → `com/sitemap.xml`）
- 再発防止テスト追加: 全 `<loc>` が 200 を返す / priority 不在 / 除去パス不混入 / robots.txt の URL 正常

## 意思決定

### 採用アプローチ
- 既存カスタム SitemapView + テンプレートを維持したままのクリーンアップを採用。理由: 768 URL 規模で動的生成は既に機能しており、混入排除 + CI 検証が費用対効果最大（research-loop 調査結果）

### 却下した代替案
- django.contrib.sitemaps への移行 → 却下: 304 対応が必要になった時でよい（不急。得られるのはキャッシュ効率のみ）
- lastmod の削除 → 却下: モデルの updated_at 由来で正確なため維持が有利（Google が実際に使う唯一のフィールド）

## テスト

- [x] `docker compose run --rm vrc-ta-hub python manage.py test sitemap -v 2` — 12 件全 pass（既存 8 + 新規 4）
- [x] ローカル /code-review — 指摘なし

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)