### PR TITLE
refactor(ta_hub): Markdown配信の重複実装を整理

### DIFF
--- a/app/ta_hub/index_cache.py
+++ b/app/ta_hub/index_cache.py
@@ -5,7 +5,6 @@ from django.db.models import Prefetch
 from django.utils import timezone
 
 from event.models import Event, EventDetail
-from event.views import EventListView
 from event_calendar.calendar_utils import generate_google_calendar_url
 from utils.vrchat_time import get_vrchat_today
 from website.constants import CACHE_TTL_HOUR
@@ -83,10 +82,6 @@ def build_index_database_context(request, today, cache_key):
     ).exclude(
         event__community__poster_image=''
     ).select_related('event', 'event__community').order_by('-event__date', '-start_time')[:10]
-
-    # Google Calendar URLを生成
-    event_list_view = EventListView()
-    event_list_view.request = request
 
     # イベントとイベント詳細のGoogle Calendar URLを生成
     events_with_urls = []

--- a/app/ta_hub/tests/test_views_llm.py
+++ b/app/ta_hub/tests/test_views_llm.py
@@ -9,6 +9,9 @@ from django.urls import reverse
 
 from community.models import Community
 from event.models import Event, EventDetail
+from ta_hub.index_cache import build_index_database_context
+from ta_hub.views import build_index_database_context as index_view_database_context
+from ta_hub.views_llm import build_index_database_context as markdown_view_database_context
 
 
 def _create_test_image():
@@ -78,6 +81,10 @@ class LlmMarkdownViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'text/markdown; charset=utf-8')
 
+    def test_index_views_share_the_module_level_database_context_builder(self):
+        self.assertIs(index_view_database_context, build_index_database_context)
+        self.assertIs(markdown_view_database_context, build_index_database_context)
+
     def test_llms_txt_body_contains_landmark_sections(self):
         response = self.client.get(reverse('ta_hub:llms_txt'))
 
@@ -85,6 +92,8 @@ class LlmMarkdownViewTest(TestCase):
         self.assertContains(response, '## 主要ページ')
         self.assertContains(response, '## 構造化データAPI')
         self.assertContains(response, '## Optional')
+        self.assertContains(response, '[集会一覧](http://testserver/community/)')
+        self.assertContains(response, '[発表詳細API](http://testserver/api/v1/event_detail/)')
 
     @patch('ta_hub.views_llm.get_vrchat_today')
     def test_index_md_returns_markdown_content_type(self, mock_get_vrchat_today):

--- a/app/ta_hub/views_llm.py
+++ b/app/ta_hub/views_llm.py
@@ -73,9 +73,8 @@ def _build_markdown_context(database_context, today):
     }
 
 
-class LlmsTxtView(TemplateView):
-    template_name = 'ta_hub/llms.txt'
-    content_type = 'text/markdown; charset=utf-8'
+class MarkdownTemplateView(TemplateView):
+    """Provide an absolute site URL to Markdown templates."""
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -83,7 +82,12 @@ class LlmsTxtView(TemplateView):
         return context
 
 
-class IndexMarkdownView(TemplateView):
+class LlmsTxtView(MarkdownTemplateView):
+    template_name = 'ta_hub/llms.txt'
+    content_type = 'text/markdown; charset=utf-8'
+
+
+class IndexMarkdownView(MarkdownTemplateView):
     template_name = 'ta_hub/index.md'
     content_type = 'text/markdown; charset=utf-8'
 
@@ -91,7 +95,6 @@ class IndexMarkdownView(TemplateView):
         context = super().get_context_data(**kwargs)
         today = get_vrchat_today()
         context['current_date'] = timezone.localdate()
-        context['site_base'] = self.request.build_absolute_uri('/')
         context['database_degraded'] = False
         context['upcoming_events'] = []
         context['upcoming_event_details'] = []


### PR DESCRIPTION
## なぜこの変更が必要か

PR #517の機能部分（絶対URL、DB縮退表示、週外SPECIAL、Markdownエスケープ、共有DBコンテキスト）は、後発のPR #521でより強い回帰テストとともにmainへ先行マージされた。そのまま古い差分を競合解消すると、E2E・CI・HTTPS修正を含む新しいmainを巻き戻す危険があるため、最新mainへ載せ直し、#517にだけ残る安全な改善へ縮小する。

## 変更内容

- index_cacheから未使用のEventListView importとインスタンス生成を削除
- MarkdownTemplateViewでsite_baseの注入を共通化
- HTML版とMarkdown版が同じDBコンテキストビルダーを使うことを回帰テストで固定
- llms.txtの主要リンクが絶対URLであることを追加検証

## 意思決定

### 採用アプローチ
- #521と重複する機能実装はmainを正として維持し、未使用依存削除とDRY化だけを残した。

### 却下した代替案
- 旧#517をそのままマージ: 既にmainへ入った改善と競合し、現在のテスト・CI・HTTPS修正を巻き戻すため却下。
- 表示文言の追加変更: 主観的で今回の競合解消に不要なため見送り。

## テスト

- [x] 関連Djangoテスト23件成功
- [x] Ruff 0.11.6成功
- [x] git diff --check成功
- [x] コードレビュー: major / medium / minor 指摘なし
- [x] セキュリティレビュー: major / medium / minor 指摘なし
- [ ] GitHub Actions CI

## 経緯

- Issue #516の機能要件はPR #521で完了済み
- 本PRは重複実装を安全に整理するfollow-up

---
Generated with Codex