### PR TITLE
docs: CLAUDE.md のデプロイ記述を圧縮

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,11 +126,7 @@ docker compose run --rm --service-ports -e DEBUG_LOGIN_SKIP=true vrc-ta-hub \
 ## 開発時の注意点
 - 外部ネットワーク `my_network` を使用
 - Supervisorでプロセス管理
-- **デプロイ**: `main` への push で Cloud Build トリガー（`asia-northeast1`）が発火し、以下を自動実行する
-  - 本番 (`vrc-ta-hub` / `cloudbuild.yaml`): イメージビルド + Cloud Run リビジョン作成まで自動、**トラフィック切替は手動**（`--no-traffic` 指定）。切替は `gcloud run services update-traffic vrc-ta-hub --region=asia-northeast1 --to-revisions=<REV>=100` または skill `deploy-watch` を使う
-  - 開発 (`vrc-ta-hub-dev` / `cloudbuild-dev.yaml`): 完全自動（`--no-traffic` なし、`latestRevision` に 100% トラフィック）
-- Cloud Build 実行状況: `gcloud builds list --project=vrc-ta-hub --region=asia-northeast1`（**`--region` 必須**。省略すると global を見て空扱いになる）
-- Cloud Build トリガー確認: `gcloud builds triggers list --project=vrc-ta-hub --region=asia-northeast1`
+- デプロイ: `main` push で Cloud Build (`asia-northeast1`) が自動ビルド・リビジョン作成。本番は `--no-traffic` のためトラフィック切替のみ手動（skill `deploy-watch` または `gcloud run services update-traffic vrc-ta-hub --region=asia-northeast1 --to-revisions=<REV>=100`）。開発は完全自動。確認系 `gcloud` は `--region=asia-northeast1` 必須（省略すると global を見て空扱いになる）
 - テストは実際のAPIを使用するため環境変数の設定が必須
 - **テストファイルは各Djangoアプリの`tests`ディレクトリ内に配置すること**（例: `app/event/tests/`、`app/community/tests/`）
 - プロジェクトルートや`app/`直下にテストファイルを配置しない


### PR DESCRIPTION
## なぜこの変更が必要か

前 PR #514 で CLAUDE.md にデプロイフロー 5 行を追加したが、CLAUDE.md は毎セッション必ずロードされるため詳細を書くほど全セッションの context を占める。事故再発防止に必要な要点だけを 1 行に凝縮する。

## 変更内容

`## 開発時の注意点` セクションのデプロイ記述を 5 行 → 1 行に圧縮。

### 残した要点
1. Cloud Build が **自動**でリビジョンまで作る
2. 本番は `--no-traffic` で **切替のみ手動**
3. 切替コマンド 1 例 + skill `deploy-watch` への誘導
4. `--region=asia-northeast1` 必須の罠

### 削ったもの
- dev の運用差の詳細説明（dev は完全自動、AI が触るのはほぼ本番）
- `gcloud builds list` の確認コマンド例（切替コマンド例に `--region` が含まれるため類推可）

## 意思決定

### 採用アプローチ
- **CLAUDE.md 内で 1 行に圧縮**。ファイル分割はしない

### 却下した代替案
- `.claude/rules/deployment.md` に切り出し → 却下: 既存の `staticfiles-deployment.md` 前例はあるが、今回の内容は 1 行で伝わるためファイル分割のオーバーヘッドが不釣り合い
- CLAUDE.md から完全削除 → 却下: 人間が CLAUDE.md だけ読むケースで場所を知る手がかりが消える

### Codex との共有
- `AGENTS.md → CLAUDE.md` の symlink 構造のため、Claude Code / Codex どちらも自動的に同じ記述を参照する（追加同期作業なし）

## テスト

- ドキュメント変更のみ
- `git diff CLAUDE.md` で意図通りの差分を確認済み
- CI (GitHub Actions) が pass すること

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)