### PR TITLE
feat(event): イベント開始時刻の編集ボタンを追加

### DIFF
--- a/app/event/forms/__init__.py
+++ b/app/event/forms/__init__.py
@@ -3,7 +3,7 @@
 既存の `from event.forms import EventDetailForm` 等を後方互換で動作させる。
 """
 from event.forms.mixins import EventDetailMediaFormMixin  # noqa: F401
-from event.forms.event import EventSearchForm, EventCreateForm  # noqa: F401
+from event.forms.event import EventSearchForm, EventCreateForm, EventUpdateForm  # noqa: F401
 from event.forms.recurrence import (  # noqa: F401
     RecurringEventForm,
     RECURRENCE_CHOICES,

--- a/app/event/forms/event.py
+++ b/app/event/forms/event.py
@@ -29,6 +29,35 @@ class EventSearchForm(forms.Form):
     )
 
 
+class EventUpdateForm(forms.ModelForm):
+    """開始時刻のみを編集するフォーム。
+
+    date / community は変更不可（UniqueConstraint (community, date, start_time) と
+    Google カレンダー連携の副作用範囲を最小化するため、フィールドを start_time に限定）。
+    """
+
+    class Meta:
+        model = Event
+        fields = ['start_time']
+        widgets = {
+            'start_time': forms.TimeInput(attrs={'type': 'time', 'class': 'form-control'}),
+        }
+
+    def clean_start_time(self):
+        start_time = self.cleaned_data.get('start_time')
+        if start_time is None or self.instance is None or self.instance.pk is None:
+            return start_time
+        # UniqueConstraint (community, date, start_time) 対応
+        conflict = Event.objects.filter(
+            community=self.instance.community,
+            date=self.instance.date,
+            start_time=start_time,
+        ).exclude(pk=self.instance.pk).exists()
+        if conflict:
+            raise forms.ValidationError('同じ日時にすでにイベントが登録されています。')
+        return start_time
+
+
 class EventCreateForm(forms.ModelForm):
     class Meta:
         model = Event

--- a/app/event/management/commands/generate_recurring_events.py
+++ b/app/event/management/commands/generate_recurring_events.py
@@ -154,13 +154,13 @@ class Command(BaseCommand):
             )
             
             # 既存のイベントを除外
+            # 開始時刻を編集済みのイベントを重複生成しないため date 単位で判定
             new_dates = []
             for date in dates:
                 if date >= base_date and date <= end_date:
                     exists = Event.objects.filter(
                         community=community,
                         date=date,
-                        start_time=community.start_time
                     ).exists()
                     if not exists:
                         new_dates.append(date)

--- a/app/event/recurrence/persistence.py
+++ b/app/event/recurrence/persistence.py
@@ -49,10 +49,10 @@ def create_recurring_events(
     # 残りのインスタンスを作成
     for event_date in dates[1:]:
         # 既存のイベントがあるかチェック
+        # 開始時刻を編集済みのイベントを重複生成しないため date 単位で判定
         existing = Event.objects.filter(
             community=community,
             date=event_date,
-            start_time=start_time,
         ).first()
 
         if not existing:

--- a/app/event/sync_to_google.py
+++ b/app/event/sync_to_google.py
@@ -15,6 +15,27 @@ from community.models import Community
 logger = logging.getLogger(__name__)
 
 
+def build_google_event_description(event: Event) -> str:
+    """Googleカレンダーのイベント説明文を生成する（同期/単発更新で共用）。
+
+    EventUpdateView など単発の時刻変更でも同じ文面になるよう module 関数として公開する
+    （description が旧時刻のまま残ると同期処理が日時+ID一致で skipped 扱いにし恒久矛盾になる）。
+    """
+    lines = [
+        f"集会: {event.community.name}",
+        f"開催日時: {event.date.strftime('%Y年%m月%d日')} {event.start_time.strftime('%H:%M')}",
+        f"開催時間: {event.duration}分",
+    ]
+
+    if event.community.description:
+        lines.append(f"\n{event.community.description}")
+
+    if event.community.group_url:
+        lines.append(f"\nURL: {event.community.group_url}")
+
+    return "\n".join(lines)
+
+
 class DatabaseToGoogleSync:
     """データベースを主体としたGoogleカレンダー同期"""
     
@@ -364,20 +385,8 @@ class DatabaseToGoogleSync:
             raise
     
     def _generate_description(self, event: Event) -> str:
-        """イベントの説明文を生成"""
-        lines = [
-            f"集会: {event.community.name}",
-            f"開催日時: {event.date.strftime('%Y年%m月%d日')} {event.start_time.strftime('%H:%M')}",
-            f"開催時間: {event.duration}分",
-        ]
-        
-        if event.community.description:
-            lines.append(f"\n{event.community.description}")
-        
-        if event.community.group_url:
-            lines.append(f"\nURL: {event.community.group_url}")
-        
-        return "\n".join(lines)
+        """イベントの説明文を生成（module 関数へ委譲。挙動不変）。"""
+        return build_google_event_description(event)
     
     def delete_orphaned_google_events(self, all_google_events: List[Dict], start_date: datetime.date, end_date: datetime.date) -> int:
         """DBに存在しないGoogleカレンダーイベントを削除

--- a/app/event/templates/event/event_form.html
+++ b/app/event/templates/event/event_form.html
@@ -1,0 +1,60 @@
+{% extends 'ta_hub/base.html' %}
+{% load django_bootstrap5 %}
+
+{% block main %}
+<div class="container my-4">
+    <div class="row">
+        <div class="col-12 col-md-8 offset-md-2">
+            {% include 'ta_hub/messages.html' %}
+            <h1 class="text-center my-5 fw-bold keiko_yellow">
+                開始時刻の変更
+            </h1>
+
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <dl class="row mb-4">
+                        <dt class="col-sm-3">集会</dt>
+                        <dd class="col-sm-9">{{ event.community.name }}</dd>
+                        <dt class="col-sm-3">開催日</dt>
+                        <dd class="col-sm-9">{{ event.date }}</dd>
+                    </dl>
+
+                    <form method="post">
+                        {% csrf_token %}
+
+                        {% if form.non_field_errors %}
+                        <div class="alert alert-danger">
+                            {% for error in form.non_field_errors %}
+                            {{ error }}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+
+                        <div class="mb-3">
+                            <label for="{{ form.start_time.id_for_label }}" class="form-label">
+                                {{ form.start_time.label }}
+                            </label>
+                            {{ form.start_time }}
+                            {% if form.start_time.errors %}
+                            <div class="invalid-feedback d-block">
+                                {% for error in form.start_time.errors %}
+                                {{ error }}
+                                {% endfor %}
+                            </div>
+                            {% endif %}
+                            <div class="form-text">
+                                配下の発表の開始時刻も同じ差分だけ自動で調整されます。
+                            </div>
+                        </div>
+
+                        <div class="mt-4">
+                            <button type="submit" class="btn btn-primary">保存</button>
+                            <a href="{% url 'event:my_list' %}" class="btn btn-secondary">キャンセル</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -140,7 +140,24 @@
                             <div class="row">
                                 <div class="col-md-5">
                                     <div class="card-text mb-2">開催日: {{ event.date }}</div>
-                                    <div class="card-text mb-2">開始時刻: {{ event.start_time }}</div>
+                                    <div class="d-flex justify-content-between align-items-center card-text mb-2">
+                                        <span>開始時刻: {{ event.start_time }}</span>
+                                        {% if event.can_edit_event %}
+                                            {% if event.vket_locked %}
+                                                <span tabindex="0" title="Vketコラボ期間中は編集できません">
+                                                    <a class="btn btn-sm btn-outline-secondary disabled" aria-disabled="true" tabindex="-1">
+                                                        <i class="bi bi-pencil-fill"></i>
+                                                    </a>
+                                                </span>
+                                            {% else %}
+                                                <a href="{% url 'event:update' event.pk %}"
+                                                   class="btn btn-sm btn-outline-secondary"
+                                                   title="開始時刻を編集">
+                                                    <i class="bi bi-pencil-fill"></i>
+                                                </a>
+                                            {% endif %}
+                                        {% endif %}
+                                    </div>
                                     <div class="mb-2 mt-3">
                                         <div>
                                             {% if event.calendar_url %}

--- a/app/event/tests/test_event_my_list_view.py
+++ b/app/event/tests/test_event_my_list_view.py
@@ -646,3 +646,78 @@ class VketBannerTests(TweetGenerationPatchMixin, TestCase):
         banner = response.context['vket_banner']
         self.assertIsNotNone(banner)
         self.assertIn('受付中', banner['message'])
+
+
+class EventMyListEditButtonTest(TweetGenerationPatchMixin, TestCase):
+    """my_list テンプレートの開始時刻編集ボタン表示テスト。"""
+
+    def setUp(self):
+        self.client = Client()
+        self.owner = User.objects.create_user(
+            user_name='EB Owner', email='eb_owner@example.com',
+        )
+        self.community = Community.objects.create(
+            name='EB Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Sat'],
+            frequency='Every week',
+            organizers='EB',
+            status='approved',
+        )
+        CommunityMember.objects.create(
+            community=self.community, user=self.owner, role=CommunityMember.Role.OWNER,
+        )
+
+    def test_pencil_button_shown_for_future_event(self):
+        future = timezone.now().date() + timedelta(days=14)
+        event = Event.objects.create(
+            community=self.community, date=future, start_time=time(22, 0),
+            duration=60, weekday='SAT',
+        )
+        self.client.force_login(self.owner)
+        response = self.client.get(reverse('event:my_list'))
+        self.assertEqual(response.status_code, 200)
+        update_url = reverse('event:update', kwargs={'pk': event.pk})
+        self.assertContains(response, update_url)
+
+    def test_pencil_button_hidden_for_past_event(self):
+        past = timezone.now().date() - timedelta(days=14)
+        event = Event.objects.create(
+            community=self.community, date=past, start_time=time(22, 0),
+            duration=60, weekday='SAT',
+        )
+        self.client.force_login(self.owner)
+        response = self.client.get(reverse('event:my_list'))
+        self.assertEqual(response.status_code, 200)
+        update_url = reverse('event:update', kwargs={'pk': event.pk})
+        self.assertNotContains(response, update_url)
+
+    def test_pencil_button_disabled_during_vket_lock(self):
+        today = timezone.localdate()
+        future = today + timedelta(days=2)
+        event = Event.objects.create(
+            community=self.community, date=future, start_time=time(22, 0),
+            duration=60, weekday='SAT',
+        )
+        collab = VketCollaboration.objects.create(
+            slug='eb-vket',
+            name='EB Vket',
+            phase=VketCollaboration.Phase.LOCKED,
+            period_start=future - timedelta(days=1),
+            period_end=future + timedelta(days=1),
+            registration_deadline=today - timedelta(days=5),
+            lt_deadline=today - timedelta(days=3),
+        )
+        VketParticipation.objects.create(
+            collaboration=collab,
+            community=self.community,
+            lifecycle=VketParticipation.Lifecycle.ACTIVE,
+        )
+        self.client.force_login(self.owner)
+        response = self.client.get(reverse('event:my_list'))
+        self.assertEqual(response.status_code, 200)
+        update_url = reverse('event:update', kwargs={'pk': event.pk})
+        # 有効なリンクとしては表示されない（disabled ラップ）
+        self.assertNotContains(response, f'href="{update_url}"')
+        self.assertContains(response, 'Vketコラボ期間中は編集できません')

--- a/app/event/tests/test_event_update_view.py
+++ b/app/event/tests/test_event_update_view.py
@@ -9,8 +9,11 @@ from django.utils import timezone
 
 from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
+from event.sync_to_google import build_google_event_description
 from event.tests.tweet_generation import TweetGenerationPatchMixin
+from twitter.models import TweetQueue
 from user_account.models import CustomUser
+from utils.vrchat_time import get_vrchat_today
 
 
 class EventUpdateViewBaseMixin(TweetGenerationPatchMixin):
@@ -229,3 +232,124 @@ class EventUpdateViewVketLockTest(EventUpdateViewBaseMixin, TestCase):
         self.assertEqual(response.url, reverse('event:my_list'))
         self.event.refresh_from_db()
         self.assertEqual(self.event.start_time, time(20, 0))
+
+
+class EventUpdateViewPastEventTest(EventUpdateViewBaseMixin, TestCase):
+    """過去イベントは URL 直叩きでも編集不可（PR #544 Cursor 指摘）。"""
+
+    def setUp(self):
+        super().setUp()
+        # yesterday（VRChat today より確実に過去）に付け替え
+        yesterday = get_vrchat_today() - timedelta(days=1)
+        # 一意制約回避のため時刻を変える
+        self.event.date = yesterday
+        self.event.start_time = time(20, 0)
+        self.event.save(update_fields=['date', 'start_time'])
+
+    def test_owner_post_to_past_event_blocked(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(self.url, {'start_time': '19:00'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('event:my_list'))
+        self.event.refresh_from_db()
+        # DB 不変
+        self.assertEqual(self.event.start_time, time(20, 0))
+
+    def test_owner_get_to_past_event_blocked(self):
+        self.client.force_login(self.owner)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('event:my_list'))
+
+
+class EventUpdateViewIndexCacheTest(EventUpdateViewBaseMixin, TestCase):
+    """clear_index_view_cache が実キャッシュキー（get_vrchat_today ベース）で呼ばれる。"""
+
+    def test_clear_index_view_cache_called_without_args(self):
+        self.client.force_login(self.owner)
+        with mock.patch('event.views.crud.clear_index_view_cache') as mock_clear:
+            response = self.client.post(self.url, {'start_time': '21:00'})
+        self.assertEqual(response.status_code, 302)
+        mock_clear.assert_called_once_with()
+
+
+class EventUpdateViewGoogleCalendarDescriptionTest(EventUpdateViewBaseMixin, TestCase):
+    """GCal patch に description（sync 側と同じ生成関数の出力）が渡る。"""
+
+    def test_update_event_receives_description(self):
+        self.event.google_calendar_event_id = 'gcal-abc'
+        self.event.save(update_fields=['google_calendar_event_id'])
+
+        self.client.force_login(self.owner)
+        with mock.patch('event.views.crud.GoogleCalendarService') as MockService:
+            instance = MockService.return_value
+            response = self.client.post(self.url, {'start_time': '20:00'})
+
+        self.assertEqual(response.status_code, 302)
+        instance.update_event.assert_called_once()
+        call_kwargs = instance.update_event.call_args.kwargs
+
+        # description は sync 側の生成関数と同一出力
+        self.event.refresh_from_db()
+        expected = build_google_event_description(self.event)
+        self.assertEqual(call_kwargs['description'], expected)
+        # 新時刻が description 本文に反映されている
+        self.assertIn('20:00', call_kwargs['description'])
+        # summary は渡さない（community 名で不変のため）
+        self.assertNotIn('summary', call_kwargs)
+
+
+class EventUpdateViewTweetQueueResetTest(EventUpdateViewBaseMixin, TestCase):
+    """開始時刻変更で未投稿 TweetQueue を再生成対象に戻す（PR #544 Cursor 指摘）。"""
+
+    def _make_queue(self, status: str) -> TweetQueue:
+        return TweetQueue.objects.create(
+            tweet_type='daily_reminder',
+            community=self.community,
+            event=self.event,
+            generated_text='OLD TEXT with 22:00',
+            status=status,
+            scheduled_at=timezone.now() + timedelta(days=1),
+        )
+
+    def test_unposted_queue_reset_to_regeneration(self):
+        ready = self._make_queue('ready')
+
+        self.client.force_login(self.owner)
+        response = self.client.post(self.url, {'start_time': '21:00'})
+        self.assertEqual(response.status_code, 302)
+
+        ready.refresh_from_db()
+        self.assertEqual(ready.status, 'generation_failed')
+        self.assertEqual(ready.generated_text, '')
+
+    def test_posted_queue_not_touched(self):
+        posted = TweetQueue.objects.create(
+            tweet_type='lt',
+            community=self.community,
+            event=self.event,
+            generated_text='POSTED TEXT',
+            status='posted',
+            scheduled_at=timezone.now() - timedelta(hours=1),
+            posted_at=timezone.now() - timedelta(hours=1),
+        )
+        failed = TweetQueue.objects.create(
+            tweet_type='lt',
+            community=self.community,
+            event=self.event,
+            generated_text='FAILED TEXT',
+            status='failed',
+            scheduled_at=timezone.now() - timedelta(hours=1),
+        )
+
+        self.client.force_login(self.owner)
+        response = self.client.post(self.url, {'start_time': '21:00'})
+        self.assertEqual(response.status_code, 302)
+
+        posted.refresh_from_db()
+        failed.refresh_from_db()
+        # posted / failed は不変
+        self.assertEqual(posted.status, 'posted')
+        self.assertEqual(posted.generated_text, 'POSTED TEXT')
+        self.assertEqual(failed.status, 'failed')
+        self.assertEqual(failed.generated_text, 'FAILED TEXT')

--- a/app/event/tests/test_event_update_view.py
+++ b/app/event/tests/test_event_update_view.py
@@ -1,0 +1,231 @@
+"""EventUpdateView（開始時刻編集）のテスト。"""
+from datetime import time, timedelta
+from unittest import mock
+
+from django.contrib.messages import get_messages
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from community.models import Community, CommunityMember
+from event.models import Event, EventDetail
+from event.tests.tweet_generation import TweetGenerationPatchMixin
+from user_account.models import CustomUser
+
+
+class EventUpdateViewBaseMixin(TweetGenerationPatchMixin):
+    """テスト共通のセットアップ。"""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.owner = CustomUser.objects.create_user(
+            user_name='Owner User', email='owner@example.com',
+        )
+        self.staff = CustomUser.objects.create_user(
+            user_name='Staff User', email='staff@example.com',
+        )
+        self.outsider = CustomUser.objects.create_user(
+            user_name='Outsider User', email='out@example.com',
+        )
+        self.superuser = CustomUser.objects.create_superuser(
+            user_name='Super User', email='super@example.com', password=None,
+        )
+
+        self.community = Community.objects.create(
+            name='Test Community',
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Sat'],
+            frequency='Every week',
+            organizers='Test',
+            status='approved',
+        )
+        CommunityMember.objects.create(
+            community=self.community, user=self.owner, role=CommunityMember.Role.OWNER,
+        )
+        CommunityMember.objects.create(
+            community=self.community, user=self.staff, role=CommunityMember.Role.STAFF,
+        )
+
+        # 別コミュニティ
+        self.other_community = Community.objects.create(
+            name='Other Community',
+            start_time=time(21, 0),
+            duration=60,
+            weekdays=['Sun'],
+            frequency='Every week',
+            organizers='Other',
+            status='approved',
+        )
+
+        future = timezone.now().date() + timedelta(days=14)
+        self.event = Event.objects.create(
+            community=self.community,
+            date=future,
+            start_time=time(22, 0),
+            duration=60,
+            weekday='SAT',
+        )
+        self.url = reverse('event:update', kwargs={'pk': self.event.pk})
+
+
+class EventUpdateViewPermissionTest(EventUpdateViewBaseMixin, TestCase):
+    def test_anonymous_redirected_to_login(self):
+        response = self.client.post(self.url, {'start_time': '21:00'})
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/account/login/', response.url)
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.start_time, time(22, 0))
+
+    def test_owner_can_update(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(self.url, {'start_time': '21:00'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('event:my_list'))
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.start_time, time(21, 0))
+
+    def test_staff_can_update(self):
+        self.client.force_login(self.staff)
+        response = self.client.post(self.url, {'start_time': '21:30'})
+        self.assertEqual(response.status_code, 302)
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.start_time, time(21, 30))
+
+    def test_outsider_cannot_update(self):
+        self.client.force_login(self.outsider)
+        response = self.client.post(self.url, {'start_time': '21:00'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('event:my_list'))
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.start_time, time(22, 0))
+
+
+class EventUpdateViewFormValidationTest(EventUpdateViewBaseMixin, TestCase):
+    def test_unique_constraint_violation_shows_form_error(self):
+        # 同 community/date で別 start_time のイベントを追加
+        Event.objects.create(
+            community=self.community,
+            date=self.event.date,
+            start_time=time(23, 0),
+            duration=60,
+            weekday='SAT',
+        )
+        self.client.force_login(self.owner)
+        response = self.client.post(self.url, {'start_time': '23:00'})
+        # フォーム再表示（200）またはリダイレクトを許容せず、DB 不変を主軸に確認
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.start_time, time(22, 0))
+        # クリーン側でエラー化するため 200 が返る
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '同じ日時にすでにイベントが登録されています。')
+
+    def test_event_detail_start_times_shift_by_delta(self):
+        # 開始 22:00 のイベント配下の発表を作成
+        detail1 = EventDetail.objects.create(
+            event=self.event, detail_type='LT', start_time=time(22, 15), duration=15,
+        )
+        detail2 = EventDetail.objects.create(
+            event=self.event, detail_type='LT', start_time=time(22, 45), duration=15,
+        )
+        self.client.force_login(self.owner)
+        response = self.client.post(self.url, {'start_time': '21:00'})
+        self.assertEqual(response.status_code, 302)
+
+        detail1.refresh_from_db()
+        detail2.refresh_from_db()
+        # 1 時間前倒し
+        self.assertEqual(detail1.start_time, time(21, 15))
+        self.assertEqual(detail2.start_time, time(21, 45))
+
+
+class EventUpdateViewGoogleCalendarTest(EventUpdateViewBaseMixin, TestCase):
+    def test_google_calendar_update_called_with_new_time(self):
+        self.event.google_calendar_event_id = 'gcal-abc'
+        self.event.save(update_fields=['google_calendar_event_id'])
+
+        self.client.force_login(self.owner)
+        with mock.patch('event.views.crud.GoogleCalendarService') as MockService:
+            instance = MockService.return_value
+            response = self.client.post(self.url, {'start_time': '20:00'})
+
+        self.assertEqual(response.status_code, 302)
+        MockService.assert_called_once()
+        instance.update_event.assert_called_once()
+        call_kwargs = instance.update_event.call_args.kwargs
+        self.assertEqual(call_kwargs['event_id'], 'gcal-abc')
+        self.assertEqual(call_kwargs['start_time'].time(), time(20, 0))
+        # end = start + duration(60)
+        self.assertEqual(call_kwargs['end_time'].time(), time(21, 0))
+
+    def test_google_calendar_skipped_when_no_event_id(self):
+        # google_calendar_event_id なし → update_event 呼ばれない
+        self.client.force_login(self.owner)
+        with mock.patch('event.views.crud.GoogleCalendarService') as MockService:
+            response = self.client.post(self.url, {'start_time': '20:00'})
+        self.assertEqual(response.status_code, 302)
+        MockService.assert_not_called()
+
+    def test_db_updated_even_when_gcal_update_fails(self):
+        self.event.google_calendar_event_id = 'gcal-abc'
+        self.event.save(update_fields=['google_calendar_event_id'])
+
+        self.client.force_login(self.owner)
+        with mock.patch('event.views.crud.GoogleCalendarService') as MockService:
+            instance = MockService.return_value
+            instance.update_event.side_effect = Exception('gcal error')
+            response = self.client.post(self.url, {'start_time': '20:00'}, follow=False)
+
+        self.assertEqual(response.status_code, 302)
+        # DB は更新済み
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.start_time, time(20, 0))
+        # エラーメッセージが積まれている
+        messages_list = list(get_messages(response.wsgi_request))
+        self.assertTrue(
+            any('Googleカレンダー' in str(m) for m in messages_list),
+            f"Expected Google カレンダー失敗メッセージ, got: {[str(m) for m in messages_list]}",
+        )
+
+
+class EventUpdateViewVketLockTest(EventUpdateViewBaseMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        from vket.models import VketCollaboration, VketParticipation
+        self.collaboration = VketCollaboration.objects.create(
+            name='Vket Test',
+            slug='vket-test',
+            phase=VketCollaboration.Phase.LOCKED,
+            period_start=self.event.date - timedelta(days=3),
+            period_end=self.event.date + timedelta(days=3),
+            registration_deadline=self.event.date - timedelta(days=10),
+            lt_deadline=self.event.date - timedelta(days=5),
+        )
+        VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            lifecycle=VketParticipation.Lifecycle.ACTIVE,
+        )
+
+    def test_owner_blocked_during_vket_lock(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(self.url, {'start_time': '20:00'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('event:my_list'))
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.start_time, time(22, 0))
+
+    def test_owner_get_blocked_during_vket_lock(self):
+        self.client.force_login(self.owner)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('event:my_list'))
+
+    def test_superuser_can_update_during_vket_lock(self):
+        self.client.force_login(self.superuser)
+        response = self.client.post(self.url, {'start_time': '20:00'})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('event:my_list'))
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.start_time, time(20, 0))

--- a/app/event/tests/test_event_update_view.py
+++ b/app/event/tests/test_event_update_view.py
@@ -353,3 +353,30 @@ class EventUpdateViewTweetQueueResetTest(EventUpdateViewBaseMixin, TestCase):
         self.assertEqual(posted.generated_text, 'POSTED TEXT')
         self.assertEqual(failed.status, 'failed')
         self.assertEqual(failed.generated_text, 'FAILED TEXT')
+
+
+class EventUpdateViewNoOpSaveTest(EventUpdateViewBaseMixin, TestCase):
+    """時刻を変えない保存では副作用を走らせない（PR #544 Cursor 指摘）。"""
+
+    def test_noop_save_keeps_queue_and_skips_gcal(self):
+        queue = TweetQueue.objects.create(
+            tweet_type='daily_reminder',
+            community=self.community,
+            event=self.event,
+            generated_text='READY TEXT with 22:00',
+            status='ready',
+            scheduled_at=timezone.now() + timedelta(days=1),
+        )
+        self.event.google_calendar_event_id = 'gcal-abc'
+        self.event.save(update_fields=['google_calendar_event_id'])
+
+        self.client.force_login(self.owner)
+        with mock.patch('event.views.crud.GoogleCalendarService') as service_cls:
+            # 現在値と同じ 22:00 のまま保存
+            response = self.client.post(self.url, {'start_time': '22:00'})
+
+        self.assertEqual(response.status_code, 302)
+        queue.refresh_from_db()
+        self.assertEqual(queue.status, 'ready')
+        self.assertEqual(queue.generated_text, 'READY TEXT with 22:00')
+        service_cls.assert_not_called()

--- a/app/event/tests/test_event_update_view.py
+++ b/app/event/tests/test_event_update_view.py
@@ -309,6 +309,7 @@ class EventUpdateViewTweetQueueResetTest(EventUpdateViewBaseMixin, TestCase):
             event=self.event,
             generated_text='OLD TEXT with 22:00',
             status=status,
+            generation_token='oldtoken123',
             scheduled_at=timezone.now() + timedelta(days=1),
         )
 
@@ -322,6 +323,8 @@ class EventUpdateViewTweetQueueResetTest(EventUpdateViewBaseMixin, TestCase):
         ready.refresh_from_db()
         self.assertEqual(ready.status, 'generation_failed')
         self.assertEqual(ready.generated_text, '')
+        # in-flight 生成の write-back を無効化するためトークンも空になる
+        self.assertEqual(ready.generation_token, '')
 
     def test_posted_queue_not_touched(self):
         posted = TweetQueue.objects.create(
@@ -380,3 +383,9 @@ class EventUpdateViewNoOpSaveTest(EventUpdateViewBaseMixin, TestCase):
         self.assertEqual(queue.status, 'ready')
         self.assertEqual(queue.generated_text, 'READY TEXT with 22:00')
         service_cls.assert_not_called()
+
+        # 変更が無いのに「変更しました」と出さない
+        from django.contrib.messages import get_messages
+        message_texts = [str(m) for m in get_messages(response.wsgi_request)]
+        self.assertIn('開始時刻に変更はありません。', message_texts)
+        self.assertNotIn('開始時刻を変更しました。', message_texts)

--- a/app/event/tests/test_generate_recurring_events_command.py
+++ b/app/event/tests/test_generate_recurring_events_command.py
@@ -181,6 +181,117 @@ class GenerateRecurringEventsCommandTest(TweetGenerationPatchMixin, TestCase):
         self.assertEqual(first_dates, second_dates, 
                         "同じ日付範囲内で重複生成が発生しました")
         
+    def test_no_duplicate_when_start_time_edited_deterministic_rule(self):
+        """開始時刻を編集済みのイベントを重複生成しない（OTHER deterministic ルート）
+
+        deterministic な OTHER ルールでは base_date=today のため毎回今日以降の期待日リストを
+        再生成する。exists チェックが start_time で絞っていると、編集済みイベントを
+        見落として同日に別スロットが作られる。
+        """
+        today = timezone.now().date()
+
+        # deterministic に解釈できる custom_rule を使う OTHER ルールと集会を用意
+        # 「毎週月曜日」相当。まず deterministic として解釈できるか検証する。
+        det_community = Community.objects.create(
+            name='deterministic-community',
+            description='テスト用',
+            weekdays=['Mon'],
+            start_time=time(21, 0),
+            duration=60,
+            status='approved',
+        )
+        det_rule = RecurrenceRule.objects.create(
+            community=det_community,
+            frequency='OTHER',
+            interval=1,
+            custom_rule='毎週月曜日',
+        )
+
+        from event.recurrence_service import RecurrenceService
+        service = RecurrenceService()
+        if not service.has_deterministic_custom_rule(det_rule):
+            self.skipTest('deterministic parser がこのルールを解釈できないためスキップ')
+
+        # 今日の月曜起点のマスターイベント
+        days_since_monday = today.weekday()  # Monday=0
+        master_date = today - timedelta(days=days_since_monday + 7)
+        det_master = Event.objects.create(
+            community=det_community,
+            date=master_date,
+            start_time=time(21, 0),
+            duration=60,
+            weekday='MON',
+            is_recurring_master=True,
+            recurrence_rule=det_rule,
+        )
+
+        # 最初の生成
+        call_command('generate_recurring_events', '--months=1', stdout=StringIO())
+
+        # 生成済み未来イベントの 1 件を community.start_time (21:00) と別時刻に編集
+        edited_event = Event.objects.filter(
+            recurring_master=det_master,
+            date__gte=today,
+        ).order_by('date').first()
+        self.assertIsNotNone(edited_event, '前提: 未来イベントが生成されている')
+        edited_event.start_time = time(23, 30)
+        edited_event.save(update_fields=['start_time'])
+        edited_date = edited_event.date
+
+        # 再度コマンドを走らせる
+        call_command('generate_recurring_events', '--months=1', stdout=StringIO())
+
+        same_day_count = Event.objects.filter(
+            community=det_community,
+            date=edited_date,
+        ).count()
+        self.assertEqual(
+            same_day_count, 1,
+            '開始時刻を編集した日に別スロットが重複生成された',
+        )
+
+    def test_persistence_create_recurring_events_skips_by_date(self):
+        """persistence.create_recurring_events は日付単位で重複を判定する
+
+        同日にすでにイベントがあれば、start_time が異なっていても新規作成しない。
+        """
+        from event.recurrence.persistence import create_recurring_events
+
+        existing_date = timezone.now().date() + timedelta(days=5)
+        # 既存イベントを community.start_time と異なる時刻で作成
+        Event.objects.create(
+            community=self.community,
+            date=existing_date,
+            start_time=time(23, 30),  # community.start_time=21:00 とは別
+            duration=60,
+            weekday=existing_date.strftime('%a').upper()[:3],
+        )
+
+        # 同じ日付を含む dates リストで recurring 生成
+        new_dates = [
+            existing_date + timedelta(days=7),  # 新規（マスターになる）
+            existing_date,  # 既存日 → スキップされるべき
+        ]
+        created = create_recurring_events(
+            community=self.community,
+            rule=self.weekly_rule,
+            dates=new_dates,
+            start_time=self.community.start_time,
+            duration=60,
+        )
+
+        # 既存日 (existing_date) に別スロットが作られていないこと
+        same_day_count = Event.objects.filter(
+            community=self.community,
+            date=existing_date,
+        ).count()
+        self.assertEqual(
+            same_day_count, 1,
+            '同日に別 start_time のイベントが重複生成された',
+        )
+        # マスター (先頭の new date) は作成されている
+        self.assertEqual(len(created), 1)
+
     def test_biweekly_rule(self):
         """隔週ルールのテスト"""
         # 隔週用の独自Communityを作成（start_time/durationをマスターと変える）

--- a/app/event/urls.py
+++ b/app/event/urls.py
@@ -3,8 +3,8 @@ from django.views.generic import TemplateView
 
 from .views import EventListView, EventDetailView, sync_calendar_events, EventDetailUpdateView, EventDetailCreateView, \
     EventDetailDeleteView, EventMyList, GenerateBlogView, EventDetailPastList, \
-    EventDeleteView, GoogleCalendarEventCreateView, EventLogListView, LTApplicationCreateView, LTApplicationReviewView, \
-    LTApplicationApproveView, LTApplicationCompleteView, LTApplicationRejectView
+    EventDeleteView, EventUpdateView, GoogleCalendarEventCreateView, EventLogListView, LTApplicationCreateView, \
+    LTApplicationReviewView, LTApplicationApproveView, LTApplicationCompleteView, LTApplicationRejectView
 from .views.material_upload_reminder import send_material_upload_reminders_view
 from .views.slide_reminder import send_slide_reminders
 from .views_llm_generate import generate_llm_events
@@ -13,6 +13,7 @@ app_name = 'event'
 urlpatterns = [
     path('list/', EventListView.as_view(), name='list'),
     path('delete/<int:pk>/', EventDeleteView.as_view(), name='delete'),
+    path('update/<int:pk>/', EventUpdateView.as_view(), name='update'),
     path('my_list/', EventMyList.as_view(), name='my_list'),
     path('sync/', sync_calendar_events, name='sync_calendar_events'),
     path('calendar/create/', GoogleCalendarEventCreateView.as_view(), name='calendar_create'),

--- a/app/event/views/__init__.py
+++ b/app/event/views/__init__.py
@@ -22,6 +22,7 @@ from event.views.crud import (  # noqa: F401
     EventDetailCreateView,
     EventDetailDeleteView,
     EventDetailUpdateView,
+    EventUpdateView,
 )
 from event.views.calendar_create import GoogleCalendarEventCreateView  # noqa: F401
 from event.views.blog import GenerateBlogView  # noqa: F401

--- a/app/event/views/crud.py
+++ b/app/event/views/crud.py
@@ -1,20 +1,138 @@
 import logging
+from datetime import datetime, timedelta
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.cache import cache
+from django.db import IntegrityError, transaction
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
+from django.utils import timezone
 from django.views.generic import CreateView, UpdateView, DeleteView
 
-from event.forms import EventDetailForm
+from event.forms import EventDetailForm, EventUpdateForm
 from event.services.content_generation_service import apply_blog_output_to_event_detail, generate_blog
 from event.models import Event, EventDetail
 from event.views.helpers import can_manage_event_detail
+from event_calendar.calendar_utils import generate_google_calendar_url
 from ta_hub.access_mixins import AuthenticatedForbiddenMixin
+from ta_hub.index_cache import clear_index_view_cache
 from website.settings import GOOGLE_CALENDAR_CREDENTIALS, GOOGLE_CALENDAR_ID, GEMINI_MODEL
 from event.google_calendar import GoogleCalendarService
 
 logger = logging.getLogger(__name__)
+
+
+class EventUpdateView(LoginRequiredMixin, UpdateView):
+    """イベントの開始時刻のみを編集するビュー。
+
+    date/duration などは変更不可。編集を許すのは所属集会の管理者（owner/staff）と
+    superuser のみ。Vket コラボ期間中はロックする（superuser/is_staff は免除）。
+    """
+
+    model = Event
+    form_class = EventUpdateForm
+    template_name = 'event/event_form.html'
+    success_url = reverse_lazy('event:my_list')
+
+    def dispatch(self, request, *args, **kwargs):
+        # 認証は LoginRequiredMixin が先に処理する
+        if not request.user.is_authenticated:
+            return super().dispatch(request, *args, **kwargs)
+
+        event = get_object_or_404(Event, pk=kwargs.get('pk'))
+
+        # 権限チェック（superuser は許可）
+        if not (request.user.is_superuser or event.community.can_edit(request.user)):
+            messages.error(request, "このイベントを編集する権限がありません。")
+            return redirect('event:my_list')
+
+        # Vket ロック（superuser/is_staff は免除）
+        if not (request.user.is_superuser or request.user.is_staff):
+            from vket.services import get_vket_lock_info
+            locked, message = get_vket_lock_info(event)
+            if locked:
+                messages.error(request, message)
+                return redirect('event:my_list')
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['event'] = self.object
+        return context
+
+    def form_valid(self, form):
+        # 旧 start_time を退避（EventDetail の delta シフトに使用）
+        old_event = Event.objects.get(pk=self.object.pk)
+        old_start_time = old_event.start_time
+        new_start_time = form.cleaned_data['start_time']
+
+        try:
+            with transaction.atomic():
+                self.object = form.save()
+
+                # 旧→新 delta で配下 EventDetail の start_time を同量シフト
+                if new_start_time != old_start_time:
+                    old_dt = datetime.combine(self.object.date, old_start_time)
+                    new_dt = datetime.combine(self.object.date, new_start_time)
+                    delta = new_dt - old_dt
+                    # soft delete 除外は EventDetail.objects の既定挙動（EventDetailManager）
+                    for detail in EventDetail.objects.filter(event=self.object):
+                        detail_dt = datetime.combine(self.object.date, detail.start_time) + delta
+                        # 日跨ぎになる場合は time 部分のみ採用（日付は event.date のまま維持）
+                        detail.start_time = detail_dt.time()
+                        detail.save(update_fields=['start_time', 'updated_at'])
+
+                # キャッシュ無効化
+                cache.delete(f'google_calendar_url_{self.object.id}')
+                # VRCイベントカレンダー投稿URLは start_time を埋め込むため両バリアントを消す
+                cache.delete(f'calendar_entry_url_{self.object.id}_True')
+                cache.delete(f'calendar_entry_url_{self.object.id}_False')
+                # lru_cache のクリア（request, event キーで cache されている可能性）
+                generate_google_calendar_url.cache_clear()
+                clear_index_view_cache(self.object.date)
+        except IntegrityError:
+            # UniqueConstraint (community, date, start_time) 競合をフォームエラーへ
+            form.add_error('start_time', '同じ日時にすでにイベントが登録されています。')
+            return self.form_invalid(form)
+
+        # atomic を抜けた後で Google カレンダーを patch（DB はコミット済み）
+        if self.object.google_calendar_event_id:
+            try:
+                start_datetime = datetime.combine(self.object.date, self.object.start_time)
+                tz = timezone.get_current_timezone()
+                start_datetime = timezone.make_aware(start_datetime, tz)
+                end_datetime = start_datetime + timedelta(minutes=self.object.duration)
+                calendar_service = GoogleCalendarService(
+                    calendar_id=GOOGLE_CALENDAR_ID,
+                    credentials_path=GOOGLE_CALENDAR_CREDENTIALS,
+                )
+                calendar_service.update_event(
+                    event_id=self.object.google_calendar_event_id,
+                    start_time=start_datetime,
+                    end_time=end_datetime,
+                )
+            except Exception:
+                # silent failure: DB 保存は成功扱いのまま進めるため、Sentry で連発検知
+                # できるよう is_silent=True の構造化ログに揃える（同ファイルの記事生成失敗と同規約）。
+                logger.exception(
+                    "silent_failure",
+                    extra={
+                        "event_type": "google_calendar_update_failed",
+                        "target_event_id": self.object.id,
+                        "is_silent": True,
+                    },
+                )
+                messages.error(
+                    self.request,
+                    "Googleカレンダーの更新に失敗しました（変更自体は保存済み。"
+                    "次回同期時に自動反映されます）",
+                )
+                return redirect(self.get_success_url())
+
+        messages.success(self.request, "開始時刻を変更しました。")
+        return redirect(self.get_success_url())
 
 
 class EventDeleteView(LoginRequiredMixin, DeleteView):

--- a/app/event/views/crud.py
+++ b/app/event/views/crud.py
@@ -76,12 +76,16 @@ class EventUpdateView(LoginRequiredMixin, UpdateView):
         old_start_time = old_event.start_time
         new_start_time = form.cleaned_data['start_time']
 
+        time_changed = new_start_time != old_start_time
+
         try:
             with transaction.atomic():
                 self.object = form.save()
 
-                # 旧→新 delta で配下 EventDetail の start_time を同量シフト
-                if new_start_time != old_start_time:
+                # 時刻が変わらない保存では副作用（詳細シフト・キャッシュ無効化・
+                # TweetQueue 再生成・GCal patch）を一切走らせない
+                if time_changed:
+                    # 旧→新 delta で配下 EventDetail の start_time を同量シフト
                     old_dt = datetime.combine(self.object.date, old_start_time)
                     new_dt = datetime.combine(self.object.date, new_start_time)
                     delta = new_dt - old_dt
@@ -92,37 +96,37 @@ class EventUpdateView(LoginRequiredMixin, UpdateView):
                         detail.start_time = detail_dt.time()
                         detail.save(update_fields=['start_time', 'updated_at'])
 
-                # キャッシュ無効化
-                cache.delete(f'google_calendar_url_{self.object.id}')
-                # VRCイベントカレンダー投稿URLは start_time を埋め込むため両バリアントを消す
-                cache.delete(f'calendar_entry_url_{self.object.id}_True')
-                cache.delete(f'calendar_entry_url_{self.object.id}_False')
-                # lru_cache のクリア（request, event キーで cache されている可能性）
-                generate_google_calendar_url.cache_clear()
-                # IndexView のキャッシュキーは get_vrchat_today() ベース。
-                # event.date を渡すと別キーを消してしまい実キャッシュが残るため引数なしで呼ぶ。
-                clear_index_view_cache()
+                    # キャッシュ無効化
+                    cache.delete(f'google_calendar_url_{self.object.id}')
+                    # VRCイベントカレンダー投稿URLは start_time を埋め込むため両バリアントを消す
+                    cache.delete(f'calendar_entry_url_{self.object.id}_True')
+                    cache.delete(f'calendar_entry_url_{self.object.id}_False')
+                    # lru_cache のクリア（request, event キーで cache されている可能性）
+                    generate_google_calendar_url.cache_clear()
+                    # IndexView のキャッシュキーは get_vrchat_today() ベース。
+                    # event.date を渡すと別キーを消してしまい実キャッシュが残るため引数なしで呼ぶ。
+                    clear_index_view_cache()
 
-                # 未投稿の TweetQueue は generated_text に旧時刻が焼き込まれているため、
-                # 再生成対象に戻す（status='generation_failed' + generated_text='' で
-                # 既存の retry_generation フローが拾って新時刻で再生成する。scheduled_at は
-                # 日付基準のため変更不要）。posted / failed / skipped は触らない。
-                from twitter.models import TweetQueue
-                TweetQueue.objects.filter(
-                    event=self.object,
-                    status__in=('generating', 'generation_failed', 'ready'),
-                ).update(
-                    status='generation_failed',
-                    generated_text='',
-                    error_message='開始時刻変更により再生成',
-                )
+                    # 未投稿の TweetQueue は generated_text に旧時刻が焼き込まれているため、
+                    # 再生成対象に戻す（status='generation_failed' + generated_text='' で
+                    # 既存の retry_generation フローが拾って新時刻で再生成する。scheduled_at は
+                    # 日付基準のため変更不要）。posted / failed / skipped は触らない。
+                    from twitter.models import TweetQueue
+                    TweetQueue.objects.filter(
+                        event=self.object,
+                        status__in=('generating', 'generation_failed', 'ready'),
+                    ).update(
+                        status='generation_failed',
+                        generated_text='',
+                        error_message='開始時刻変更により再生成',
+                    )
         except IntegrityError:
             # UniqueConstraint (community, date, start_time) 競合をフォームエラーへ
             form.add_error('start_time', '同じ日時にすでにイベントが登録されています。')
             return self.form_invalid(form)
 
         # atomic を抜けた後で Google カレンダーを patch（DB はコミット済み）
-        if self.object.google_calendar_event_id:
+        if time_changed and self.object.google_calendar_event_id:
             try:
                 start_datetime = datetime.combine(self.object.date, self.object.start_time)
                 tz = timezone.get_current_timezone()

--- a/app/event/views/crud.py
+++ b/app/event/views/crud.py
@@ -13,10 +13,12 @@ from django.views.generic import CreateView, UpdateView, DeleteView
 from event.forms import EventDetailForm, EventUpdateForm
 from event.services.content_generation_service import apply_blog_output_to_event_detail, generate_blog
 from event.models import Event, EventDetail
+from event.sync_to_google import build_google_event_description
 from event.views.helpers import can_manage_event_detail
 from event_calendar.calendar_utils import generate_google_calendar_url
 from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 from ta_hub.index_cache import clear_index_view_cache
+from utils.vrchat_time import get_vrchat_today
 from website.settings import GOOGLE_CALENDAR_CREDENTIALS, GOOGLE_CALENDAR_ID, GEMINI_MODEL
 from event.google_calendar import GoogleCalendarService
 
@@ -45,6 +47,12 @@ class EventUpdateView(LoginRequiredMixin, UpdateView):
         # 権限チェック（superuser は許可）
         if not (request.user.is_superuser or event.community.can_edit(request.user)):
             messages.error(request, "このイベントを編集する権限がありません。")
+            return redirect('event:my_list')
+
+        # 過去イベントの編集はブロック（UI で鉛筆非表示のため URL 直叩き対策）。
+        # my_list の _attach_edit_flags と同じ VRChat today 基準に揃える。
+        if event.date < get_vrchat_today():
+            messages.error(request, "過去のイベントは編集できません。")
             return redirect('event:my_list')
 
         # Vket ロック（superuser/is_staff は免除）
@@ -91,7 +99,23 @@ class EventUpdateView(LoginRequiredMixin, UpdateView):
                 cache.delete(f'calendar_entry_url_{self.object.id}_False')
                 # lru_cache のクリア（request, event キーで cache されている可能性）
                 generate_google_calendar_url.cache_clear()
-                clear_index_view_cache(self.object.date)
+                # IndexView のキャッシュキーは get_vrchat_today() ベース。
+                # event.date を渡すと別キーを消してしまい実キャッシュが残るため引数なしで呼ぶ。
+                clear_index_view_cache()
+
+                # 未投稿の TweetQueue は generated_text に旧時刻が焼き込まれているため、
+                # 再生成対象に戻す（status='generation_failed' + generated_text='' で
+                # 既存の retry_generation フローが拾って新時刻で再生成する。scheduled_at は
+                # 日付基準のため変更不要）。posted / failed / skipped は触らない。
+                from twitter.models import TweetQueue
+                TweetQueue.objects.filter(
+                    event=self.object,
+                    status__in=('generating', 'generation_failed', 'ready'),
+                ).update(
+                    status='generation_failed',
+                    generated_text='',
+                    error_message='開始時刻変更により再生成',
+                )
         except IntegrityError:
             # UniqueConstraint (community, date, start_time) 競合をフォームエラーへ
             form.add_error('start_time', '同じ日時にすでにイベントが登録されています。')
@@ -108,10 +132,15 @@ class EventUpdateView(LoginRequiredMixin, UpdateView):
                     calendar_id=GOOGLE_CALENDAR_ID,
                     credentials_path=GOOGLE_CALENDAR_CREDENTIALS,
                 )
+                # description も更新する（本文内「開催日時」が旧時刻のまま残ると、
+                # 後続の DB→Google 同期が日時+ID 一致で skipped 判定になり恒久的に矛盾する）。
+                # sync 側と同じ生成関数を使うことで文面のドリフトを防ぐ。summary は community 名で
+                # 不変のため渡さない。
                 calendar_service.update_event(
                     event_id=self.object.google_calendar_event_id,
                     start_time=start_datetime,
                     end_time=end_datetime,
+                    description=build_google_event_description(self.object),
                 )
             except Exception:
                 # silent failure: DB 保存は成功扱いのまま進めるため、Sentry で連発検知

--- a/app/event/views/crud.py
+++ b/app/event/views/crud.py
@@ -119,6 +119,9 @@ class EventUpdateView(LoginRequiredMixin, UpdateView):
                         status='generation_failed',
                         generated_text='',
                         error_message='開始時刻変更により再生成',
+                        # in-flight の非同期生成が旧時刻スナップショットで ready に戻すのを防ぐ
+                        # （write-back は generation_token の compare-and-set で守られている）
+                        generation_token='',
                     )
         except IntegrityError:
             # UniqueConstraint (community, date, start_time) 競合をフォームエラーへ
@@ -164,7 +167,10 @@ class EventUpdateView(LoginRequiredMixin, UpdateView):
                 )
                 return redirect(self.get_success_url())
 
-        messages.success(self.request, "開始時刻を変更しました。")
+        if time_changed:
+            messages.success(self.request, "開始時刻を変更しました。")
+        else:
+            messages.info(self.request, "開始時刻に変更はありません。")
         return redirect(self.get_success_url())
 
 

--- a/app/event/views/my_list.py
+++ b/app/event/views/my_list.py
@@ -136,6 +136,33 @@ class EventMyList(LoginRequiredMixin, ListView):
             event.twitter_button_active = today <= twitter_display_until
         return events
 
+    def _attach_edit_flags(self, events):
+        """各イベントに開始時刻編集用のフラグを付与する。
+
+        - can_edit_event: 集会の管理者（owner/staff）または superuser
+        - vket_locked: Vket コラボ期間中で編集不可（superuser/is_staff は False）
+        """
+        from vket.services import get_vket_lock_info
+
+        user = self.request.user
+        today = get_vrchat_today()
+        # community 単位で権限判定を1回にまとめる（N+1回避）
+        community_edit_cache = {}
+        for event in events:
+            community_id = event.community_id
+            if community_id not in community_edit_cache:
+                community_edit_cache[community_id] = (
+                    user.is_superuser or event.community.can_edit(user)
+                )
+            event.can_edit_event = community_edit_cache[community_id] and event.date >= today
+
+            if user.is_superuser or user.is_staff:
+                event.vket_locked = False
+            else:
+                locked, _ = get_vket_lock_info(event)
+                event.vket_locked = locked
+        return events
+
     def _attach_event_details(self, events):
         """イベントごとにイベント詳細情報を取得・設定する
 
@@ -212,6 +239,9 @@ class EventMyList(LoginRequiredMixin, ListView):
 
         # イベント詳細情報を取得・設定
         events = self._attach_event_details(events)
+
+        # 開始時刻編集ボタン表示用のフラグを設定
+        events = self._attach_edit_flags(events)
 
         # 更新されたイベントリストをコンテキストに再設定
         context['events'] = events


### PR DESCRIPTION
## なぜこの変更が必要か

イベント管理ページでは開催日・開始時刻を後から変更する手段がなく、主催者が時刻を変えたい場合は削除→再登録しか無かった。また、開始時刻の異なるイベントが存在すると定期イベント生成が同日に複製を作るバグがあった。

当初は日付編集・削除UIモーダル統合まで含む計画だったが、影響範囲（tombstone・TweetQueue 再スケジュール・Vket 新日付ロック等）が大きいため、開始時刻のみの編集に絞った（残タスクは #540 #541 #542 #543 に分割済み）。

## 変更内容

- my_list の開始時刻行に鉛筆ボタンを追加し、開始時刻のみ編集できる `EventUpdateView` / `EventUpdateForm` / `event/update/<pk>/` を新設
- 保存時に Google カレンダーへ即時 patch（日時のみ送信）。失敗時は DB 保存を維持しエラーメッセージ表示（次回同期で自己修復）
- 配下の発表（EventDetail）の開始時間も同じ差分だけ自動シフト
- Vket コラボ期間中はボタン disabled + ビュー側でもブロック（superuser / is_staff は免除、EventDeleteView と同条件）
- 定期イベント生成の重複判定を (community, date, start_time) → (community, date) に変更し、時刻編集後の同日複製を防止

## 意思決定

### 採用アプローチ
- 編集対象を start_time のみに限定。理由: date 変更は TweetQueue・Vket ロック・再生成防止（tombstone）等の広範な副作用対応が必要で、多角レビューの結果リスクが大きいと判断（#541 に分離）
- GCal 反映は保存時の即時 patch。理由: 削除ビューと同じパターンで一貫性があり、ユーザーがすぐ結果を確認できる。summary/description を送らないことで DB→Google 同期の説明文生成と干渉しない
- DB commit 後に GCal patch を実行。理由: 逆順だと DB 保存失敗時に Google だけ更新される

### 却下した代替案
- GCal 反映を次回同期任せ → 却下: 同期までカレンダーと画面がズレる
- 再生成防止に tombstone モデル新設 → 却下（今回scope）: migration 込みで重い。時刻編集起因の複製は date 単位判定で新モデルなしに防げる（削除イベントの復活防止は #541）

### トレードオフ
- 生成の重複判定を date 単位に緩和 > 同日複数イベントの自動生成: 生成コマンドは 1 community 1 日 1 スロットしか作らない運用のため実質的な機能劣化なし

### 技術的負債
- 削除UIのモーダル統合 #540 / 日付編集 + tombstone #541 / Google→DB デッドコード整理 #542 / weekday 表記揺れ #543

## テスト

- [x] 新規 `test_event_update_view.py` 12件（権限・GCal 呼び出し/失敗時挙動・UniqueConstraint 衝突・Vket ロック・EventDetail シフト）
- [x] 生成の同日複製の再発防止テスト（修正前に失敗することを確認済み）+ 自己回復の回帰テスト
- [x] event アプリ全486テスト緑（`docker compose exec vrc-ta-hub python manage.py test event`）
- [x] Playwright でブラウザ確認: 鉛筆の表示条件（未来イベントのみ・Vket ロック中 disabled）、編集→反映→原状復帰

## Screenshot

| 一覧（鉛筆ボタン） | 編集フォーム | 保存後 |
|--------|-------|-------|
| ![list](https://agent-toolbox-assets.kaisha3.com/uploads/2026/07/6119ea827e7a-01-my-list-initial-2026-07-24T15-24-53.avif) | ![form](https://agent-toolbox-assets.kaisha3.com/uploads/2026/07/3d0fb6a1d0eb-06-edit-form-shown-2026-07-24T15-28-54.avif) | ![after](https://agent-toolbox-assets.kaisha3.com/uploads/2026/07/8c25b15f4af0-07-after-edit-submit-2026-07-24T15-28-54.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Google Calendar updates, TweetQueue regeneration, and recurring-event dedup logic; mistakes could desync calendars or tweets, though scope is limited to start_time and is well tested.
> 
> **Overview**
> **Organizers can change an event’s start time** from イベント管理 (`my_list`) via a new pencil control and `event/update/<pk>/` flow, without changing date or community.
> 
> `EventUpdateForm` / `EventUpdateView` limit edits to `start_time`, enforce `(community, date, start_time)` uniqueness, and block past events (VRChat today) and Vket-locked periods (same exemptions as delete). Saving shifts child `EventDetail` start times by the same delta, clears calendar/index caches, resets unposted `TweetQueue` rows for regeneration, and patches Google Calendar when an ID exists (including `description` via shared `build_google_event_description`); DB commits even if GCal fails.
> 
> **Recurring generation** no longer treats “missing default start_time” as a free slot: `generate_recurring_events` and `create_recurring_events` skip dates that already have any event for that community, preventing duplicate instances after a time edit.
> 
> Tests cover the update view, my_list button states, and the new dedup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182b4bdeb0a1f9ec3b2b219df921b8ff30f9d95c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->