### PR TITLE
test: ローカルテスト実行時の実Discord webhook送信を修正し外向き遮断を既定化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,11 @@ jobs:
           EMAIL_FILE_PATH: "/tmp/emails"
         run: |
           # 実サービスへ接続する live smoke とブラウザE2Eだけを除外する。
-          # OfflineNetworkDiscoverRunner が loopback 以外への接続を拒否するため、
-          # dummy credentialを渡しても通常suiteから外向き通信は発生しない。
+          # 遮断runner (OfflineNetworkDiscoverRunner) は settings の TEST_RUNNER 既定で有効になるため、
+          # ここでCLI指定しない（ローカルとCIで同じ遮断条件にする）。
           # coverage 設定は ../pyproject.toml の [tool.coverage] を参照
           coverage run --rcfile=../pyproject.toml -m tests.offline_manage test \
             --exclude-tag=live_smoke --exclude-tag=e2e \
-            --testrunner=website.tests.offline_runner.OfflineNetworkDiscoverRunner \
             --noinput
           coverage report --rcfile=../pyproject.toml
 
@@ -153,7 +152,12 @@ jobs:
 
       - name: Run browser E2E tests
         working-directory: app
-        run: python manage.py test website.tests.e2e.test_user_journeys --tag=e2e --noinput --verbosity=2
+        # Playwright driver との通信経路が socket patch の影響を受けないことを確認できていないため、
+        # settings 既定の遮断 runner ではなく Django 標準 runner を明示する。
+        # E2E はブラウザ経由で loopback のテストサーバにしかアクセスしない前提。
+        run: |
+          python manage.py test website.tests.e2e.test_user_journeys --tag=e2e --noinput --verbosity=2 \
+            --testrunner=django.test.runner.DiscoverRunner
 
       - name: Upload E2E failure artifacts
         if: failure()

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -8,6 +8,7 @@ import datetime
 from django.db import DatabaseError, IntegrityError, OperationalError, transaction
 from unittest.mock import MagicMock, Mock, patch
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase, TransactionTestCase, override_settings, tag
 from django.urls import reverse
@@ -943,9 +944,11 @@ class PostScheduledTweetsViewTest(AutoTweetTestBase):
         self.assertEqual(first.status, "posted")
         self.assertEqual(second.status, "ready")
 
+    @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
+    @patch("twitter.notifications.requests.post")
     @patch("twitter.views.post_tweet")
-    def test_post_scheduled_tweets_post_failure(self, mock_post):
-        """X API 投稿失敗時の処理"""
+    def test_post_scheduled_tweets_post_failure(self, mock_post, mock_webhook_post):
+        """X API 投稿失敗時にキューが failed になり管理者へ通知が送られる"""
         mock_post.return_value = {"ok": False, "data": None, "status_code": 403, "error_body": "You are not permitted to perform this action."}
 
         TweetQueue.objects.create(
@@ -969,6 +972,12 @@ class PostScheduledTweetsViewTest(AutoTweetTestBase):
 
         queue = TweetQueue.objects.first()
         self.assertEqual(queue.status, "failed")
+
+        mock_webhook_post.assert_called_once()
+        self.assertEqual(
+            mock_webhook_post.call_args.args[0],
+            settings.DISCORD_WEBHOOK_URL,
+        )
 
     def test_post_scheduled_tweets_empty_queue(self):
         """キューが空の場合の処理"""

--- a/app/twitter/tests/test_tweet_queue_views.py
+++ b/app/twitter/tests/test_tweet_queue_views.py
@@ -7,8 +7,9 @@
 import datetime
 from unittest.mock import MagicMock, patch
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -382,10 +383,12 @@ class TweetQueueDetailViewTest(TweetQueueViewTestBase):
         self.assertEqual(self.queue_item.tweet_id, '12345678')
         self.assertIsNotNone(self.queue_item.posted_at)
 
+    @override_settings(DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/test/token')
+    @patch('twitter.notifications.requests.post')
     @patch('twitter.views.post_tweet')
     @patch('twitter.views.upload_media')
-    def test_post_now_failure(self, mock_upload, mock_post):
-        """手動投稿が失敗した場合は元ステータスを維持する"""
+    def test_post_now_failure(self, mock_upload, mock_post, mock_webhook_post):
+        """手動投稿が失敗した場合は元ステータスを維持し管理者へ通知する"""
         mock_post.return_value = {'ok': False, 'data': None, 'status_code': 403, 'error_body': 'Forbidden'}
         mock_upload.return_value = None
 
@@ -397,6 +400,12 @@ class TweetQueueDetailViewTest(TweetQueueViewTestBase):
         self.queue_item.refresh_from_db()
         self.assertEqual(self.queue_item.status, 'ready')
         self.assertIn('X API', self.queue_item.error_message)
+
+        mock_webhook_post.assert_called_once()
+        self.assertEqual(
+            mock_webhook_post.call_args.args[0],
+            settings.DISCORD_WEBHOOK_URL,
+        )
 
     @patch('twitter.views.post_tweet')
     @patch('twitter.views.upload_media')

--- a/app/website/settings/base.py
+++ b/app/website/settings/base.py
@@ -182,6 +182,13 @@ if 'test' in sys.argv or TESTING:
         from cryptography.fernet import Fernet as _Fernet
         FERNET_KEY = _Fernet.generate_key().decode()
 
+    # ローカルの `manage.py test` も既定で外向き通信を遮断する。
+    # モック漏れがあると .env.local の実 DISCORD_WEBHOOK_URL などへ本物のリクエストが飛び、
+    # 管理者に偽の通知が届く事故が起きるため（Issue #547）。
+    # live_smoke タグのテストを実サービス相手に流す時だけ ALLOW_EXTERNAL_TEST_NETWORK=1 で解除する。
+    if os.environ.get('ALLOW_EXTERNAL_TEST_NETWORK', '').strip().lower() not in {'1', 'true', 'yes', 'on'}:
+        TEST_RUNNER = 'website.tests.offline_runner.OfflineNetworkDiscoverRunner'
+
 _settings_logger.info('DB_NAME: %s', _mask(DATABASES['default']['NAME']))
 
 # Cache settings

--- a/app/website/tests/offline_runner.py
+++ b/app/website/tests/offline_runner.py
@@ -1,11 +1,12 @@
 """通常テストから外向きネットワーク接続を遮断するtest runner。"""
 
 import ipaddress
+import os
 import socket
 import sys
 import threading
 import traceback
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -47,6 +48,7 @@ def _summarize_call_stack() -> tuple[str, ...]:
 
     urllib3 等のライブラリ内フレームだけだとどのテストか分からないため、
     プロジェクト内 (PROJECT_ROOT 配下、本ファイル除く) の直近フレームを先頭に置く。
+    ソース行そのものは出さない。webhook URL などのリテラルがCIログへ漏れるため。
     """
     frames = [
         frame for frame in traceback.extract_stack()
@@ -54,12 +56,12 @@ def _summarize_call_stack() -> tuple[str, ...]:
     ]
     project_frames = [
         frame for frame in frames
-        if frame.filename.startswith(PROJECT_ROOT)
+        if frame.filename.startswith(PROJECT_ROOT + os.sep)
     ]
     selected = project_frames[-2:] + frames[-BLOCKED_STACK_FRAME_LIMIT:]
-    lines = []
+    lines: list[str] = []
     for frame in selected:
-        line = f'{frame.filename}:{frame.lineno} in {frame.name} | {(frame.line or "").strip()}'
+        line = f"{frame.filename}:{frame.lineno} in {frame.name}"
         if line not in lines:
             lines.append(line)
     return tuple(lines)
@@ -103,6 +105,11 @@ class BlockedNetworkRecorder:
         with self._lock:
             return list(self.events)
 
+    def restore(self, events: Sequence[BlockedNetworkEvent]) -> None:
+        """snapshot で退避した記録を書き戻す（入れ子でrunnerを動かすテスト用）。"""
+        with self._lock:
+            self.events[:] = list(events)
+
 
 blocked_network_recorder = BlockedNetworkRecorder()
 
@@ -113,7 +120,7 @@ def _block(operation: str, target: object, message: str) -> NoReturn:
     raise ExternalNetworkBlockedError(message)
 
 
-def format_blocked_network_report(events: list[BlockedNetworkEvent]) -> str:
+def format_blocked_network_report(events: Sequence[BlockedNetworkEvent]) -> str:
     """遮断イベント一覧を stderr 向けのレポート文字列に整形する。"""
     header = (
         f"外向き通信が {len(events)} 件遮断されました "
@@ -174,17 +181,19 @@ class OfflineNetworkDiscoverRunner(DiscoverRunner):
     def run_tests(self, test_labels, **kwargs):
         """外向き通信を遮断した状態でDjango test suiteを実行する。
 
-        遮断が発生したら失敗数に加算する。アプリ側が requests の例外を握りつぶすと
+        遮断が発生したら失敗数に1加算する。アプリ側が requests の例外を握りつぶすと
         テストは緑のまま通るため、suite の終了コードで検出できるようにする。
+        件数は加算せず stderr レポート側に出す（失敗テスト数と混ざると誤読を招くため）。
         """
         blocked_network_recorder.reset()
         with block_external_network():
             failures = super().run_tests(test_labels, **kwargs)
 
         events = blocked_network_recorder.snapshot()
-        if events:
-            print(format_blocked_network_report(events), file=sys.stderr)
-        return failures + len(events)
+        if not events:
+            return failures
+        print(format_blocked_network_report(events), file=sys.stderr)
+        return failures + 1
 
 
 @contextmanager

--- a/app/website/tests/offline_runner.py
+++ b/app/website/tests/offline_runner.py
@@ -2,15 +2,146 @@
 
 import ipaddress
 import socket
+import sys
+import threading
+import traceback
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import NoReturn
 from unittest.mock import patch
 
 from django.test.runner import DiscoverRunner
 
+# 遮断イベント1件あたりに保持するスタックフレーム数。多すぎると出力が読めない。
+BLOCKED_STACK_FRAME_LIMIT = 6
+# 自プロジェクトのフレーム判定に使うルート（app/ ディレクトリ）。
+_THIS_FILE = str(Path(__file__).resolve())
+PROJECT_ROOT = str(Path(__file__).resolve().parents[2])
+# 報告するイベント件数の上限。同じモック漏れが大量に出ても出力を潰さない。
+BLOCKED_EVENT_REPORT_LIMIT = 20
+
 
 class ExternalNetworkBlockedError(ConnectionError):
     """許可されていない外向き接続を検出したことを表す。"""
+
+
+@dataclass(frozen=True)
+class BlockedNetworkEvent:
+    """遮断した外向き通信の1件分の記録。"""
+
+    operation: str
+    target: str
+    stack: tuple[str, ...]
+
+    def format(self) -> str:
+        """人が読める1件分のレポートを返す。"""
+        lines = [f"- {self.operation}: {self.target}"]
+        lines.extend(f"    {frame}" for frame in self.stack)
+        return "\n".join(lines)
+
+
+def _summarize_call_stack() -> tuple[str, ...]:
+    """遮断元を追える程度にスタックを要約する。
+
+    urllib3 等のライブラリ内フレームだけだとどのテストか分からないため、
+    プロジェクト内 (PROJECT_ROOT 配下、本ファイル除く) の直近フレームを先頭に置く。
+    """
+    frames = [
+        frame for frame in traceback.extract_stack()
+        if frame.filename != _THIS_FILE
+    ]
+    project_frames = [
+        frame for frame in frames
+        if frame.filename.startswith(PROJECT_ROOT)
+    ]
+    selected = project_frames[-2:] + frames[-BLOCKED_STACK_FRAME_LIMIT:]
+    lines = []
+    for frame in selected:
+        line = f'{frame.filename}:{frame.lineno} in {frame.name} | {(frame.line or "").strip()}'
+        if line not in lines:
+            lines.append(line)
+    return tuple(lines)
+
+
+@dataclass
+class BlockedNetworkRecorder:
+    """遮断イベントをスレッドセーフに集める。"""
+
+    events: list[BlockedNetworkEvent] = field(default_factory=list)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _suppressed: threading.local = field(default_factory=threading.local, repr=False)
+
+    @contextmanager
+    def suppressed(self) -> Iterator[None]:
+        """意図的に遮断を発生させるテストの間だけ記録を止める（呼び出しスレッド限定）。"""
+        previous = getattr(self._suppressed, "active", False)
+        self._suppressed.active = True
+        try:
+            yield
+        finally:
+            self._suppressed.active = previous
+
+    def record(self, operation: str, target: object) -> None:
+        """遮断イベントを1件記録する。"""
+        if getattr(self._suppressed, "active", False):
+            return
+        stack = _summarize_call_stack()
+        with self._lock:
+            self.events.append(
+                BlockedNetworkEvent(operation=operation, target=repr(target), stack=stack),
+            )
+
+    def reset(self) -> None:
+        """記録を初期化する。"""
+        with self._lock:
+            self.events.clear()
+
+    def snapshot(self) -> list[BlockedNetworkEvent]:
+        """記録済みイベントのコピーを返す。"""
+        with self._lock:
+            return list(self.events)
+
+
+blocked_network_recorder = BlockedNetworkRecorder()
+
+
+def _block(operation: str, target: object, message: str) -> NoReturn:
+    """遮断イベントを記録してから ExternalNetworkBlockedError を送出する。"""
+    blocked_network_recorder.record(operation, target)
+    raise ExternalNetworkBlockedError(message)
+
+
+def format_blocked_network_report(events: list[BlockedNetworkEvent]) -> str:
+    """遮断イベント一覧を stderr 向けのレポート文字列に整形する。"""
+    header = (
+        f"外向き通信が {len(events)} 件遮断されました "
+        "(テストのモック漏れの可能性があります):"
+    )
+    shown = events[:BLOCKED_EVENT_REPORT_LIMIT]
+    body = "\n".join(event.format() for event in shown)
+    if len(events) > len(shown):
+        body = f"{body}\n- ... ほか {len(events) - len(shown)} 件"
+    return f"{header}\n{body}"
+
+
+def _is_own_hostname(host: object) -> bool:
+    """自ホスト名の解決かどうかを判定する。
+
+    Django のメール送信は Message-ID 生成で socket.getfqdn() を呼び、
+    コンテナ自身のホスト名を逆引きする。外向き通信ではないので許可する。
+    """
+    if isinstance(host, bytes):
+        try:
+            host = host.decode("ascii")
+        except UnicodeDecodeError:
+            return False
+    if not isinstance(host, str):
+        return False
+    own = socket.gethostname().rstrip(".").lower()
+    normalized = host.rstrip(".").lower()
+    return bool(own) and normalized in {own, own.split(".", maxsplit=1)[0]}
 
 
 def _is_loopback_host(host: object) -> bool:
@@ -41,9 +172,19 @@ class OfflineNetworkDiscoverRunner(DiscoverRunner):
     """Unix socketとloopbackを許可し、それ以外のsocket接続を拒否する。"""
 
     def run_tests(self, test_labels, **kwargs):
-        """外向き通信を遮断した状態でDjango test suiteを実行する。"""
+        """外向き通信を遮断した状態でDjango test suiteを実行する。
+
+        遮断が発生したら失敗数に加算する。アプリ側が requests の例外を握りつぶすと
+        テストは緑のまま通るため、suite の終了コードで検出できるようにする。
+        """
+        blocked_network_recorder.reset()
         with block_external_network():
-            return super().run_tests(test_labels, **kwargs)
+            failures = super().run_tests(test_labels, **kwargs)
+
+        events = blocked_network_recorder.snapshot()
+        if events:
+            print(format_blocked_network_report(events), file=sys.stderr)
+        return failures + len(events)
 
 
 @contextmanager
@@ -62,50 +203,53 @@ def block_external_network() -> Iterator[None]:
     def guarded_connect(sock, address):
         if _is_allowed_address(address):
             return original_connect(sock, address)
-        raise ExternalNetworkBlockedError(f"offline test blocked connection to {address!r}")
+        _block("connect", address, f"offline test blocked connection to {address!r}")
 
     def guarded_connect_ex(sock, address):
         if _is_allowed_address(address):
             return original_connect_ex(sock, address)
-        raise ExternalNetworkBlockedError(f"offline test blocked connection to {address!r}")
+        _block("connect_ex", address, f"offline test blocked connection to {address!r}")
 
     def guarded_getaddrinfo(host, *args, **kwargs):
         if host is None or _is_loopback_host(host):
             return original_getaddrinfo(host, *args, **kwargs)
-        raise ExternalNetworkBlockedError(f"offline test blocked DNS lookup for {host!r}")
+        _block("getaddrinfo", host, f"offline test blocked DNS lookup for {host!r}")
 
     def guarded_gethostbyaddr(host):
-        if _is_loopback_host(host):
+        if _is_loopback_host(host) or _is_own_hostname(host):
             return original_gethostbyaddr(host)
-        raise ExternalNetworkBlockedError(f"offline test blocked reverse DNS lookup for {host!r}")
+        _block("gethostbyaddr", host, f"offline test blocked reverse DNS lookup for {host!r}")
 
     def guarded_gethostbyname(host):
         if _is_loopback_host(host):
             return original_gethostbyname(host)
-        raise ExternalNetworkBlockedError(f"offline test blocked DNS lookup for {host!r}")
+        _block("gethostbyname", host, f"offline test blocked DNS lookup for {host!r}")
 
     def guarded_gethostbyname_ex(host):
         if _is_loopback_host(host):
             return original_gethostbyname_ex(host)
-        raise ExternalNetworkBlockedError(f"offline test blocked DNS lookup for {host!r}")
+        _block("gethostbyname_ex", host, f"offline test blocked DNS lookup for {host!r}")
 
     def guarded_getnameinfo(address, flags):
         if _is_allowed_address(address):
             return original_getnameinfo(address, flags)
-        raise ExternalNetworkBlockedError(f"offline test blocked reverse DNS lookup for {address!r}")
+        _block(
+            "getnameinfo", address,
+            f"offline test blocked reverse DNS lookup for {address!r}",
+        )
 
     def guarded_sendto(sock, data, *args):
         if args and _is_allowed_address(args[-1]):
             return original_sendto(sock, data, *args)
         if not args:
             return original_sendto(sock, data, *args)
-        raise ExternalNetworkBlockedError(f"offline test blocked UDP send to {args[-1]!r}")
+        _block("sendto", args[-1], f"offline test blocked UDP send to {args[-1]!r}")
 
     def guarded_sendmsg(sock, buffers, *args):
         address = args[2] if len(args) >= 3 else None
         if address is None or _is_allowed_address(address):
             return original_sendmsg(sock, buffers, *args)
-        raise ExternalNetworkBlockedError(f"offline test blocked message send to {address!r}")
+        _block("sendmsg", address, f"offline test blocked message send to {address!r}")
 
     with ExitStack() as stack:
         stack.enter_context(patch("socket.socket.connect", guarded_connect))

--- a/app/website/tests/test_offline_runner.py
+++ b/app/website/tests/test_offline_runner.py
@@ -172,8 +172,7 @@ class BlockedNetworkDetectionTest(SimpleTestCase):
 
     def _restore_outer_events(self):
         """外側の suite が集めていた記録を元に戻す。"""
-        blocked_network_recorder.reset()
-        blocked_network_recorder.events.extend(self._outer_events)
+        blocked_network_recorder.restore(self._outer_events)
 
     @staticmethod
     def _swallowing_suite(_self, _test_labels, **_kwargs):
@@ -194,13 +193,45 @@ class BlockedNetworkDetectionTest(SimpleTestCase):
         return failures, stderr.getvalue()
 
     def test_swallowed_external_call_fails_the_suite(self):
-        """アプリ側が例外を握りつぶしても遮断件数が失敗数に加算される。"""
+        """アプリ側が例外を握りつぶしても suite が失敗になる。"""
         failures, report = self._run_suite_with(self._swallowing_suite)
 
         self.assertEqual(failures, 1)
         self.assertIn("外向き通信が 1 件遮断されました", report)
         self.assertIn("discord.com", report)
         self.assertIn("test_offline_runner.py", report)
+
+    def test_multiple_blocks_add_one_failure_and_report_the_count(self):
+        """遮断が複数件でも失敗数への加算は1件（件数はレポートで示す）。"""
+        def repeatedly_swallowing_suite(_self, _labels, **_kwargs):
+            for _ in range(3):
+                try:
+                    socket.getaddrinfo("discord.com", 443)
+                except OSError:
+                    pass
+            return 0
+
+        failures, report = self._run_suite_with(repeatedly_swallowing_suite)
+
+        self.assertEqual(failures, 1)
+        self.assertIn("外向き通信が 3 件遮断されました", report)
+
+    def test_report_does_not_include_source_lines(self):
+        """レポートにソース行を出さない（webhook URL 等のリテラル漏洩防止）。"""
+        secret_marker = "webhook-token-must-not-appear"
+
+        def suite_with_literal(_self, _labels, **_kwargs):
+            try:
+                # 遮断が起きる行そのものに秘密値リテラルを置く（旧実装ならこの行が出力された）。
+                socket.getaddrinfo("discord.example.invalid", 443, 0, 0, 0, 0)  # webhook-token-must-not-appear
+            except OSError:
+                pass
+            return 0
+
+        _, report = self._run_suite_with(suite_with_literal)
+
+        self.assertIn("test_offline_runner.py", report)
+        self.assertNotIn(secret_marker, report)
 
     def test_clean_suite_keeps_original_failure_count(self):
         """遮断が起きなければ元の失敗数をそのまま返す。"""

--- a/app/website/tests/test_offline_runner.py
+++ b/app/website/tests/test_offline_runner.py
@@ -1,15 +1,23 @@
 """外向き通信を遮断するtest runner境界の回帰テスト。"""
 
+import contextlib
 import errno
+import io
 import socket
 import tempfile
 import threading
 from collections.abc import Callable
 from pathlib import Path
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
+from django.test.runner import DiscoverRunner
 
-from website.tests.offline_runner import ExternalNetworkBlockedError
+from website.tests.offline_runner import (
+    ExternalNetworkBlockedError,
+    OfflineNetworkDiscoverRunner,
+    blocked_network_recorder,
+)
 
 # socket.herror exposes h_errno=2 but not the legacy TRY_AGAIN constant.
 H_ERRNO_TRY_AGAIN = 2
@@ -23,9 +31,13 @@ class OfflineNetworkRunnerTest(SimpleTestCase):
         operation: Callable[[], object],
         accepted_os_errors: tuple[tuple[type[OSError], frozenset[int]], ...],
     ) -> None:
-        """Python遮断またはnetwork namespace遮断を外向き通信の失敗として受け入れる。"""
+        """Python遮断またはnetwork namespace遮断を外向き通信の失敗として受け入れる。
+
+        遮断はこのテストの期待動作なので、suite の遮断件数には数えない。
+        """
         try:
-            operation()
+            with blocked_network_recorder.suppressed():
+                operation()
         except ExternalNetworkBlockedError:
             return
         except OSError as exc:
@@ -149,3 +161,65 @@ class OfflineNetworkRunnerTest(SimpleTestCase):
                 with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as client:
                     client.sendto(b"allowed", socket_path)
                 self.assertEqual(server.recvfrom(32)[0], b"allowed")
+
+
+class BlockedNetworkDetectionTest(SimpleTestCase):
+    """遮断イベントが suite の終了コードとレポートに反映されることを確認する。"""
+
+    def setUp(self):
+        self._outer_events = blocked_network_recorder.snapshot()
+        self.addCleanup(self._restore_outer_events)
+
+    def _restore_outer_events(self):
+        """外側の suite が集めていた記録を元に戻す。"""
+        blocked_network_recorder.reset()
+        blocked_network_recorder.events.extend(self._outer_events)
+
+    @staticmethod
+    def _swallowing_suite(_self, _test_labels, **_kwargs):
+        """アプリと同様に接続エラーを握りつぶす「緑の」suiteを模擬する。"""
+        try:
+            socket.getaddrinfo("discord.com", 443)
+        except OSError:
+            pass
+        return 0
+
+    def _run_suite_with(self, suite_body):
+        """OfflineNetworkDiscoverRunner 経由で疑似suiteを実行し、失敗数とstderrを返す。"""
+        stderr = io.StringIO()
+        runner = OfflineNetworkDiscoverRunner(verbosity=0, interactive=False)
+        with patch.object(DiscoverRunner, "run_tests", suite_body), \
+                contextlib.redirect_stderr(stderr):
+            failures = runner.run_tests([])
+        return failures, stderr.getvalue()
+
+    def test_swallowed_external_call_fails_the_suite(self):
+        """アプリ側が例外を握りつぶしても遮断件数が失敗数に加算される。"""
+        failures, report = self._run_suite_with(self._swallowing_suite)
+
+        self.assertEqual(failures, 1)
+        self.assertIn("外向き通信が 1 件遮断されました", report)
+        self.assertIn("discord.com", report)
+        self.assertIn("test_offline_runner.py", report)
+
+    def test_clean_suite_keeps_original_failure_count(self):
+        """遮断が起きなければ元の失敗数をそのまま返す。"""
+        failures, report = self._run_suite_with(lambda _self, _labels, **_kw: 2)
+
+        self.assertEqual(failures, 2)
+        self.assertEqual(report, "")
+
+    def test_suppressed_block_is_not_counted(self):
+        """意図的に遮断を起こすテストは件数に数えない。"""
+        def suppressed_suite(_self, _labels, **_kwargs):
+            with blocked_network_recorder.suppressed():
+                try:
+                    socket.getaddrinfo("discord.com", 443)
+                except OSError:
+                    pass
+            return 0
+
+        failures, report = self._run_suite_with(suppressed_suite)
+
+        self.assertEqual(failures, 0)
+        self.assertEqual(report, "")

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,10 +29,17 @@ scripts/run_tests.sh \
 通常テストは `OfflineNetworkDiscoverRunner` で実行し、Unix socket と loopback
 （`localhost` / `127.0.0.0/8` / `::1`）以外への DNS・socket 接続を拒否する。
 CI には dummy credential だけを渡し、外向き通信が発生した時点でテストを失敗させる。
+遮断が発生すると、接続先と発生箇所を stderr に出したうえで suite 全体を失敗扱いにする
+（アプリ側が `except requests.RequestException` で握りつぶしてもモック漏れを検出できる）。
+
+この runner の指定は `website/settings/base.py` の `TEST_RUNNER` が正本で、
+テスト実行時（`TESTING=1` または `manage.py test`）に自動で有効になる。
+CLI の `--testrunner=...` は付けない。実サービスへ疎通する live smoke だけが
+`ALLOW_EXTERNAL_TEST_NETWORK=1` で遮断を解除する（`scripts/run_live_smoke.py` が自動設定）。
 
 通常実行の正本は `scripts/run_tests.sh`。引数なしで実行すると CI (`.github/workflows/ci.yml`) と
 同じ全探索でテストを収集する。引数を指定した場合も内部で
-`tests.offline_manage`、`OfflineNetworkDiscoverRunner`、`live_smoke` / `e2e` の除外を必ず付ける。
+`tests.offline_manage` と `live_smoke` / `e2e` の除外を必ず付ける。
 生の `python manage.py test` はこれらを省略できるため、通常テストの標準手順にはしない。
 
 ### GitHub Actions の隔離PR承認ゲート

--- a/scripts/run_live_smoke.py
+++ b/scripts/run_live_smoke.py
@@ -159,6 +159,9 @@ def build_execution(
     values = _load_profile_values(profile, environ, repo_root)
     child_env = {name: environ[name] for name in _SAFE_HOST_ENV if environ.get(name)}
     child_env["RUN_LIVE_SMOKE_TESTS"] = "1"
+    # settings 既定の遮断runnerを解除する。live smokeは実サービスへの疎通確認が目的で、
+    # 外向き通信を止めると全滅する（通常テストは既定のまま遮断される）。
+    child_env["ALLOW_EXTERNAL_TEST_NETWORK"] = "1"
     child_env.update(values)
 
     command = [
@@ -176,6 +179,8 @@ def build_execution(
         "--build",
         "-e",
         "RUN_LIVE_SMOKE_TESTS",
+        "-e",
+        "ALLOW_EXTERNAL_TEST_NETWORK",
     ]
 
     for name in profile.required_env:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,6 +3,7 @@
 # CI (.github/workflows/ci.yml) と同じ全探索で実行し、実行範囲のずれを防ぐ
 
 # 実疎通は明示モードに分離し、通常の引数あり実行にもoffline境界を適用する。
+# 遮断runnerの指定は settings (TEST_RUNNER) が正本なのでここではCLI指定しない。
 if [ "${1:-}" = "--live-smoke" ]; then
     shift
     python3 "$(dirname "$0")/run_live_smoke.py" "$@"
@@ -10,13 +11,11 @@ elif [ $# -gt 0 ]; then
     docker compose exec vrc-ta-hub python -m tests.offline_manage test "$@" \
         --exclude-tag=live_smoke \
         --exclude-tag=e2e \
-        --testrunner=website.tests.offline_runner.OfflineNetworkDiscoverRunner \
         --noinput
 else
     docker compose exec vrc-ta-hub python -m tests.offline_manage test \
         --exclude-tag=live_smoke \
         --exclude-tag=e2e \
-        --testrunner=website.tests.offline_runner.OfflineNetworkDiscoverRunner \
         --noinput \
         --verbosity=1
 fi

--- a/scripts/tests/test_run_live_smoke.py
+++ b/scripts/tests/test_run_live_smoke.py
@@ -74,6 +74,20 @@ class LiveSmokeExecutionTest(unittest.TestCase):
         self.assertTrue(any("test_generate_blog_video_and_pdf" in item for item in command))
         self.assertFalse(any("test_generate_blog_pdf_only" in item for item in command))
 
+    def test_external_network_is_allowed_in_the_live_smoke_container(self):
+        """settings 既定の遮断runnerを解除する環境変数がcontainerへ渡る。"""
+        environ = {**self.base_env, "OPENROUTER_API_KEY": "real-openrouter-secret"}
+
+        command, child_env = build_execution(
+            "openrouter",
+            (),
+            environ=environ,
+            repo_root=self.repo_root,
+        )
+
+        self.assertEqual(child_env["ALLOW_EXTERNAL_TEST_NETWORK"], "1")
+        self.assertIn("ALLOW_EXTERNAL_TEST_NETWORK", command)
+
     def test_env_file_reads_only_profile_allowlist(self):
         env_file = self.repo_root / ".env.local"
         env_file.write_text(

--- a/scripts/tests/test_run_tests.sh
+++ b/scripts/tests/test_run_tests.sh
@@ -37,7 +37,8 @@ export PATH="$TMP_DIR:$PATH"
 assert_contains "python -m tests.offline_manage test twitter.tests.test_x_api"
 assert_contains "--exclude-tag=live_smoke"
 assert_contains "--exclude-tag=e2e"
-assert_contains "--testrunner=website.tests.offline_runner.OfflineNetworkDiscoverRunner"
+# 遮断runnerは settings (TEST_RUNNER) が正本。CLI指定を復活させない。
+assert_not_contains "--testrunner="
 assert_not_contains "python manage.py test twitter.tests.test_x_api"
 
 : > "$CALLS_FILE"
@@ -45,7 +46,7 @@ OPENROUTER_API_KEY=real-openrouter-secret \
   "$REPO_ROOT/scripts/run_tests.sh" --live-smoke openrouter
 assert_contains "compose --project-name vrc-ta-hub-live-smoke"
 assert_contains "run --rm --no-deps --build"
-assert_contains "-e RUN_LIVE_SMOKE_TESTS -e OPENROUTER_API_KEY"
+assert_contains "-e RUN_LIVE_SMOKE_TESTS -e ALLOW_EXTERNAL_TEST_NETWORK -e OPENROUTER_API_KEY"
 assert_contains "live-smoke python manage.py test"
 assert_contains "--tag=live_smoke"
 assert_not_contains "tests.offline_manage"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"


### PR DESCRIPTION
## なぜこの変更が必要か

テストスイートをローカル（`.env.local` 読込の Docker 環境）で回すたびに、twitter の投稿失敗系テストがモック漏れにより実 `DISCORD_WEBHOOK_URL` へ「❌ X投稿に失敗しました」通知を実送信し、管理者 Discord に偽アラートが届いていた。GitHub CI は遮断ランナー + ダミー URL で白。発生源はローカル実行のみ（調査詳細は #547）。

## 変更内容

- twitter の投稿失敗系テスト2本（scheduled / 手動）に `@patch("twitter.notifications.requests.post")` を追加し、「失敗時に管理者通知が1回送られる」ことを振る舞いとして固定
- settings（テスト時分岐内）に `TEST_RUNNER = OfflineNetworkDiscoverRunner` を追加し、ローカルの素の `manage.py test` でも既定で外向き通信を遮断。`ALLOW_EXTERNAL_TEST_NETWORK=1` で解除可能（live smoke 用エスケープハッチ）
- live smoke 実行経路（`scripts/run_live_smoke.py`）に `ALLOW_EXTERNAL_TEST_NETWORK=1` を伝搬 + 回帰テスト追加
- `OfflineNetworkDiscoverRunner` に遮断イベント記録を追加。アプリ側 except で握りつぶされても suite 終了時に stderr レポート + 失敗扱い（+1）で非ゼロ終了し、将来のモック漏れを CI で自動検出
- CI test job の `--testrunner` CLI 指定・`scripts/run_tests.sh`・`docs/testing.md` を settings 正本に一本化。e2e job は標準ランナーを明示（Playwright への socket patch 影響を安全側に回避）

## 意思決定

### 採用アプローチ
- 遮断ランナーの正本を settings に置き、CLI 指定を全廃。理由: CLI 指定を忘れた素の `manage.py test` こそが今回の事故経路のため
- 遮断レポートは `filename:lineno in name` までに限定（ソース行の逐語出力は webhook URL リテラル混入時に CI ログへ漏れるため出さない）
- 失敗数への加算は件数でなく +1（遮断件数と失敗テスト数のセマンティクス混在を防止。件数は stderr レポートで判別）

### 却下した代替案
- テストのモック追加のみ（runner 既定化なし）→ 却下: 将来の新規テストで同じ漏れが再発する
- 遮断件数をそのまま失敗数に加算 → 却下: リトライで1漏れが10失敗に見える誤読

### トレードオフ
- 既定遮断の安全性 > live smoke の手軽さ: live smoke は専用スクリプト経由でエスケープハッチが自動付与されるため実質影響なし
- Django のメール Message-ID 生成が行う自ホスト名逆引き（`gethostbyaddr`）は許可（外向き POST ではなく、遮断すると全メール系テストが偽陽性で落ちるため）

### 技術的負債
- e2e job の Playwright × 遮断ランナー共存は未検証のため標準ランナーを明示（ci.yml にコメント）
- `scripts/` 配下の既存 ruff エラー6件（本 PR 対象外・CI 対象外）は未対応

## テスト

- [x] 全 suite（live_smoke/e2e 除外・遮断ランナー既定）: 1909 tests OK、遮断違反 0
- [x] `website.tests.test_offline_runner`: 15 tests OK（検出強化・レポート非漏洩の behavior テスト5本新規）
- [x] `scripts/tests/test_run_live_smoke.py` 12 tests OK（エスケープハッチ伝搬の回帰テスト新規）+ `test_run_tests.sh` PASS
- [x] 実地確認: モックを一時除去 → suite が EXIT=1 + stderr に `getaddrinfo: 'discord.com'` / `notifications.py:64` を出力（ソース行なし）、復元で EXIT=0
- [x] ruff 0.11.6（CI 同版）All checks passed

Closes #547

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default test execution and global socket patching for most suites; misconfiguration could block legitimate tests or leave E2E on a different runner path than unit tests.
> 
> **Overview**
> Prevents local test runs from hitting real Discord webhooks when mocks are missing, and makes outbound network blocking the default for all non–live-smoke tests.
> 
> **Default offline runner:** `TEST_RUNNER` is set in test settings to `OfflineNetworkDiscoverRunner` unless `ALLOW_EXTERNAL_TEST_NETWORK=1`. CI, `scripts/run_tests.sh`, and docs no longer pass `--testrunner` on the CLI so bare `manage.py test` matches CI. Live smoke sets `ALLOW_EXTERNAL_TEST_NETWORK=1` in the container env.
> 
> **Stronger detection:** The offline runner records blocked socket/DNS attempts, prints a stderr report (file:line only, no source lines), and fails the suite with +1 failure even when app code swallows connection errors. Own-hostname reverse DNS is allowed for Django mail; E2E explicitly uses Django’s standard `DiscoverRunner` to avoid Playwright/socket patch risk.
> 
> **Twitter tests:** Scheduled and manual post-failure tests now mock `twitter.notifications.requests.post` and assert one admin Discord notification to `DISCORD_WEBHOOK_URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7b3b8501ab52e4b52c783cdc2d145596103f01f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->