### PR TITLE
fix(cli): management command / scripts の失敗時 exit code とトークン露出を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,8 @@ local_settings.py
 .env
 .env.local
 .env.production.local
+# generate_x_token が書き出す X アクセストークン（0600）
+.x-token.env
 db.sqlite3
 test_db.sqlite3
 app/test_db.sqlite3

--- a/app/event/management/commands/sync_calendar.py
+++ b/app/event/management/commands/sync_calendar.py
@@ -1,22 +1,35 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.http import HttpRequest
+
 from event.views import sync_calendar_events
 from website.settings import REQUEST_TOKEN
+
+HTTP_OK = 200
+
 
 class Command(BaseCommand):
     help = 'Sync events from Google Calendar'
 
     def handle(self, *args, **options):
         self.stdout.write('Syncing calendar events...')
-        
+
         # Create a mock request
         request = HttpRequest()
         request.method = 'GET'
         request.headers = {'Request-Token': REQUEST_TOKEN}
-        
+
         # Call the sync function
         response = sync_calendar_events(request)
-        
-        # Output the result
-        self.stdout.write(self.style.SUCCESS(f'Sync completed. Status: {response.status_code}'))
-        self.stdout.write(response.content.decode('utf-8')) 
+        body = response.content.decode('utf-8')
+
+        # 非200は cron / Cloud Run Job 側で失敗検知できるよう異常終了させる。
+        # CommandError は stderr へ出力され exit code 1 になる（sync_analytics と同じ扱い）
+        if response.status_code != HTTP_OK:
+            raise CommandError(
+                f'Sync failed. Status: {response.status_code}. {body}'
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(f'Sync completed. Status: {response.status_code}')
+        )
+        self.stdout.write(body)

--- a/app/event/services/content_generation_service.py
+++ b/app/event/services/content_generation_service.py
@@ -11,6 +11,12 @@ from typing import Optional
 
 from googleapiclient.discovery import build
 from openai import OpenAI
+from openai.types.chat import (
+    ChatCompletionMessageParam,
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionToolParam,
+)
+from openai.types.shared_params import FunctionDefinition
 from pydantic import BaseModel, Field
 from pypdf import PdfReader
 from youtube_transcript_api import YouTubeTranscriptApi
@@ -233,26 +239,33 @@ def generate_blog(event_detail: EventDetail, model=None) -> BlogOutput:
 
         try:
             # BlogOutputスキーマを関数定義形式に変換
-            blog_output_schema = {
+            blog_output_schema: FunctionDefinition = {
                 "name": "generate_blog_post",
                 "description": "VRChatイベントの発表内容に基づいてブログ記事を生成する",
                 "parameters": BlogOutput.model_json_schema(),
-                "required": ["title", "meta_description", "text"]
+            }
+            messages: list[ChatCompletionMessageParam] = [
+                {"role": "system",
+                 "content": "あなたはVRChatの技術イベントに関するブログ記事を生成する専門のライターです。必ず指定されたJSON形式で出力してください。"},
+                {"role": "user", "content": prompt_text},
+            ]
+            tools: list[ChatCompletionToolParam] = [
+                {"type": "function", "function": blog_output_schema}
+            ]
+            tool_choice: ChatCompletionNamedToolChoiceParam = {
+                "type": "function",
+                "function": {"name": "generate_blog_post"},
             }
 
             # Function Callingを使用したリクエスト
             completion = client.chat.completions.create(
                 extra_headers=build_openrouter_extra_headers(),
                 model=model,
-                messages=[
-                    {"role": "system",
-                     "content": "あなたはVRChatの技術イベントに関するブログ記事を生成する専門のライターです。必ず指定されたJSON形式で出力してください。"},
-                    {"role": "user", "content": prompt_text}
-                ],
+                messages=messages,
                 temperature=0.3,  # 温度を下げて出力の安定性を向上
                 max_tokens=5000,
-                tools=[{"type": "function", "function": blog_output_schema}],
-                tool_choice={"type": "function", "function": {"name": "generate_blog_post"}}
+                tools=tools,
+                tool_choice=tool_choice,
             )
 
             # デバッグ用：APIリクエスト終了時刻とかかった時間を記録
@@ -300,6 +313,10 @@ def generate_blog(event_detail: EventDetail, model=None) -> BlogOutput:
 
             # レスポンスからテキストを取得（Function Calling未対応の場合のフォールバック）
             response_text = message.content
+            # content が空なら tool_calls も content も無い異常応答なので、後段で
+            # 曖昧に落ちる前にここで失敗させる
+            if not response_text:
+                raise ValueError("OpenRouter response has neither tool_calls nor content")
             logger.info(f"Raw response from OpenRouter:\n{response_text[:500]}...")
 
             # 以下はJSON抽出の既存コード

--- a/app/event/tests/test_sync_calendar_command.py
+++ b/app/event/tests/test_sync_calendar_command.py
@@ -1,0 +1,51 @@
+"""sync_calendar 管理コマンドの exit code 契約テスト。
+
+cron / Cloud Run Job から失敗を検知できるよう、同期 view が非200を返したら
+CommandError（exit code 1）で終了することを保証する。
+"""
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.http import HttpResponse
+from django.test import TestCase
+
+
+class SyncCalendarCommandTest(TestCase):
+    """sync_calendar コマンドのユニットテスト。"""
+
+    def _call(self):
+        out = StringIO()
+        err = StringIO()
+        call_command("sync_calendar", stdout=out, stderr=err)
+        return out.getvalue(), err.getvalue()
+
+    @patch("event.management.commands.sync_calendar.sync_calendar_events")
+    def test_success_writes_body_to_stdout(self, mock_sync):
+        """200 応答なら成功メッセージと body を stdout に出す。"""
+        mock_sync.return_value = HttpResponse("Sync OK", status=200)
+
+        out, _ = self._call()
+
+        self.assertIn("Sync completed. Status: 200", out)
+        self.assertIn("Sync OK", out)
+
+    @patch("event.management.commands.sync_calendar.sync_calendar_events")
+    def test_non_200_raises_command_error(self, mock_sync):
+        """非200応答なら CommandError で異常終了する（exit code 1）。"""
+        mock_sync.return_value = HttpResponse("Calendar API error", status=500)
+
+        with self.assertRaises(CommandError) as ctx:
+            self._call()
+
+        self.assertIn("Sync failed. Status: 500", str(ctx.exception))
+        self.assertIn("Calendar API error", str(ctx.exception))
+
+    @patch("event.management.commands.sync_calendar.sync_calendar_events")
+    def test_forbidden_response_raises_command_error(self, mock_sync):
+        """認証失敗(403)でも成功扱いしない。"""
+        mock_sync.return_value = HttpResponse("Invalid token", status=403)
+
+        with self.assertRaises(CommandError):
+            self._call()

--- a/app/twitter/management/commands/generate_x_token.py
+++ b/app/twitter/management/commands/generate_x_token.py
@@ -2,30 +2,49 @@
 
 使い方:
   docker compose exec vrc-ta-hub python manage.py generate_x_token
+
+取得したトークンは stdout に出さず、パーミッション 0600 のファイルへ書き出す
+（ターミナルのスクロールバック・CI ログ経由での秘密情報漏洩を防ぐため）。
 """
 
 import os
+from pathlib import Path
 
-from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
 from requests_oauthlib import OAuth1Session
 
 X_REQUEST_TOKEN_URL = "https://api.x.com/oauth/request_token"
 X_AUTHORIZE_URL = "https://api.x.com/oauth/authorize"
 X_ACCESS_TOKEN_URL = "https://api.x.com/oauth/access_token"
 
+# 秘密情報ファイルは所有者のみ読み書き可能にする
+TOKEN_FILE_MODE = 0o600
+DEFAULT_TOKEN_FILENAME = ".x-token.env"
+
 
 class Command(BaseCommand):
     help = "X API OAuth 1.0a でアクセストークンを取得する"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output",
+            dest="output",
+            default=None,
+            help=(
+                "トークンの書き出し先パス"
+                f"（省略時は BASE_DIR/{DEFAULT_TOKEN_FILENAME}）"
+            ),
+        )
 
     def handle(self, *args, **options):
         consumer_key = os.environ.get("X_API_KEY")
         consumer_secret = os.environ.get("X_API_SECRET")
 
         if not consumer_key or not consumer_secret:
-            self.stderr.write(self.style.ERROR(
+            raise CommandError(
                 "X_API_KEY と X_API_SECRET を .env.local に設定してください"
-            ))
-            return
+            )
 
         # Step 1: Request Token
         oauth = OAuth1Session(
@@ -34,10 +53,7 @@ class Command(BaseCommand):
         try:
             request_token = oauth.fetch_request_token(X_REQUEST_TOKEN_URL)
         except Exception as e:
-            self.stderr.write(self.style.ERROR(
-                f"Request Token の取得に失敗: {e}"
-            ))
-            return
+            raise CommandError(f"Request Token の取得に失敗: {e}")
 
         auth_url = oauth.authorization_url(X_AUTHORIZE_URL)
         self.stdout.write("")
@@ -51,8 +67,7 @@ class Command(BaseCommand):
 
         verifier = input("表示されたPINを入力してください: ").strip()
         if not verifier:
-            self.stderr.write(self.style.ERROR("PINが入力されませんでした"))
-            return
+            raise CommandError("PINが入力されませんでした")
 
         # Step 2: Access Token
         oauth = OAuth1Session(
@@ -65,10 +80,10 @@ class Command(BaseCommand):
         try:
             tokens = oauth.fetch_access_token(X_ACCESS_TOKEN_URL)
         except Exception as e:
-            self.stderr.write(self.style.ERROR(
-                f"Access Token の取得に失敗: {e}"
-            ))
-            return
+            raise CommandError(f"Access Token の取得に失敗: {e}")
+
+        output_path = self._resolve_output_path(options["output"])
+        self._write_token_file(output_path, tokens)
 
         screen_name = tokens.get("screen_name", "不明")
         self.stdout.write("")
@@ -78,6 +93,34 @@ class Command(BaseCommand):
         ))
         self.stdout.write(self.style.SUCCESS("=" * 60))
         self.stdout.write("")
-        self.stdout.write("以下を .env.local に追加してください:")
-        self.stdout.write(f"X_ACCESS_TOKEN={tokens['oauth_token']}")
-        self.stdout.write(f"X_ACCESS_TOKEN_SECRET={tokens['oauth_token_secret']}")
+        self.stdout.write(f"トークンを書き出しました: {output_path}")
+        self.stdout.write(
+            "ファイルの中身を .env.local に追記し、不要になったら削除してください"
+        )
+
+    def _resolve_output_path(self, output: str | None) -> Path:
+        if output:
+            return Path(output).expanduser()
+        return Path(settings.BASE_DIR) / DEFAULT_TOKEN_FILENAME
+
+    def _write_token_file(self, path: Path, tokens: dict) -> None:
+        """トークンを 0600 のファイルへ書き出す。
+
+        既存ファイルのパーミッションを引き継がないよう、書き込み前に
+        os.open(O_CREAT) のモード指定と chmod の両方で 0600 を保証する。
+        """
+        content = (
+            f"X_ACCESS_TOKEN={tokens['oauth_token']}\n"
+            f"X_ACCESS_TOKEN_SECRET={tokens['oauth_token_secret']}\n"
+        )
+        try:
+            fd = os.open(
+                path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                TOKEN_FILE_MODE,
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+            os.chmod(path, TOKEN_FILE_MODE)
+        except OSError as e:
+            raise CommandError(f"トークンの書き出しに失敗: {path}: {e}")

--- a/app/twitter/management/commands/generate_x_token.py
+++ b/app/twitter/management/commands/generate_x_token.py
@@ -8,6 +8,7 @@
 """
 
 import os
+import tempfile
 from pathlib import Path
 
 from django.conf import settings
@@ -104,23 +105,37 @@ class Command(BaseCommand):
         return Path(settings.BASE_DIR) / DEFAULT_TOKEN_FILENAME
 
     def _write_token_file(self, path: Path, tokens: dict) -> None:
-        """トークンを 0600 のファイルへ書き出す。
+        """トークンを 0600 のファイルへ atomic に書き出す。
 
-        既存ファイルのパーミッションを引き継がないよう、書き込み前に
-        os.open(O_CREAT) のモード指定と chmod の両方で 0600 を保証する。
+        同一ディレクトリに 0600 の一時ファイルを作って書き切ってから os.replace で
+        差し替える。これにより
+        - 平文トークンが一瞬でも緩いパーミッションのファイルに載らない
+          （既存ファイルが 0644 でも、書き込み中の中身は一時ファイル側にある）
+        - 書き込み途中で失敗しても既存のトークンファイルを壊さない
+        の両方を満たす。
         """
         content = (
             f"X_ACCESS_TOKEN={tokens['oauth_token']}\n"
             f"X_ACCESS_TOKEN_SECRET={tokens['oauth_token_secret']}\n"
         )
+        tmp_fd, tmp_name = None, None
         try:
-            fd = os.open(
-                path,
-                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                TOKEN_FILE_MODE,
+            tmp_fd, tmp_name = tempfile.mkstemp(
+                dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
             )
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
+            # mkstemp は 0600 で作るが、環境差異に依存しないよう明示する
+            os.fchmod(tmp_fd, TOKEN_FILE_MODE)
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                tmp_fd = None  # fd の所有権は file object へ移る
                 f.write(content)
-            os.chmod(path, TOKEN_FILE_MODE)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_name, path)
+            tmp_name = None
         except OSError as e:
             raise CommandError(f"トークンの書き出しに失敗: {path}: {e}")
+        finally:
+            if tmp_fd is not None:
+                os.close(tmp_fd)
+            if tmp_name is not None and os.path.exists(tmp_name):
+                os.unlink(tmp_name)

--- a/app/twitter/management/commands/regenerate_ready_tweets.py
+++ b/app/twitter/management/commands/regenerate_ready_tweets.py
@@ -6,7 +6,7 @@ X のスパムフィルタを避ける「本文3行以内」制約は以降の�
 """
 import logging
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from twitter.models import TweetQueue
 from twitter.tweet_generator import (
@@ -163,10 +163,15 @@ class Command(BaseCommand):
             else:
                 self.stdout.write(f"  {prefix} -> 新weighted={new_weighted} 新行数={new_lines} (OK)")
 
-        self.stdout.write("")
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"完了: 更新={updated} 件, 失敗={failed} 件, "
-                f"再生成後も制約超過={still_over_limit} 件"
-            )
+        summary = (
+            f"更新={updated} 件, 失敗={failed} 件, "
+            f"再生成後も制約超過={still_over_limit} 件"
         )
+        self.stdout.write("")
+
+        # 1件でも再生成に失敗したら異常終了させる。
+        # cron / 手動実行のどちらでも「一部だけ失敗」を見落とさないため。
+        if failed:
+            raise CommandError(f"再生成に失敗したキューがある: {summary}")
+
+        self.stdout.write(self.style.SUCCESS(f"完了: {summary}"))

--- a/app/twitter/tests/test_generate_x_token.py
+++ b/app/twitter/tests/test_generate_x_token.py
@@ -177,10 +177,15 @@ class GenerateXTokenCommandTest(TestCase):
     @patch(
         "twitter.management.commands.generate_x_token.OAuth1Session"
     )
-    def test_existing_file_permissions_are_tightened(self, mock_session_cls, mock_input):
-        """既存ファイルが緩いパーミッションでも 0600 に強制される。"""
+    def test_existing_0644_file_is_replaced_not_written_in_place(self, mock_session_cls, mock_input):
+        """既存 0644 ファイルへ書き込まず、0600 の別 inode に差し替えること。
+
+        in-place 書き込みだと chmod するまでの間トークンが他ユーザーから読めるため、
+        「同じ inode を書き換えていない」ことまで確認する。
+        """
         self.output_path.write_text("stale", encoding="utf-8")
         os.chmod(self.output_path, 0o644)
+        old_inode = os.stat(self.output_path).st_ino
 
         mock_session_cls.side_effect = self._mock_oauth_sessions({
             "oauth_token": "token-no-name",
@@ -190,6 +195,56 @@ class GenerateXTokenCommandTest(TestCase):
         out, _ = self._call_command()
 
         self.assertIn("認証成功", out)
-        mode = stat.S_IMODE(os.stat(self.output_path).st_mode)
-        self.assertEqual(mode, 0o600)
         self.assertNotIn("token-no-name", out)
+        new_stat = os.stat(self.output_path)
+        self.assertEqual(stat.S_IMODE(new_stat.st_mode), 0o600)
+        self.assertNotEqual(new_stat.st_ino, old_inode)
+        self.assertIn(
+            "X_ACCESS_TOKEN=token-no-name",
+            self.output_path.read_text(encoding="utf-8"),
+        )
+
+    @patch.dict("os.environ", OAUTH1_ENV, clear=False)
+    @patch("builtins.input", return_value="654321")
+    @patch(
+        "twitter.management.commands.generate_x_token.OAuth1Session"
+    )
+    def test_write_failure_keeps_existing_token_file(self, mock_session_cls, mock_input):
+        """書き出しに失敗しても既存トークンファイルを壊さない。"""
+        self.output_path.write_text("X_ACCESS_TOKEN=previous\n", encoding="utf-8")
+        os.chmod(self.output_path, 0o600)
+
+        mock_session_cls.side_effect = self._mock_oauth_sessions({
+            "oauth_token": "new-token",
+            "oauth_token_secret": "new-secret",
+        })
+
+        with patch("os.replace", side_effect=OSError("disk full")):
+            with self.assertRaises(CommandError) as ctx:
+                self._call_command()
+
+        self.assertIn("トークンの書き出しに失敗", str(ctx.exception))
+        self.assertEqual(
+            self.output_path.read_text(encoding="utf-8"),
+            "X_ACCESS_TOKEN=previous\n",
+        )
+        self.assertNotIn("new-token", self.output_path.read_text(encoding="utf-8"))
+
+    @patch.dict("os.environ", OAUTH1_ENV, clear=False)
+    @patch("builtins.input", return_value="654321")
+    @patch(
+        "twitter.management.commands.generate_x_token.OAuth1Session"
+    )
+    def test_write_failure_does_not_leave_temp_file(self, mock_session_cls, mock_input):
+        """失敗時に平文トークンを含む一時ファイルを残さない。"""
+        mock_session_cls.side_effect = self._mock_oauth_sessions({
+            "oauth_token": "leaked-token",
+            "oauth_token_secret": "leaked-secret",
+        })
+
+        with patch("os.replace", side_effect=OSError("disk full")):
+            with self.assertRaises(CommandError):
+                self._call_command()
+
+        leftovers = list(Path(self._tmpdir.name).iterdir())
+        self.assertEqual(leftovers, [], f"一時ファイルが残っている: {leftovers}")

--- a/app/twitter/tests/test_generate_x_token.py
+++ b/app/twitter/tests/test_generate_x_token.py
@@ -1,12 +1,19 @@
 """generate_x_token 管理コマンドのテスト（OAuth 1.0a PINフロー）。
 
 OAuth フロー全体は外部API依存のため、各ステップをモックしてテストする。
+失敗時は CommandError（exit code 1）で終了し、成功時もトークン値を
+stdout に出さず 0600 のファイルへ書き出すことを検証する。
 """
 
+import os
+import stat
+import tempfile
 from io import StringIO
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase
 
 
@@ -18,71 +25,97 @@ class GenerateXTokenCommandTest(TestCase):
         "X_API_SECRET": "test-api-secret",
     }
 
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.output_path = Path(self._tmpdir.name) / "x-token.env"
+
     def _call_command(self, **kwargs):
         """コマンドを呼び出し、stdout/stderr を返す。"""
         out = StringIO()
         err = StringIO()
+        kwargs.setdefault("output", str(self.output_path))
         call_command("generate_x_token", stdout=out, stderr=err, **kwargs)
         return out.getvalue(), err.getvalue()
+
+    def _mock_oauth_sessions(self, access_tokens):
+        """Request Token / Access Token 用のセッションモックを返す。"""
+        request_session = MagicMock()
+        request_session.fetch_request_token.return_value = {
+            "oauth_token": "req-token",
+            "oauth_token_secret": "req-secret",
+        }
+        request_session.authorization_url.return_value = (
+            "https://api.x.com/oauth/authorize?oauth_token=req-token"
+        )
+
+        access_session = MagicMock()
+        access_session.fetch_access_token.return_value = access_tokens
+        return [request_session, access_session]
 
     @patch.dict(
         "os.environ", {"X_API_KEY": "", "X_API_SECRET": ""}, clear=False
     )
-    def test_missing_credentials_shows_error(self):
-        """API Key/Secret が未設定の場合、エラーメッセージを出力する。"""
-        _, err = self._call_command()
-        self.assertIn("X_API_KEY", err)
-        self.assertIn("X_API_SECRET", err)
+    def test_missing_credentials_raises_command_error(self):
+        """API Key/Secret が未設定なら CommandError で異常終了する。"""
+        with self.assertRaises(CommandError) as ctx:
+            self._call_command()
+        self.assertIn("X_API_KEY", str(ctx.exception))
+        self.assertIn("X_API_SECRET", str(ctx.exception))
 
     @patch.dict("os.environ", OAUTH1_ENV, clear=False)
     @patch(
         "twitter.management.commands.generate_x_token.OAuth1Session"
     )
-    def test_request_token_failure_shows_error(self, mock_session_cls):
-        """Request Token 取得失敗時にエラーメッセージを出力する。"""
+    def test_request_token_failure_raises_command_error(self, mock_session_cls):
+        """Request Token 取得失敗時に CommandError で異常終了する。"""
         mock_session = MagicMock()
         mock_session.fetch_request_token.side_effect = Exception(
             "Request token failed"
         )
         mock_session_cls.return_value = mock_session
 
-        _, err = self._call_command()
-        self.assertIn("Request Token の取得に失敗", err)
+        with self.assertRaises(CommandError) as ctx:
+            self._call_command()
+        self.assertIn("Request Token の取得に失敗", str(ctx.exception))
 
     @patch.dict("os.environ", OAUTH1_ENV, clear=False)
     @patch("builtins.input", return_value="")
     @patch(
         "twitter.management.commands.generate_x_token.OAuth1Session"
     )
-    def test_empty_pin_shows_error(self, mock_session_cls, mock_input):
-        """PINが空の場合にエラーメッセージを出力する。"""
+    def test_empty_pin_raises_command_error(self, mock_session_cls, mock_input):
+        """PINが空なら CommandError で異常終了する。"""
         mock_session = MagicMock()
         mock_session.fetch_request_token.return_value = {
             "oauth_token": "req-token",
             "oauth_token_secret": "req-secret",
         }
-        mock_session.authorization_url.return_value = "https://api.x.com/oauth/authorize?oauth_token=req-token"
+        mock_session.authorization_url.return_value = (
+            "https://api.x.com/oauth/authorize?oauth_token=req-token"
+        )
         mock_session_cls.return_value = mock_session
 
-        _, err = self._call_command()
-        self.assertIn("PINが入力されませんでした", err)
+        with self.assertRaises(CommandError) as ctx:
+            self._call_command()
+        self.assertIn("PINが入力されませんでした", str(ctx.exception))
 
     @patch.dict("os.environ", OAUTH1_ENV, clear=False)
     @patch("builtins.input", return_value="123456")
     @patch(
         "twitter.management.commands.generate_x_token.OAuth1Session"
     )
-    def test_access_token_failure_shows_error(self, mock_session_cls, mock_input):
-        """Access Token 取得失敗時にエラーメッセージを出力する。"""
-        # 1回目: Request Token 取得用セッション
+    def test_access_token_failure_raises_command_error(self, mock_session_cls, mock_input):
+        """Access Token 取得失敗時に CommandError で異常終了する。"""
         request_session = MagicMock()
         request_session.fetch_request_token.return_value = {
             "oauth_token": "req-token",
             "oauth_token_secret": "req-secret",
         }
-        request_session.authorization_url.return_value = "https://api.x.com/oauth/authorize?oauth_token=req-token"
+        request_session.authorization_url.return_value = (
+            "https://api.x.com/oauth/authorize?oauth_token=req-token"
+        )
 
-        # 2回目: Access Token 取得用セッション
         access_session = MagicMock()
         access_session.fetch_access_token.side_effect = Exception(
             "Access token failed"
@@ -90,65 +123,73 @@ class GenerateXTokenCommandTest(TestCase):
 
         mock_session_cls.side_effect = [request_session, access_session]
 
-        _, err = self._call_command()
-        self.assertIn("Access Token の取得に失敗", err)
+        with self.assertRaises(CommandError) as ctx:
+            self._call_command()
+        self.assertIn("Access Token の取得に失敗", str(ctx.exception))
 
     @patch.dict("os.environ", OAUTH1_ENV, clear=False)
     @patch("builtins.input", return_value="654321")
     @patch(
         "twitter.management.commands.generate_x_token.OAuth1Session"
     )
-    def test_successful_flow_outputs_tokens(self, mock_session_cls, mock_input):
-        """正常フローでトークンが標準出力に表示される。"""
-        # 1回目: Request Token 取得用セッション
-        request_session = MagicMock()
-        request_session.fetch_request_token.return_value = {
-            "oauth_token": "req-token",
-            "oauth_token_secret": "req-secret",
-        }
-        request_session.authorization_url.return_value = "https://api.x.com/oauth/authorize?oauth_token=req-token"
-
-        # 2回目: Access Token 取得用セッション
-        access_session = MagicMock()
-        access_session.fetch_access_token.return_value = {
+    def test_successful_flow_does_not_print_tokens(self, mock_session_cls, mock_input):
+        """正常フローでトークン値が stdout/stderr に出ないこと。"""
+        mock_session_cls.side_effect = self._mock_oauth_sessions({
             "oauth_token": "access-token-123",
             "oauth_token_secret": "access-secret-456",
             "screen_name": "vrc_ta_hub",
-        }
+        })
 
-        mock_session_cls.side_effect = [request_session, access_session]
-
-        out, _ = self._call_command()
+        out, err = self._call_command()
 
         self.assertIn("@vrc_ta_hub", out)
         self.assertIn("認証成功", out)
-        self.assertIn("X_ACCESS_TOKEN=access-token-123", out)
-        self.assertIn("X_ACCESS_TOKEN_SECRET=access-secret-456", out)
+        self.assertNotIn("access-token-123", out)
+        self.assertNotIn("access-secret-456", out)
+        self.assertNotIn("access-token-123", err)
+        self.assertNotIn("access-secret-456", err)
+        self.assertIn(str(self.output_path), out)
 
     @patch.dict("os.environ", OAUTH1_ENV, clear=False)
     @patch("builtins.input", return_value="654321")
     @patch(
         "twitter.management.commands.generate_x_token.OAuth1Session"
     )
-    def test_successful_flow_without_screen_name(self, mock_session_cls, mock_input):
-        """screen_name がレスポンスにない場合でもトークンが出力される。"""
-        request_session = MagicMock()
-        request_session.fetch_request_token.return_value = {
-            "oauth_token": "req-token",
-            "oauth_token_secret": "req-secret",
-        }
-        request_session.authorization_url.return_value = "https://api.x.com/oauth/authorize?oauth_token=req-token"
+    def test_successful_flow_writes_token_file_with_0600(self, mock_session_cls, mock_input):
+        """トークンは 0600 のファイルへ書き出される。"""
+        mock_session_cls.side_effect = self._mock_oauth_sessions({
+            "oauth_token": "access-token-123",
+            "oauth_token_secret": "access-secret-456",
+            "screen_name": "vrc_ta_hub",
+        })
 
-        access_session = MagicMock()
-        access_session.fetch_access_token.return_value = {
+        self._call_command()
+
+        content = self.output_path.read_text(encoding="utf-8")
+        self.assertIn("X_ACCESS_TOKEN=access-token-123", content)
+        self.assertIn("X_ACCESS_TOKEN_SECRET=access-secret-456", content)
+
+        mode = stat.S_IMODE(os.stat(self.output_path).st_mode)
+        self.assertEqual(mode, 0o600)
+
+    @patch.dict("os.environ", OAUTH1_ENV, clear=False)
+    @patch("builtins.input", return_value="654321")
+    @patch(
+        "twitter.management.commands.generate_x_token.OAuth1Session"
+    )
+    def test_existing_file_permissions_are_tightened(self, mock_session_cls, mock_input):
+        """既存ファイルが緩いパーミッションでも 0600 に強制される。"""
+        self.output_path.write_text("stale", encoding="utf-8")
+        os.chmod(self.output_path, 0o644)
+
+        mock_session_cls.side_effect = self._mock_oauth_sessions({
             "oauth_token": "token-no-name",
             "oauth_token_secret": "secret-no-name",
-        }
-
-        mock_session_cls.side_effect = [request_session, access_session]
+        })
 
         out, _ = self._call_command()
 
         self.assertIn("認証成功", out)
-        self.assertIn("X_ACCESS_TOKEN=token-no-name", out)
-        self.assertIn("X_ACCESS_TOKEN_SECRET=secret-no-name", out)
+        mode = stat.S_IMODE(os.stat(self.output_path).st_mode)
+        self.assertEqual(mode, 0o600)
+        self.assertNotIn("token-no-name", out)

--- a/app/twitter/tests/test_regenerate_ready_tweets.py
+++ b/app/twitter/tests/test_regenerate_ready_tweets.py
@@ -9,6 +9,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase, override_settings
 
 from community.models import Community
@@ -45,6 +46,13 @@ class RegenerateReadyTweetsCommandTest(TestCase):
         out = StringIO()
         call_command("regenerate_ready_tweets", *args, stdout=out)
         return out.getvalue()
+
+    def _call_expecting_failure(self, *args):
+        """失敗時に CommandError（exit code 1）で終わることを前提に呼ぶ。"""
+        out = StringIO()
+        with self.assertRaises(CommandError) as ctx:
+            call_command("regenerate_ready_tweets", *args, stdout=out)
+        return str(ctx.exception)
 
     def test_dry_run_does_not_update_db(self):
         """--dry-run では DB が更新されない"""
@@ -128,11 +136,11 @@ class RegenerateReadyTweetsCommandTest(TestCase):
 
         with patch("twitter.management.commands.regenerate_ready_tweets.get_generator") as mock_get:
             mock_get.return_value = lambda qi: None
-            output = self._call()
+            message = self._call_expecting_failure()
 
         item.refresh_from_db()
         self.assertEqual(item.generated_text, over_limit)
-        self.assertIn("失敗=1", output)
+        self.assertIn("失敗=1", message)
 
     def test_unknown_tweet_type_is_skipped(self):
         """get_generator が None を返した場合はスキップし失敗扱いになる"""
@@ -141,11 +149,11 @@ class RegenerateReadyTweetsCommandTest(TestCase):
 
         with patch("twitter.management.commands.regenerate_ready_tweets.get_generator") as mock_get:
             mock_get.return_value = None
-            output = self._call()
+            message = self._call_expecting_failure()
 
         item.refresh_from_db()
         self.assertEqual(item.generated_text, over_limit)
-        self.assertIn("失敗=1", output)
+        self.assertIn("失敗=1", message)
 
     def test_non_ready_queues_are_ignored(self):
         """ready 以外の status は対象外"""
@@ -208,3 +216,51 @@ class RegenerateReadyTweetsCommandTest(TestCase):
 
         item.refresh_from_db()
         self.assertEqual(item.status, "ready")
+
+    def test_generator_exception_raises_command_error(self):
+        """生成関数が例外を投げた場合も CommandError で異常終了する"""
+        over_limit = "行1\n行2\n行3\n行4\nhttps://example.com"
+        item = self._create_queue(over_limit)
+
+        def _raise(_queue_item):
+            raise RuntimeError("LLM error")
+
+        with patch("twitter.management.commands.regenerate_ready_tweets.get_generator") as mock_get:
+            mock_get.return_value = _raise
+            message = self._call_expecting_failure()
+
+        item.refresh_from_db()
+        self.assertEqual(item.generated_text, over_limit)
+        self.assertIn("失敗=1", message)
+
+    def test_partial_failure_still_raises_command_error(self):
+        """一部だけ失敗した場合も見逃さず異常終了する"""
+        over_limit = "行1\n行2\n行3\n行4\nhttps://example.com"
+        ok_item = self._create_queue(over_limit)
+        ng_item = self._create_queue(over_limit)
+        new_text = "新A\n新B\nhttps://example.com"
+
+        def _generator(queue_item):
+            return None if queue_item.pk == ng_item.pk else new_text
+
+        with patch("twitter.management.commands.regenerate_ready_tweets.get_generator") as mock_get:
+            mock_get.return_value = _generator
+            message = self._call_expecting_failure()
+
+        ok_item.refresh_from_db()
+        ng_item.refresh_from_db()
+        self.assertEqual(ok_item.generated_text, new_text)
+        self.assertEqual(ng_item.generated_text, over_limit)
+        self.assertIn("更新=1", message)
+        self.assertIn("失敗=1", message)
+
+    def test_all_success_does_not_raise(self):
+        """全件成功なら正常終了し、完了メッセージを出す"""
+        over_limit = "行1\n行2\n行3\n行4\nhttps://example.com"
+        self._create_queue(over_limit)
+
+        with patch("twitter.management.commands.regenerate_ready_tweets.get_generator") as mock_get:
+            mock_get.return_value = lambda qi: "新A\n新B\nhttps://example.com"
+            output = self._call()
+
+        self.assertIn("完了: 更新=1 件, 失敗=0 件", output)

--- a/app/website/tests/test_script_exit_codes.py
+++ b/app/website/tests/test_script_exit_codes.py
@@ -1,0 +1,188 @@
+"""scripts/*.py の exit code 契約テスト。
+
+cron / 手動実行のどちらでも失敗を検知できるよう、単発メンテナンススクリプトが
+- `main()` の戻り値を `sys.exit()` に渡す（失敗時 exit 1）
+- 進捗・診断を print ではなく logging に出す
+- import しただけでは django.setup() が走らない（テスト可能性の担保）
+ことを検証する。実処理は DB 状態に依存するため、代表的な失敗パスのみ
+実際に import して戻り値を確認する。
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, TestCase
+
+# app/website/tests/ から見たリポジトリルート
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+# exit code 契約の対象スクリプト（Django の単発メンテナンス用）
+TARGET_SCRIPTS = (
+    "check_event_schedule.py",
+    "create_activity_posts.py",
+    "create_update_post.py",
+    "create_vket_posts.py",
+    "fix_h1_duplicates.py",
+    "fix_inner_h1_tags.py",
+)
+
+
+def _parse(script_name: str) -> ast.Module:
+    return ast.parse((SCRIPTS_DIR / script_name).read_text(encoding="utf-8"))
+
+
+def _main_guard_body(tree: ast.Module) -> list[ast.stmt]:
+    """`if __name__ == '__main__':` ブロックの本体を返す。"""
+    for node in tree.body:
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if (
+            isinstance(test, ast.Compare)
+            and isinstance(test.left, ast.Name)
+            and test.left.id == "__name__"
+        ):
+            return node.body
+    return []
+
+
+class ScriptExitCodeContractTest(SimpleTestCase):
+    """静的解析で exit code 契約を検証する。"""
+
+    def test_scripts_exist(self):
+        for name in TARGET_SCRIPTS:
+            self.assertTrue((SCRIPTS_DIR / name).exists(), name)
+
+    def test_main_guard_exits_with_main_return_value(self):
+        """`sys.exit(main())` で main() の戻り値を exit code にすること。"""
+        for name in TARGET_SCRIPTS:
+            with self.subTest(script=name):
+                body = _main_guard_body(_parse(name))
+                self.assertTrue(body, f"{name}: __main__ ガードがない")
+
+                exits = [
+                    node
+                    for node in ast.walk(ast.Module(body=body, type_ignores=[]))
+                    if isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "exit"
+                ]
+                self.assertTrue(exits, f"{name}: sys.exit(...) がない")
+
+                arg_sources = [
+                    ast.dump(call.args[0]) for call in exits if call.args
+                ]
+                self.assertTrue(
+                    any("'main'" in src for src in arg_sources),
+                    f"{name}: sys.exit(main()) になっていない",
+                )
+
+    def test_scripts_define_main_function(self):
+        for name in TARGET_SCRIPTS:
+            with self.subTest(script=name):
+                names = [
+                    node.name
+                    for node in _parse(name).body
+                    if isinstance(node, ast.FunctionDef)
+                ]
+                self.assertIn("main", names, f"{name}: main() がない")
+
+    def test_scripts_do_not_use_print(self):
+        """診断出力は logging に統一する（print は stdout を汚す）。"""
+        for name in TARGET_SCRIPTS:
+            with self.subTest(script=name):
+                prints = [
+                    node
+                    for node in ast.walk(_parse(name))
+                    if isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "print"
+                ]
+                self.assertEqual(prints, [], f"{name}: print が残っている")
+
+    def test_scripts_do_not_call_django_setup_at_import_time(self):
+        """import 時の副作用禁止（テストから import できるようにする）。"""
+        for name in TARGET_SCRIPTS:
+            with self.subTest(script=name):
+                calls = [
+                    node
+                    for node in _parse(name).body
+                    if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)
+                ]
+                self.assertEqual(
+                    calls, [], f"{name}: モジュールトップレベルで関数を呼んでいる"
+                )
+
+
+def _load_script(script_name: str):
+    """scripts/ を sys.path に載せてスクリプトを import する。"""
+    scripts_dir = str(SCRIPTS_DIR)
+    inserted = scripts_dir not in sys.path
+    if inserted:
+        sys.path.insert(0, scripts_dir)
+    try:
+        module_name = f"_vrc537_{Path(script_name).stem}"
+        spec = importlib.util.spec_from_file_location(
+            module_name, SCRIPTS_DIR / script_name
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if inserted:
+            sys.path.remove(scripts_dir)
+
+
+class ScriptFailurePathTest(TestCase):
+    """代表的な失敗パスが exit code 1 を返すことを実際に確認する。"""
+
+    def _delete_categories(self):
+        """カテゴリ不在（= 前提条件が崩れた状態）を作る。"""
+        from news.models import Category, Post
+
+        # Post.category は PROTECT なので、記事を消してからカテゴリを消す
+        Post.objects.all().delete()
+        Category.objects.all().delete()
+
+    def test_create_update_post_returns_1_when_category_missing(self):
+        self._delete_categories()
+        module = _load_script("create_update_post.py")
+        self.assertEqual(module.create_update_post(), 1)
+
+    def test_create_vket_posts_returns_1_when_category_missing(self):
+        self._delete_categories()
+        module = _load_script("create_vket_posts.py")
+        self.assertEqual(module.create_vket_posts(), 1)
+
+    def test_create_activity_posts_returns_1_when_category_missing(self):
+        self._delete_categories()
+        module = _load_script("create_activity_posts.py")
+        self.assertEqual(module.create_activity_posts(), 1)
+
+    def test_create_vket_posts_returns_1_when_fixture_missing(self):
+        """fixture が見つからない場合も失敗として扱う。"""
+        module = _load_script("create_vket_posts.py")
+        with patch.object(module, "app_dir", return_value=Path("/nonexistent")):
+            self.assertEqual(module.create_vket_posts(), 1)
+
+    def test_create_update_post_returns_1_when_fixture_missing(self):
+        module = _load_script("create_update_post.py")
+        with patch.object(module, "app_dir", return_value=Path("/nonexistent")):
+            self.assertEqual(module.create_update_post(), 1)
+
+    def test_check_event_schedule_returns_0_without_duplicates(self):
+        module = _load_script("check_event_schedule.py")
+        self.assertEqual(module.check_event_schedule(), 0)
+
+    def test_fix_h1_duplicates_returns_0_on_empty_db(self):
+        module = _load_script("fix_h1_duplicates.py")
+        self.assertEqual(module.fix_h1_duplicates(), 0)
+
+    def test_fix_inner_h1_tags_returns_0_on_empty_db(self):
+        module = _load_script("fix_inner_h1_tags.py")
+        self.assertEqual(module.fix_inner_h1_tags(), 0)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,9 @@ services:
       # website.tests.test_ci_workflow が PROJECT_ROOT/.github/workflows/ci.yml を
       # 静的検証するため、コンテナからも参照できるようにする
       - ./.github:/.github:ro
+      # website.tests.test_script_exit_codes が PROJECT_ROOT/scripts の exit code 契約を
+      # 検証するため、コンテナからも参照できるようにする
+      - ./scripts:/scripts:ro
       # coverage 設定 (docs/coverage.md 参照)。コンテナ内で coverage コマンドを
       # 実行する際に `--rcfile=/pyproject.toml` で参照する
       - ./pyproject.toml:/pyproject.toml:ro

--- a/requirements.lock
+++ b/requirements.lock
@@ -297,15 +297,22 @@ tqdm==4.68.2
     # via
     #   google-generativeai
     #   openai
+types-bleach==6.4.0.20260607
+    # via -r requirements.txt
+types-html5lib==1.1.11.20260518
+    # via types-bleach
+types-markdown==3.10.2.20260712
+    # via -r requirements.txt
 types-pyyaml==6.0.12.20260518
     # via
     #   django-stubs
     #   djangorestframework-stubs
 types-requests==2.33.0.20260518
     # via djangorestframework-stubs
+types-webencodings==0.5.0.20260408
+    # via types-html5lib
 typing-extensions==4.15.0
     # via
-    #   anyio
     #   django-stubs
     #   django-stubs-ext
     #   djangorestframework-stubs
@@ -315,7 +322,6 @@ typing-extensions==4.15.0
     #   openai
     #   pydantic
     #   pydantic-core
-    #   referencing
 uritemplate==4.2.0
     # via
     #   drf-spectacular

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,5 +38,8 @@ structlog==25.1.0
 mypy==1.14.1
 django-stubs==5.1.2
 djangorestframework-stubs==3.15.2
+# mypy 用の型スタブ（bleach / markdown 本体には型情報が同梱されていない）
+types-bleach==6.4.0.20260607
+types-Markdown==3.10.2.20260712
 sentry-sdk[django]==2.21.0
 cryptography==48.0.0

--- a/scripts/_script_bootstrap.py
+++ b/scripts/_script_bootstrap.py
@@ -1,0 +1,41 @@
+"""ad-hoc スクリプト用の Django セットアップと logging 初期化。
+
+各スクリプトが同じ bootstrap を共有することで、
+「import 時に django.setup() が走ってテストから import できない」問題を避ける。
+setup_django() は main() から呼ぶ前提で、import 時には副作用を持たせない。
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+# コンテナでは /app に app/ がマウントされる。ローカル実行では repo/app を使う。
+DOCKER_APP_DIR = Path("/app")
+LOCAL_APP_DIR = Path(__file__).resolve().parent.parent / "app"
+DEFAULT_SETTINGS_MODULE = "website.settings"
+
+
+def app_dir() -> Path:
+    """Django プロジェクトルート（manage.py のあるディレクトリ）を返す。"""
+    if (DOCKER_APP_DIR / "manage.py").exists():
+        return DOCKER_APP_DIR
+    return LOCAL_APP_DIR
+
+
+def setup_django(settings_module: str = DEFAULT_SETTINGS_MODULE) -> None:
+    """logging を初期化し Django をセットアップする。"""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
+    target = str(app_dir())
+    if target not in sys.path:
+        sys.path.insert(0, target)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)
+
+    import django
+
+    django.setup()

--- a/scripts/check_event_schedule.py
+++ b/scripts/check_event_schedule.py
@@ -1,50 +1,75 @@
 #!/usr/bin/env python
-"""30日間のイベントスケジュールを確認するスクリプト"""
-import os
+"""30日間のイベントスケジュールを確認するスクリプト
+
+重複イベントを検出したら非ゼロ終了し、自動化から異常を検知できるようにする。
+"""
+from __future__ import annotations
+
+import logging
 import sys
-import django
+from collections import Counter
 from datetime import timedelta
 
-sys.path.append('/app/website')
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
-django.setup()
+from _script_bootstrap import setup_django
 
-from event.models import Event
-from django.utils import timezone
+logger = logging.getLogger(__name__)
 
-# 特定の日付範囲でイベントを確認
-today = timezone.now().date()
-end_date = today + timedelta(days=30)
+CHECK_DAYS = 30
 
-print(f'今日から30日間のイベントを確認 ({today} - {end_date})')
-print('-' * 60)
 
-events = Event.objects.filter(
-    date__gte=today,
-    date__lte=end_date
-).order_by('date', 'start_time', 'community__name')
+def check_event_schedule() -> int:
+    """今日から30日間のイベントを表示し、重複があれば exit code 1 を返す。"""
+    from django.utils import timezone
 
-current_date = None
-for event in events:
-    if event.date != current_date:
-        current_date = event.date
-        print(f'\n{current_date} ({current_date.strftime("%A")}):')
-    
-    master_info = ''
-    if event.is_recurring_master:
-        master_info = ' [MASTER]'
-    elif event.recurring_master:
-        master_info = f' [Instance of #{event.recurring_master_id}]'
-    
-    print(f'  {event.start_time} - {event.community.name}{master_info}')
+    from event.models import Event
 
-print(f'\n合計: {events.count()}件')
+    today = timezone.now().date()
+    end_date = today + timedelta(days=CHECK_DAYS)
 
-# 重複チェック
-from collections import Counter
-event_keys = [(e.community.name, e.date, e.start_time) for e in events]
-duplicates = [k for k, v in Counter(event_keys).items() if v > 1]
-print(f'\n重複イベント: {len(duplicates)}件')
-if duplicates:
+    logger.info("今日から%d日間のイベントを確認 (%s - %s)", CHECK_DAYS, today, end_date)
+
+    events = Event.objects.filter(
+        date__gte=today,
+        date__lte=end_date
+    ).order_by('date', 'start_time', 'community__name')
+
+    current_date = None
+    for event in events:
+        if event.date != current_date:
+            current_date = event.date
+            logger.info("%s (%s):", current_date, current_date.strftime("%A"))
+
+        master_info = ''
+        if event.is_recurring_master:
+            master_info = ' [MASTER]'
+        elif event.recurring_master:
+            master_info = f' [Instance of #{event.recurring_master_id}]'
+
+        logger.info("  %s - %s%s", event.start_time, event.community.name, master_info)
+
+    logger.info("合計: %d件", events.count())
+
+    # 重複チェック
+    event_keys = [(e.community.name, e.date, e.start_time) for e in events]
+    duplicates = [k for k, v in Counter(event_keys).items() if v > 1]
+    if not duplicates:
+        logger.info("重複イベント: 0件")
+        return 0
+
+    logger.error("重複イベント: %d件", len(duplicates))
     for dup in duplicates:
-        print(f'  - {dup[0]} on {dup[1]} at {dup[2]}')
+        logger.error("  - %s on %s at %s", dup[0], dup[1], dup[2])
+    return 1
+
+
+def main() -> int:
+    setup_django()
+    try:
+        return check_event_schedule()
+    except Exception:
+        logger.exception("イベントスケジュールの確認に失敗しました")
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/create_activity_posts.py
+++ b/scripts/create_activity_posts.py
@@ -1,27 +1,30 @@
 #!/usr/bin/env python
-import os
+"""活動記事を作成するスクリプト
+
+カテゴリ不在などの失敗時は非ゼロ終了する。
+"""
+from __future__ import annotations
+
+import logging
 import sys
-import django
 from datetime import datetime, timezone
 
-# Djangoのセットアップ
-sys.path.append('/app')
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ta_hub.settings')
-django.setup()
+from _script_bootstrap import setup_django
 
-from news.models import Post, Category
-from django.utils.text import slugify
+logger = logging.getLogger(__name__)
 
-def create_activity_posts():
-    """3つの活動記事を作成"""
-    
+
+def create_activity_posts() -> int:
+    """3つの活動記事を作成する。戻り値は exit code。"""
+    from news.models import Category, Post
+
     # 活動カテゴリーを取得
     try:
         activity_category = Category.objects.get(slug='activity')
     except Category.DoesNotExist:
-        print("活動カテゴリーが見つかりません")
-        return
-    
+        logger.error("活動カテゴリーが見つかりません")
+        return 1
+
     # 記事データ
     posts_data = [
         {
@@ -139,9 +142,10 @@ Web APIと連携し、最新のイベント情報をリアルタイムで取得�
     for data in posts_data:
         # 既存の記事をチェック
         if Post.objects.filter(slug=data['slug']).exists():
-            print(f"記事 '{data['title']}' は既に存在します")
+            logger.info("記事 '%s' は既に存在します", data['title'])
             continue
-        
+
+
         post = Post.objects.create(
             title=data['title'],
             slug=data['slug'],
@@ -151,9 +155,20 @@ Web APIと連携し、最新のイベント情報をリアルタイムで取得�
             is_published=data['is_published'],
             published_at=data['published_at']
         )
-        print(f"記事 '{post.title}' を作成しました")
-    
-    print("\n活動記事の作成が完了しました")
+        logger.info("記事 '%s' を作成しました", post.title)
+
+    logger.info("活動記事の作成が完了しました")
+    return 0
+
+
+def main() -> int:
+    setup_django()
+    try:
+        return create_activity_posts()
+    except Exception:
+        logger.exception("活動記事の作成に失敗しました")
+        return 1
+
 
 if __name__ == '__main__':
-    create_activity_posts()
+    sys.exit(main())

--- a/scripts/create_update_post.py
+++ b/scripts/create_update_post.py
@@ -1,40 +1,47 @@
 #!/usr/bin/env python
-import os
+"""アップデート記事を作成するスクリプト
+
+カテゴリ不在・fixture 不在などの失敗時は非ゼロ終了する。
+"""
+from __future__ import annotations
+
+import logging
 import sys
-import django
 from datetime import datetime, timezone
+from pathlib import Path
 
-# Djangoのセットアップ
-sys.path.append('/app')
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ta_hub.settings')
-django.setup()
+from _script_bootstrap import app_dir, setup_django
 
-from news.models import Post, Category
-from django.utils.text import slugify
+logger = logging.getLogger(__name__)
 
-def create_update_post():
-    """アップデート記事を作成"""
-    
-    # アップデートカテゴリーを取得
+MARKDOWN_FILENAME = "2025-01-10-ui-improvements.md"
+
+
+def create_update_post() -> int:
+    """アップデート記事を作成する。戻り値は exit code。"""
+    from news.models import Category, Post
+
     try:
         update_category = Category.objects.get(slug='update')
     except Category.DoesNotExist:
-        print("アップデートカテゴリーが見つかりません")
-        return
-    
-    # 記事データ
+        logger.error("アップデートカテゴリーが見つかりません")
+        return 1
+
     title = "サイトのUI/UX改善とGoogleカレンダー連携機能を追加しました"
     slug = "2025-01-10-ui-improvements"
-    
-    # 既存記事をチェック
+
+    # 既存記事があるのは正常系（冪等に再実行できる）
     if Post.objects.filter(slug=slug).exists():
-        print(f"記事は既に存在します: {slug}")
-        return
-    
-    # Markdownファイルを読み込み
-    with open('/app/news/fixtures/2025-01-10-ui-improvements.md', 'r') as f:
-        body_markdown = f.read()
-    
+        logger.info("記事は既に存在します: %s", slug)
+        return 0
+
+    markdown_path = Path(app_dir()) / "news" / "fixtures" / MARKDOWN_FILENAME
+    try:
+        body_markdown = markdown_path.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.error("Markdownファイルの読み込みに失敗: %s: %s", markdown_path, e)
+        return 1
+
     post = Post.objects.create(
         title=title,
         slug=slug,
@@ -44,7 +51,18 @@ def create_update_post():
         is_published=True,
         published_at=datetime.now(timezone.utc)
     )
-    print(f"記事を作成しました: {post.title}")
+    logger.info("記事を作成しました: %s", post.title)
+    return 0
+
+
+def main() -> int:
+    setup_django()
+    try:
+        return create_update_post()
+    except Exception:
+        logger.exception("アップデート記事の作成に失敗しました")
+        return 1
+
 
 if __name__ == '__main__':
-    create_update_post()
+    sys.exit(main())

--- a/scripts/create_vket_posts.py
+++ b/scripts/create_vket_posts.py
@@ -1,59 +1,63 @@
 #!/usr/bin/env python
-import os
+"""Vket関連の記事を作成するスクリプト
+
+カテゴリ不在・fixture 不在などの失敗時は非ゼロ終了する。
+"""
+from __future__ import annotations
+
+import logging
 import sys
-import django
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
+from pathlib import Path
 
-# Djangoのセットアップ
-sys.path.append('/app')
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ta_hub.settings')
-django.setup()
+from _script_bootstrap import app_dir, setup_django
 
-from news.models import Post, Category
-from django.utils.text import slugify
+logger = logging.getLogger(__name__)
 
-def create_vket_posts():
-    """Vket関連の記事を作成"""
-    
-    # 活動履歴カテゴリーを取得
-    try:
-        activity_category = Category.objects.get(slug='activity')
-    except Category.DoesNotExist:
-        print("活動履歴カテゴリーが見つかりません")
-        return
-    
-    # 記事データ
-    posts_data = [
+
+def _posts_data(fixtures_dir: Path) -> list[dict]:
+    return [
         {
             'title': 'VRC技術・学術系イベントHUB × Vketステージ コラボ【Vket技術学術WEEK】開催決定！',
             'slug': '2025-07-04-vket-week-announcement',
-            'markdown_file': '/app/news/fixtures/2025-07-04-vket-week-announcement.md',
+            'markdown_file': fixtures_dir / '2025-07-04-vket-week-announcement.md',
             'meta_description': 'VirtualMarketとのコラボで16日間連続・20団体が登壇するVket技術学術WEEKの開催が決定！',
             'published_at': datetime(2025, 7, 4, 19, 52, tzinfo=timezone.utc),  # 画像のツイート時刻
         },
         {
             'title': 'Vket技術学術WEEK 動画アーカイブまとめ',
-            'slug': '2025-01-10-vket-week-videos', 
-            'markdown_file': '/app/news/fixtures/2025-01-10-vket-week-videos.md',
+            'slug': '2025-01-10-vket-week-videos',
+            'markdown_file': fixtures_dir / '2025-01-10-vket-week-videos.md',
             'meta_description': '2025年7月12日〜27日開催のVket技術学術WEEK全20団体の発表動画アーカイブまとめ',
             'published_at': datetime.now(timezone.utc),  # 今日の日付
         }
     ]
-    
-    for data in posts_data:
-        # 既存記事をチェック
+
+
+def create_vket_posts() -> int:
+    """Vket関連の記事を作成する。戻り値は exit code。"""
+    from news.models import Category, Post
+
+    try:
+        activity_category = Category.objects.get(slug='activity')
+    except Category.DoesNotExist:
+        logger.error("活動履歴カテゴリーが見つかりません")
+        return 1
+
+    failed = 0
+    for data in _posts_data(Path(app_dir()) / "news" / "fixtures"):
+        # 既存記事があるのは正常系（冪等に再実行できる）
         if Post.objects.filter(slug=data['slug']).exists():
-            print(f"記事は既に存在します: {data['slug']}")
+            logger.info("記事は既に存在します: %s", data['slug'])
             continue
-        
-        # Markdownファイルを読み込み
+
         try:
-            with open(data['markdown_file'], 'r') as f:
-                body_markdown = f.read()
-        except FileNotFoundError:
-            print(f"ファイルが見つかりません: {data['markdown_file']}")
+            body_markdown = Path(data['markdown_file']).read_text(encoding="utf-8")
+        except OSError as e:
+            logger.error("ファイルの読み込みに失敗: %s: %s", data['markdown_file'], e)
+            failed += 1
             continue
-        
+
         post = Post.objects.create(
             title=data['title'],
             slug=data['slug'],
@@ -63,9 +67,24 @@ def create_vket_posts():
             is_published=True,
             published_at=data['published_at']
         )
-        print(f"記事を作成しました: {post.title}")
-    
-    print("\nVket関連記事の作成が完了しました")
+        logger.info("記事を作成しました: %s", post.title)
+
+    if failed:
+        logger.error("Vket関連記事の作成に失敗: %d件", failed)
+        return 1
+
+    logger.info("Vket関連記事の作成が完了しました")
+    return 0
+
+
+def main() -> int:
+    setup_django()
+    try:
+        return create_vket_posts()
+    except Exception:
+        logger.exception("Vket関連記事の作成に失敗しました")
+        return 1
+
 
 if __name__ == '__main__':
-    create_vket_posts()
+    sys.exit(main())

--- a/scripts/fix_h1_duplicates.py
+++ b/scripts/fix_h1_duplicates.py
@@ -1,44 +1,43 @@
 #!/usr/bin/env python
+"""H1タグの重複を修正するスクリプト
+
+NewsとEventDetailの本文から最初の # 行を削除する。
+失敗時は非ゼロ終了して自動化から検知できるようにする。
 """
-H1タグの重複を修正するスクリプト
-NewsとEventDetailの本文から最初の # 行を削除
-"""
-import os
+from __future__ import annotations
+
+import logging
 import sys
-import django
 
-# Djangoのセットアップ
-sys.path.append('/app')
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ta_hub.settings')
-django.setup()
+from _script_bootstrap import setup_django
 
-from news.models import Post
-from event.models import EventDetail
+logger = logging.getLogger(__name__)
 
 
-def fix_h1_duplicates():
-    """NewsとEventDetailのH1重複を修正"""
-    
-    print("=== H1重複修正開始 ===\n")
-    
+def fix_h1_duplicates() -> int:
+    """NewsとEventDetailのH1重複を修正する。戻り値は exit code。"""
+    from event.models import EventDetail
+    from news.models import Post
+
+    logger.info("=== H1重複修正開始 ===")
+
     # News記事のH1削除
-    print("News記事の修正...")
+    logger.info("News記事の修正...")
     news_fixed = 0
-    posts = Post.objects.all()
-    for post in posts:
+    for post in Post.objects.all():
         lines = post.body_markdown.split('\n')
         if lines and lines[0].strip().startswith('# '):
             original_first_line = lines[0]
             post.body_markdown = '\n'.join(lines[1:]).lstrip()
             post.save()
-            print(f"  Fixed News: {post.slug}")
-            print(f"    削除した行: {original_first_line[:50]}...")
+            logger.info("Fixed News: %s", post.slug)
+            logger.info("  削除した行: %s", original_first_line[:50])
             news_fixed += 1
-    
-    print(f"\nNews記事: {news_fixed}件修正\n")
-    
+
+    logger.info("News記事: %d件修正", news_fixed)
+
     # EventDetailのH1削除
-    print("EventDetailの修正...")
+    logger.info("EventDetailの修正...")
     event_fixed = 0
     event_details = EventDetail.objects.exclude(contents='').exclude(contents__isnull=True)
     for ed in event_details:
@@ -47,15 +46,23 @@ def fix_h1_duplicates():
             original_first_line = lines[0]
             ed.contents = '\n'.join(lines[1:]).lstrip()
             ed.save()
-            print(f"  Fixed EventDetail ID {ed.id}: {ed.title[:30]}...")
-            print(f"    削除した行: {original_first_line[:50]}...")
+            logger.info("Fixed EventDetail ID %s: %s", ed.id, ed.title[:30])
+            logger.info("  削除した行: %s", original_first_line[:50])
             event_fixed += 1
-    
-    print(f"\nEventDetail: {event_fixed}件修正")
-    
-    print(f"\n=== 修正完了 ===")
-    print(f"合計: {news_fixed + event_fixed}件のH1重複を修正しました")
+
+    logger.info("EventDetail: %d件修正", event_fixed)
+    logger.info("=== 修正完了 === 合計: %d件", news_fixed + event_fixed)
+    return 0
+
+
+def main() -> int:
+    setup_django()
+    try:
+        return fix_h1_duplicates()
+    except Exception:
+        logger.exception("H1重複の修正に失敗しました")
+        return 1
 
 
 if __name__ == '__main__':
-    fix_h1_duplicates()
+    sys.exit(main())

--- a/scripts/fix_inner_h1_tags.py
+++ b/scripts/fix_inner_h1_tags.py
@@ -1,38 +1,36 @@
 #!/usr/bin/env python
+"""本文内のH1タグをH2に変換するスクリプト
+
+EventDetailのcontents内にある # をすべて ## に変換する。
+失敗時は非ゼロ終了して自動化から検知できるようにする。
 """
-本文内のH1タグをH2に変換するスクリプト
-EventDetailのcontents内にある # をすべて ## に変換
-"""
-import os
+from __future__ import annotations
+
+import logging
 import sys
-import django
 
-# Djangoのセットアップ
-sys.path.append('/app')
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ta_hub.settings')
-django.setup()
+from _script_bootstrap import setup_django
 
-from event.models import EventDetail
+logger = logging.getLogger(__name__)
 
 
-def fix_inner_h1_tags():
-    """EventDetailの本文内のH1をH2に変換"""
-    
-    print("=== 本文内のH1タグ修正開始 ===\n")
-    
-    # EventDetailの本文内のH1をH2に変換
-    print("EventDetailの本文内H1をH2に変換...")
+def fix_inner_h1_tags() -> int:
+    """EventDetailの本文内のH1をH2に変換する。戻り値は exit code。"""
+    from event.models import EventDetail
+
+    logger.info("=== 本文内のH1タグ修正開始 ===")
+
     fixed_count = 0
     event_details = EventDetail.objects.exclude(contents='').exclude(contents__isnull=True)
-    
+
     for ed in event_details:
         if not ed.contents:
             continue
-            
+
         lines = ed.contents.split('\n')
         new_lines = []
         has_h1 = False
-        
+
         for line in lines:
             # 行頭の # で始まる行（H1）を検出
             if line.strip().startswith('# '):
@@ -41,20 +39,29 @@ def fix_inner_h1_tags():
                 new_lines.append(new_line)
                 has_h1 = True
                 if fixed_count == 0:  # 最初の1件だけ詳細を表示
-                    print(f"  変換例: {line[:50]}... -> {new_line[:50]}...")
+                    logger.info("変換例: %s -> %s", line[:50], new_line[:50])
             else:
                 new_lines.append(line)
-        
+
         if has_h1:
             ed.contents = '\n'.join(new_lines)
             ed.save()
-            print(f"  Fixed EventDetail ID {ed.id}: {ed.title[:30]}...")
+            logger.info("Fixed EventDetail ID %s: %s", ed.id, ed.title[:30])
             fixed_count += 1
-    
-    print(f"\nEventDetail: {fixed_count}件の本文内H1をH2に変換")
-    
-    print(f"\n=== 修正完了 ===")
+
+    logger.info("EventDetail: %d件の本文内H1をH2に変換", fixed_count)
+    logger.info("=== 修正完了 ===")
+    return 0
+
+
+def main() -> int:
+    setup_django()
+    try:
+        return fix_inner_h1_tags()
+    except Exception:
+        logger.exception("本文内H1タグの変換に失敗しました")
+        return 1
 
 
 if __name__ == '__main__':
-    fix_inner_h1_tags()
+    sys.exit(main())

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -9,6 +9,16 @@ Django関係のスクリプトはカスタムコマンドとして、各アプ�
 - `scripts/tests/test_run_tests.sh`: 引数あり通常実行もoffline境界を通り、live smokeだけが分離経路になることを検証します。
 - `scripts/tests/test_run_live_smoke.py`: profile検証、credential非漏洩、専用containerの起動引数を検証します。
 
+## 単発メンテナンス（Django）
+
+`scripts/_script_bootstrap.py` の `setup_django()` を `main()` から呼び、成功=0 / 失敗=1 の exit code を返します。
+進捗・診断は logging（stderr）へ出します。
+
+- `scripts/check_event_schedule.py`: 30日先までのイベントを一覧表示し、重複イベントがあれば exit 1。
+- `scripts/create_activity_posts.py` / `scripts/create_update_post.py` / `scripts/create_vket_posts.py`: News 記事の投入。カテゴリ不在・fixture 不在は exit 1。
+- `scripts/fix_h1_duplicates.py` / `scripts/fix_inner_h1_tags.py`: 本文の H1 重複・内部 H1 の是正。
+- `app/website/tests/test_script_exit_codes.py`: 上記スクリプトが exit code 契約（`sys.exit(main())` / print 不使用）を守っていることを検証します。
+
 ## DB同期
 
 - `scripts/db_pull_restore.sh`: `make db-pull` が取得した本番ダンプを Docker Compose の `db` サービスへ復元し、アプリコンテナ経由で代表テーブル件数を検証します。


### PR DESCRIPTION
## なぜ

CLI（management command・scripts）に「失敗しても exit 0」「トークン平文の stdout 出力」が残っており、cron / Cloud Run Job から失敗を検知できず、ターミナルのスクロールバックやログ経由で X のアクセストークンが漏れるリスクがあった。

## 変更内容

| 対象 | 変更 |
|---|---|
| `app/event/management/commands/sync_calendar.py` | status != 200 で `CommandError`（exit 1）。準拠実装の `sync_analytics.py` に合わせた |
| `app/twitter/management/commands/generate_x_token.py` | エラー時の `stderr.write + return`（exit 0）を `CommandError` に変更。トークン値の stdout 出力を廃止し、`--output`（既定 `BASE_DIR/.x-token.env`）へ 0600 で書き出す |
| `app/twitter/management/commands/regenerate_ready_tweets.py` | `failed > 0` でも SUCCESS + exit 0 だったのを `CommandError` に変更 |
| `scripts/{check_event_schedule,create_activity_posts,create_update_post,create_vket_posts,fix_h1_duplicates,fix_inner_h1_tags}.py` | `print` + exit 0 を logging(stderr) + `main() -> exit code` + `sys.exit(main())` に統一 |
| `scripts/_script_bootstrap.py`（新規） | スクリプト共通の Django セットアップ。`main()` から呼ぶ形にし、import 時の副作用を排除 |
| `docker-compose.yaml` / `.gitignore` / `scripts/index.md` | `/scripts` の read-only マウント（静的検証テスト用）、トークンファイルの ignore、スクリプト一覧の追記 |

## 意思決定

- **トークンの受け渡し**: stdout をやめ 0600 ファイルへ。`os.open(O_CREAT, 0o600)` + `chmod` の二重掛けで、既存ファイルの緩いパーミッションを引き継がないようにした。
- **`sync_calendar` の body 出力先**: Issue では body を stderr へとあったが、参照実装 `sync_analytics.py` に揃えて「失敗時は CommandError（stderr・exit 1）、成功時の body は機械可読出力として stdout」とした。エラー出力の stderr 分離という完了条件は満たしている。
- **scripts の `django.setup()`**: import 時に走ると自動テストから import できないため `main()` 内へ移動。あわせて実在しない settings module（`ta_hub.settings` / `config.settings`）を `website.settings` に修正した。
- **`regenerate_ready_tweets`**: 一部失敗の見落としを防ぐため、1件でも失敗したら異常終了。件数サマリは例外メッセージに含める。

## テスト

- 新規 `app/event/tests/test_sync_calendar_command.py`: 200 の正常系 / 500・403 で `CommandError`
- 更新 `app/twitter/tests/test_generate_x_token.py`: 各失敗パスで `CommandError`、成功時に stdout/stderr へトークンが出ないこと、ファイルが 0600 になること（既存 0644 ファイルの締め直し含む）
- 更新 `app/twitter/tests/test_regenerate_ready_tweets.py`: 生成 None / 例外 / 部分失敗で `CommandError`、全件成功では正常終了
- 新規 `app/website/tests/test_script_exit_codes.py`: `sys.exit(main())` 契約・`print` 不使用・import 時副作用なしを AST で静的検証 + 代表的な失敗パスが 1 を返すことを実行確認

実行結果: `python -m tests.offline_manage test --exclude-tag=live_smoke --exclude-tag=e2e` で **1929 tests OK**（skipped=1）、`ruff check app/ scripts/` パス。

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 認証トークンの取り扱いと cron/ジョブ向け exit code 契約の変更は運用影響が大きい一方、挙動はテストで固定されており本番データパス自体の大規模変更ではないため中リスクです。
> 
> **Overview**
> **cron / Cloud Run Job から失敗を検知できるよう**、複数の CLI 入口で「失敗しても exit 0」だった挙動を直し、**X トークンのログ・ターミナル漏洩**も塞いでいます。
> 
> `sync_calendar` は HTTP 非 200 で `CommandError`（exit 1）にし、`sync_analytics` と同じ契約に揃えました。`regenerate_ready_tweets` は再生成が 1 件でも失敗したら異常終了します。`generate_x_token` はエラーを `CommandError` に統一し、成功時のトークンを stdout に出さず `--output`（既定 `.x-token.env`）へ **0600・atomic 書き込み**で保存します（`.gitignore` 追記あり）。
> 
> `scripts/` の単発メンテは `_script_bootstrap.py` で Django セットアップを `main()` 内に寄せ、`print` を logging（stderr）に置き換え、`sys.exit(main())` で 0/1 を返す形に統一しました。`docker-compose` に `/scripts` の read-only マウントを追加し、`test_script_exit_codes.py` ほかで exit code 契約とトークン非露出をテストしています。
> 
> ブログ生成（`content_generation_service`）は OpenRouter 呼び出しの型付けと、tool_calls も content も無い応答の明示的エラー化のみです。mypy 用に `types-bleach` / `types-Markdown` を依存に追加しています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e9fc66bd6f7a369dc73b1b2eab5c3071ae0f60d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->