### PR TITLE
fix: Vket告知のひまわりを見出し左右に固定

### DIFF
--- a/app/ta_hub/templates/ta_hub/index.html
+++ b/app/ta_hub/templates/ta_hub/index.html
@@ -323,6 +323,39 @@
         .vket-achievement-card:hover .card-img-top {
             transform: scale(1.05);
         }
+
+        .vket-notice-heading {
+            display: inline-grid;
+            grid-template-columns: auto minmax(0, auto) auto;
+            align-items: center;
+            column-gap: 0.75rem;
+            max-width: 100%;
+        }
+
+        .vket-notice-sunflower {
+            font-size: 2.5rem;
+            line-height: 1;
+        }
+
+        @media (max-width: 991.98px) {
+            .vket-notice-heading h3 {
+                font-size: 1.5rem;
+            }
+
+            .vket-notice-sunflower {
+                font-size: 2rem;
+            }
+        }
+
+        @media (max-width: 575.98px) {
+            .vket-notice-heading {
+                column-gap: 0.4rem;
+            }
+
+            .vket-notice-heading h3 {
+                font-size: 1.25rem;
+            }
+        }
     </style>
     <link rel="stylesheet" href="https://petipeti-object-storage.work/dist/style.css">
 
@@ -467,10 +500,10 @@
                  style="background: linear-gradient(135deg, #ffb37a 0%, #ff6b9d 100%); border-bottom: 3px solid #ff6b9d;">
             <div class="container">
                 <div class="text-center">
-                    <div class="d-flex align-items-center justify-content-center mb-2 flex-wrap">
-                        <span class="fs-1 me-3">🌻</span>
+                    <div class="vket-notice-heading mb-2">
+                        <span class="vket-notice-sunflower" aria-hidden="true">🌻</span>
                         <h3 class="mb-0 fw-bold text-dark">7月11日〜7月25日はVket2026Summer 技術学術WEEK！</h3>
-                        <span class="fs-1 ms-3">🌻</span>
+                        <span class="vket-notice-sunflower" aria-hidden="true">🌻</span>
                     </div>
                     <div class="d-flex align-items-center justify-content-center gap-2 flex-wrap mb-2">
                         <a href="https://x.com/hashtag/Vketステージ" target="_blank"

--- a/app/ta_hub/tests/test_vket_achievements.py
+++ b/app/ta_hub/tests/test_vket_achievements.py
@@ -1,5 +1,8 @@
 """VKETコラボ実績セクションのテスト"""
 
+from datetime import datetime, timezone
+from unittest.mock import patch
+
 from django.test import TestCase, Client
 from django.urls import reverse
 
@@ -90,3 +93,21 @@ class VketAchievementsSectionTest(TestCase):
         self.assertContains(response, '活動履歴をもっと見る')
         activity_url = reverse('news:category_list', args=['activity'])
         self.assertContains(response, activity_url)
+
+
+class VketNoticeLayoutTest(TestCase):
+    """Vket告知見出しの装飾配置テスト"""
+
+    @patch(
+        'ta_hub.views.timezone.now',
+        return_value=datetime(2026, 7, 20, tzinfo=timezone.utc),
+    )
+    def test_sunflowers_use_three_column_heading_layout(self, _mock_now):
+        """ひまわりを見出しの上下ではなく左右に固定する"""
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'class="vket-notice-heading mb-2"')
+        self.assertContains(response, 'display: inline-grid;')
+        self.assertContains(response, 'grid-template-columns: auto minmax(0, auto) auto;')
+        self.assertContains(response, 'class="vket-notice-sunflower"', count=2)


### PR DESCRIPTION
## なぜこの変更が必要か

Vket 2026 Summer告知の見出しで、画面幅が狭いと `flex-wrap` により2つのひまわりが見出しの上・下へ分離していた。昨日確認できた左右配置をレスポンシブ幅でも維持する。

## 変更内容

- 告知見出しを3列グリッド（ひまわり・見出し・ひまわり）へ変更
- タブレット・スマートフォン幅で見出しと装飾サイズを調整
- 装飾のひまわりを読み上げ対象外に設定
- 3列レイアウトを守る回帰テストを追加

## 意思決定

`flex-wrap` の調整では幅ごとの折り返し順序を保証できないため、装飾を左右の独立列に固定するCSS Gridを採用した。色・文言・画像など既存バナーのデザインは変更していない。

## スクリーンショット

### 900px: Before / After

| Before（上下に分離） | After（左右に固定） |
|---|---|
| ![修正前 900px](https://agent-toolbox-assets.kaisha3.com/uploads/2026/07/6dd861fd71b3-02-production-900-before-viewport.avif) | ![修正後 900px](https://agent-toolbox-assets.kaisha3.com/uploads/2026/07/ca9c69761ad5-05-local-900-after-viewport.avif) |

### 375px: After

![修正後 375px](https://agent-toolbox-assets.kaisha3.com/uploads/2026/07/a03212f4e9f0-07-local-375-after-viewport.avif)

## テスト

- [x] `python manage.py test ta_hub.tests`（102件成功）
- [x] `VketNoticeLayoutTest`（1件成功）
- [x] Playwrightで900px・768px・375pxを確認
- [x] 3幅すべてで左右のひまわりが同じY座標になることを確認
- [x] コードレビュー・セキュリティレビュー: ブロッキングなし
- [x] デザインレビュー: 4軸すべてA

---
Generated with Codex