### PR TITLE
fix(ci): E2Eを通常テストと並列実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           coverage report --rcfile=../pyproject.toml
 
   e2e:
-    needs: test
+    needs: lint
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
## なぜこの変更が必要か

E2E追加後のGitHub Actionsを実測したところ、CI全体は平均73.4秒から135.7秒へ約62秒増加していた。E2E本体よりも、通常テスト完了後にE2Eジョブを起動する直列依存が待ち時間増加の主因だったため、テスト内容を削らずクリティカルパスだけを短縮する。

## 変更内容

- e2eジョブの依存先をtestからlintへ変更
- lint成功後、通常テスト・E2E・mypyを独立して並列実行

## 意思決定

### 採用アプローチ
- ジョブの依存関係だけを1行変更する。ブラウザキャッシュやテストコード最適化より導入・保守負荷が小さく、観測上の待ち時間をほぼ解消できるため。

### トレードオフ
- 通常テストが失敗した場合もE2Eは実行されるため、その場合だけGitHub Actionsのrunner使用時間が約1分増える。
- lint失敗時は従来どおり通常テストとE2Eの両方を起動しない。

## テスト

- [x] actionlintによるGitHub Actions構文検証
- [x] YAML構文とtest / e2eの依存先がともにlintであることを検証
- [x] git diff --check
- [x] コードレビュー: major / medium / minor 指摘なし
- [x] セキュリティレビュー: major / medium / minor 指摘なし
- [x] GitHub Actions全6チェック成功
- [x] 通常テストとE2Eの並列起動を確認

## CI実測結果

- 対象run: 29793716168
- 変更前（E2E追加後3 run平均）: 135.7秒
- 変更後: 76秒
- 短縮: 59.7秒（約44%）
- E2E追加前5 run平均: 73.4秒（今回との差は2.6秒）
- test: 01:39:45開始、01:40:48完了
- e2e: 01:39:47開始、01:40:42完了
- 2ジョブは約55秒間並列実行

Cloud Buildを含むPR全チェックの実時間は、PR #518の約145秒からPR #525では約118秒へ27秒短縮した。Cloud Build自体が約114秒かかるため、PR全体では今後Cloud Build側が主な待ち時間になる。

---
Generated with Codex