### PR TITLE
docs: CLAUDE.md にデプロイフローの正確な記述を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,11 @@ docker compose run --rm --service-ports -e DEBUG_LOGIN_SKIP=true vrc-ta-hub \
 ## 開発時の注意点
 - 外部ネットワーク `my_network` を使用
 - Supervisorでプロセス管理
-- 本番環境はGoogle Cloud Build（cloudbuild.yaml）でデプロイ
+- **デプロイ**: `main` への push で Cloud Build トリガー（`asia-northeast1`）が発火し、以下を自動実行する
+  - 本番 (`vrc-ta-hub` / `cloudbuild.yaml`): イメージビルド + Cloud Run リビジョン作成まで自動、**トラフィック切替は手動**（`--no-traffic` 指定）。切替は `gcloud run services update-traffic vrc-ta-hub --region=asia-northeast1 --to-revisions=<REV>=100` または skill `deploy-watch` を使う
+  - 開発 (`vrc-ta-hub-dev` / `cloudbuild-dev.yaml`): 完全自動（`--no-traffic` なし、`latestRevision` に 100% トラフィック）
+- Cloud Build 実行状況: `gcloud builds list --project=vrc-ta-hub --region=asia-northeast1`（**`--region` 必須**。省略すると global を見て空扱いになる）
+- Cloud Build トリガー確認: `gcloud builds triggers list --project=vrc-ta-hub --region=asia-northeast1`
 - テストは実際のAPIを使用するため環境変数の設定が必須
 - **テストファイルは各Djangoアプリの`tests`ディレクトリ内に配置すること**（例: `app/event/tests/`、`app/community/tests/`）
 - プロジェクトルートや`app/`直下にテストファイルを配置しない


### PR DESCRIPTION
## なぜこの変更が必要か

このリポの CLAUDE.md には「本番環境は Google Cloud Build (cloudbuild.yaml) でデプロイ」としか書かれておらず、以下の重要な運用差が抜けていた:

- `cloudbuild.yaml` (本番) の \`--no-traffic\` 指定 → イメージビルド + リビジョン作成は自動、**トラフィック切替は手動**
- `cloudbuild-dev.yaml` (開発) は \`--no-traffic\` なし → **完全自動デプロイ**
- Cloud Build トリガーは asia-northeast1 リージョンにあり、\`gcloud builds triggers list\` を \`--region\` 省略で叩くと空扱いになる罠

実際、この記述不足が原因で今日の作業中に AI がトリガーの存在を見落とし、既に自動デプロイ済みのリビジョンに対して余計な \`gcloud run deploy\` を叩く事故が起きた。今後同じ誤解を防ぐため、CLAUDE.md にデプロイフローを明記する。

## 変更内容

- \`## 開発時の注意点\` セクションの「Cloud Build でデプロイ」の 1 行を、本番と開発の運用差・トラフィック切替コマンド例・region 指定必須の注意まで含む具体的な記述に差し替え

## 意思決定

### 採用アプローチ
- CLAUDE.md に追記。理由: CLAUDE.md はセッション開始時に自動読込されるため、AI が最初に参照する場所として最適

### 却下した代替案
- 別途 \`docs/deploy.md\` を新設 → 却下: CLAUDE.md の Always True 節が参照しないため、AI が読まないリスク

## テスト

- ドキュメント変更のみ。CI (GitHub Actions) が通ることを確認する
- ロジック変更ではないため CLAUDE.md Always True のレビュー対象外

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)