### PR TITLE
fix: ログイン済みユーザーのログイン画面表示を防ぐ

### DIFF
--- a/app/user_account/tests/test_views.py
+++ b/app/user_account/tests/test_views.py
@@ -25,7 +25,7 @@ class CustomLoginViewTests(TestCase):
         """テスト用のデータを準備."""
         self.client = Client()
         self.login_url = reverse('account:login')
-        self.test_user = User.objects.create_user(
+        self.test_user = create_discord_linked_user(
             user_name='test_community',
             email='test@example.com',
             password='testpass123',
@@ -36,6 +36,30 @@ class CustomLoginViewTests(TestCase):
         response = self.client.get(self.login_url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'account/login.html')
+
+    @override_settings(DISCORD_AUTH_REQUIRED=True)
+    def test_authenticated_user_redirects_to_my_list(self):
+        """ログイン済みならnext指定に関係なくマイリストへ遷移すること."""
+        self.client.force_login(self.test_user)
+
+        for login_url in (self.login_url, f'{self.login_url}?next=/account/settings/'):
+            with self.subTest(login_url=login_url):
+                response = self.client.get(login_url)
+                self.assertRedirects(response, reverse('event:my_list'), fetch_redirect_response=False)
+
+    @override_settings(DISCORD_AUTH_REQUIRED=True)
+    def test_authenticated_user_without_discord_keeps_link_requirement(self):
+        """Discord未連携ユーザーには既存の連携必須ポリシーを維持すること."""
+        unlinked_user = User.objects.create_user(
+            user_name='unlinked_user',
+            email='unlinked@example.com',
+            password='testpass123',
+        )
+        self.client.force_login(unlinked_user)
+
+        response = self.client.get(self.login_url)
+
+        self.assertRedirects(response, reverse('account:discord_required'), fetch_redirect_response=False)
 
     def test_login_page_sets_csrf_cookie(self):
         """GETリクエスト時にCSRFクッキーが発行されること（ensure_csrf_cookie確認）."""

--- a/app/user_account/view_modules/session.py
+++ b/app/user_account/view_modules/session.py
@@ -23,6 +23,12 @@ class CustomLoginView(LoginView):
     template_name = 'account/login.html'
     form_class = BootstrapAuthenticationForm
 
+    def dispatch(self, request, *args, **kwargs):
+        """認証済みユーザーをイベント管理ページへ移動させる."""
+        if request.user.is_authenticated:
+            return redirect('event:my_list')
+        return super().dispatch(request, *args, **kwargs)
+
     def form_valid(self, form):
         """ログイン成功時に remember 設定からセッション期限を決める."""
         remember = form.cleaned_data.get('remember')


### PR DESCRIPTION
## なぜこの変更が必要か

ログイン済みユーザーが `/account/login/` にアクセスしてもログインフォームが表示され、現在の認証状態と画面が矛盾していました。ログイン済みの場合はイベント管理ページへ戻し、迷わず作業を継続できるようにします。

## 変更内容

- 認証済みのログインページアクセスを `/event/my_list/` へ固定リダイレクト
- `next` パラメータの有無にかかわらず指定先へ遷移する回帰テストを追加
- 本番相当の Discord 連携必須設定で、連携済みユーザーの遷移と未連携ユーザーの既存ゲート維持を検証

## 意思決定

### 採用アプローチ
- `CustomLoginView.dispatch()` の先頭で認証状態を判定。ログイン処理そのものの `next` 挙動を変えず、ログイン済みアクセスだけを分離できるため

### 却下した代替案
- `redirect_authenticated_user = True` のみを使う方法 → ログイン済みGETの `next` を採用し、指定先が固定されないため却下
- Discord連携必須ミドルウェアの緩和 → 既存の認証ポリシーを弱めるため対象外

### トレードオフ
- 指定先の確実性を優先し、ログイン済みアクセス時の `next` は意図的に無視

### 技術的負債
- なし

## テスト

- [x] `user_account.tests.test_views.CustomLoginViewTests`（15件）
- [x] `user_account.tests.test_views`（55件）
- [x] Ruff（変更2ファイル）
- [x] コードレビュー: ブロッキングなし
- [x] セキュリティレビュー: ブロッキングなし

---
🤖 Generated with Codex