### PR TITLE
docs: ライセンス表記を Apache 2.0 に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,4 +402,4 @@ uv pip sync requirements.lock
 
 ## ライセンス
 
-MITライセンスの下で公開されています。詳細はLICENSEファイルを参照してください。
+Apache License 2.0 の下で公開されています。詳細は LICENSE ファイルを参照してください。


### PR DESCRIPTION
## なぜこの変更が必要か

LICENSE ファイル実体は Apache License 2.0 であるにもかかわらず、README の「ライセンス」節には「MITライセンスの下で公開されています」と記載されており、法的な正本（LICENSE）と説明文（README）の間に食い違いがあった。読者・OSS 利用者が誤った条件で本プロジェクトを利用するリスクがあるため、実態に合わせて README を修正する。

## 変更内容

- `README.md` のライセンス節を「MIT ライセンス」から「Apache License 2.0」に修正

## 意思決定

### 採用アプローチ
- README を Apache 2.0 表記に合わせる。理由: LICENSE ファイルが法的な正本であり、Git 履歴上も Apache 2.0 として配布されてきた実績があるため、README 側を追従させるのが自然

### 却下した代替案
- LICENSE を MIT に差し替える → 却下: 過去コミットに Apache として配布した履歴が残っており、ライセンスの「格下げ」はコントリビューターの同意が必要で手続きコストが高い

### トレードオフ
- 表記整合の即時修正 > 履歴的経緯の温存: 誤ったライセンス表記を残しておくリスクの方が大きい

## テスト

- [x] LICENSE ファイル冒頭が `Apache License Version 2.0` であることを確認
- [x] README 差分が該当 1 行のみであることを確認（`git diff --stat`）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)