### PR TITLE
fix: mypy型エラーを解消

### DIFF
--- a/app/event/services/markdown_processor.py
+++ b/app/event/services/markdown_processor.py
@@ -252,7 +252,7 @@ def convert_markdown(markdown_text: str, auto_format: bool = False) -> str:
     logger.debug("Normalized markdown text:")
     logger.debug(markdown_text)
 
-    html = markdown.markdown(markdown_text, extensions=_MARKDOWN_EXTENSIONS)
+    html: str = markdown.markdown(markdown_text, extensions=_MARKDOWN_EXTENSIONS)
     logger.debug("Generated HTML before BeautifulSoup:")
     logger.debug(html)
 

--- a/app/event/tests/test_generate_blog.py
+++ b/app/event/tests/test_generate_blog.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 from io import BytesIO
 from datetime import date, datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.core.files.base import ContentFile
 from django.core.files import File
@@ -313,6 +313,39 @@ class TestGenerateBlog(TestCase):
         self.assertEqual(result.title, '')
         self.assertEqual(result.meta_description, '')
         self.assertEqual(result.text, '')
+
+    @patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}, clear=False)
+    @patch("event.services.content_generation_service.OpenAI")
+    def test_generate_blog_returns_empty_output_when_response_content_is_none(
+        self,
+        mock_openai_class,
+    ):
+        """通常レスポンスの本文がない場合は内部エラーを記録して空出力を返す."""
+        mock_client = MagicMock()
+        mock_completion = MagicMock()
+        mock_completion.choices = [
+            MagicMock(message=MagicMock(content=None, tool_calls=None))
+        ]
+        mock_client.chat.completions.create.return_value = mock_completion
+        mock_openai_class.return_value = mock_client
+        event_detail = self.create_event_detail(youtube_url="invalid")
+
+        with self.assertLogs(
+            "event.services.content_generation_service",
+            level="ERROR",
+        ) as log_context:
+            result = generate_blog(event_detail, model="test-model")
+
+        self.assertEqual(
+            result,
+            BlogOutput(title="", meta_description="", text=""),
+        )
+        self.assertTrue(
+            any(
+                "OpenRouter response has neither tool_calls nor content" in entry
+                for entry in log_context.output
+            )
+        )
 
     def test_blog_output_basic(self):
         """BlogOutputモデルの基本的な動作をテスト"""

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ VRC技術学術ハブの開発、運用、調査メモ、利用ガイドをま�
 - [セットアップ](setup.md)
 - [デプロイ](deployment.md) — [ヘルスチェック](deployment.md#health)
 - [テスト方針と共有 factory ヘルパー](testing.md)
+- [mypy + django-stubs 段階導入ガイド](mypy.md)
 - [関数リファレンス](functions.md)
 - [管理スクリプト一覧](../scripts/index.md)
 - [次にやるべきこと](next-actions.md)

--- a/docs/mypy.md
+++ b/docs/mypy.md
@@ -7,7 +7,7 @@
 
 | Phase | 対象 | ゴール |
 |-------|------|--------|
-| Phase 1 (現在) | `app/event/services/` | warn-only でエラー件数を可視化 |
+| Phase 1 (現在) | `app/event/services/` | warn-only を維持し、エラー 0 を継続 |
 | Phase 2 | `app/event/recurrence/` | warn-only |
 | Phase 3 | `app/twitter/generators/` | warn-only |
 | Phase 4 | Phase 1〜3 を strict 化 | warn 0 達成 → `disallow_untyped_defs = true` |
@@ -29,24 +29,21 @@ bash scripts/run_mypy.sh
 ### Docker コンテナ内で実行
 
 `requirements.txt` に mypy + django-stubs を入れているので、コンテナ再ビルド後は
-コンテナ内でも実行できる。
+使い捨てコンテナ内でも実行できる。ワークツリー全体を読み取り専用でマウントするため、
+起動中コンテナの状態には依存しない。
 
 ```bash
 docker compose build vrc-ta-hub
-docker compose up -d
-docker exec vrc-ta-hub-app bash -c "cd /app && mypy event/services/ --config-file /pyproject.toml"
+docker compose run --rm --no-deps \
+  -v "$PWD:/workspace:ro" -w /workspace \
+  vrc-ta-hub mypy app/event/services/ --config-file pyproject.toml
 ```
 
-`docker-compose.yaml` が `./pyproject.toml` をコンテナの `/pyproject.toml` にマウント済みのため、
-`--config-file /pyproject.toml` でホスト側の設定を使い回せる。
-
-### 直接 mypy を呼ぶ場合
+依存同期済みのローカル環境では、同じ検証を次のコマンドで実行できる。
 
 ```bash
-docker exec vrc-ta-hub-app mypy app/event/services/
+mypy app/event/services/ --config-file pyproject.toml
 ```
-
-設定は `pyproject.toml` の `[tool.mypy]` セクションから自動で読み込まれる。
 
 ## 設定の見どころ (`pyproject.toml`)
 
@@ -72,11 +69,12 @@ django_settings_module = "website.settings"
 `follow_imports = "silent"` と `ignore_missing_imports = true` がポイント。
 これがないと、対象外モジュール側のエラーまで吸い込んでノイズが激増する。
 
-## 既知のエラーと対処法
+## 解消済みの既知エラー
 
-Phase 1 の初回実行で 5 件のエラーが出ている。それぞれの対処方針をメモしておく。
+Phase 1 の初回実行で確認した 5 件は解消済み。CI の warn-only 設計は維持しつつ、
+`app/event/services/` の mypy はエラー 0 を基準とする。
 
-### 1. `Library stubs not installed` (bleach / markdown 等)
+### 1. `Library stubs not installed` (bleach / markdown)
 
 ```
 event/services/markdown_processor.py:13: error: Library stubs not installed for "bleach"  [import-untyped]
@@ -84,29 +82,27 @@ event/services/markdown_processor.py:14: error: Library stubs not installed for 
 event/services/markdown_processor.py:15: error: Library stubs not installed for "bleach.css_sanitizer"  [import-untyped]
 ```
 
-**対処**: `types-bleach` / `types-Markdown` を `requirements.txt` に追加する。
-本 PR では「型スタブ追加 = 別関心事」なので含めず、フォロー PR で対応する。
-急ぐ場合は `# type: ignore[import-untyped]` を import 行に付けて回避できる。
+**採用した対処**: `types-bleach` / `types-Markdown` を固定バージョンで導入した。
+型エラーの抑制コメントは追加せず、第三者ライブラリの公開スタブで解決している。
 
 ### 2. `Returning Any from function declared to return "str"`
 
 ```
-event/services/markdown_processor.py:200: error: Returning Any from function declared to return "str"  [no-any-return]
+event/services/markdown_processor.py:222: error: Returning Any from function declared to return "str"  [no-any-return]
 ```
 
-**対処**: 第三者ライブラリ (`markdown.markdown()` 等) の戻り値が `Any` のため。
-スタブを入れれば自然消滅するケースが多い。残った場合は `cast(str, ...)` で明示する。
+**採用した対処**: 型スタブを導入し、`markdown.markdown()` の戻り値を `str` として
+明示した。サニタイズ後の HTML もスタブに基づき `str` として検証される。
 
 ### 3. OpenAI Completions.create の overload 不一致
 
 ```
-event/services/content_generation_service.py:185: error: No overload variant of "create" of "Completions" matches argument types ...
+event/services/content_generation_service.py:244: error: No overload variant of "create" of "Completions" matches argument types ...
 ```
 
-**対処**: `openai` ライブラリの `client.chat.completions.create()` に渡している
-`messages` の型 (`list[dict[str, str]]`) が SDK の overload と一致していない。
-`ChatCompletionMessageParam` 型を使うか、`# type: ignore[call-overload]` で抑制する。
-SDK 側のアップデートで解消することもある。
+**採用した対処**: `messages`、`tools`、`tool_choice` を OpenAI SDK の正式型
+(`ChatCompletionMessageParam` など) で明示した。リクエスト内容は変えず、
+型エラーの抑制コメントも使用していない。
 
 ### Django ORM の型不一致 (将来出てくるパターン)
 
@@ -122,20 +118,17 @@ if user is None:
 # ここから user は User として扱える
 ```
 
-## CI 連携 (フォロー作業)
+## CI 連携
 
-`.github/workflows/ci.yml` への mypy job 追加は本 PR には含めない。
-理由: 本 PR は設定 + 観測手段の整備に集中し、CI 連携は別途レビューが必要なため。
-
-追加するときの参考 YAML は `docs/tmp/w6-10-ci-yml-followup.md` を参照。
+`.github/workflows/ci.yml` の mypy job は `continue-on-error: true` の warn-only を維持する。
+`app/event/services/` のエラー 0 は観測対象の基準であり、CI の blocking 化は Phase 5 まで行わない。
 
 ## 将来計画
 
-1. **Phase 1 (現在)**: `event/services/` の warn-only 観測
-2. **Phase 2**: `event/services/` で warn 0 達成
-   - 既知エラー (型スタブ追加 / OpenAI 型問題 / Any 戻り値) を解消
-3. **Phase 3**: `event/recurrence/`, `twitter/generators/` に範囲拡大
-4. **Phase 4**: `disallow_untyped_defs = true` に昇格し、新規関数の未注釈を禁止
+1. **Phase 1 (現在)**: `event/services/` の warn-only 観測を継続し、エラー 0 を維持
+2. **Phase 2**: `event/recurrence/` に観測範囲を拡大
+3. **Phase 3**: `twitter/generators/` に観測範囲を拡大
+4. **Phase 4**: Phase 1〜3 で `disallow_untyped_defs = true` に昇格
 5. **Phase 5**: `strict = true` 相当に到達したアプリから、CI job を warn-only から
    blocking に切り替える
 


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: [#552](https://github.com/noricha-vr/vrc-ta-hub/issues/552)「CI の mypy job が main でも失敗している（event/services 型エラー5件、warn-only で不可視化）」
- Closes #552

**追記（リベース後）**: 本PRの型エラー修正（`types-bleach` / `types-Markdown` の追加、OpenAI SDK の公開型による `messages` / `tools` / `tool_choice` の明示）は、並行して進んでいた PR #549 に同等の内容が含まれており、先にマージされました。そのため本PRを `main` にリベースし、重複ハンクを解消しています。

Issue #552 の本題（mypy エラー0）は main で既に達成済みですが、本PRには main に無い回帰テストとドキュメント更新が残るため、それらをマージします。

## 変更内容（リベース後の実質差分）

- `convert_markdown` の `markdown.markdown()` 戻り値に `html: str` を明示
- `content=None`（tool_calls も content も無い異常応答）で空 `BlogOutput` へフォールバックする契約を回帰テスト化
- `docs/mypy.md` を「Phase 1 はエラー0を継続」に更新し、使い捨てコンテナでの検証コマンドへ差し替え
- `docs/index.md` に mypy ガイドへのリンクを追加

## 意思決定

### 採用アプローチ
型スタブと OpenAI SDK の公開型を利用し、`# type: ignore` での抑制を避けました。`content` が空の場合は既存どおり空の `BlogOutput` へフォールバックし、呼び出し側の失敗契約を変えていません。

### リベース時の判断
重複ハンクは `main` 側（PR #549 でマージ済み）を採用しました。例外メッセージも main の `"OpenRouter response has neither tool_calls nor content"` に統一し、本PRのテストの assert をそちらへ合わせています（同じ振る舞いをより正確に表す文言のため）。

### トレードオフ または 却下した代替案
CI の warn-only 設定は段階導入の意図を尊重して維持しました。例外を外部へ送出する案は既存フォールバックを破るため却下し、内部エラー記録をテストで保証しています。

## テスト

- 全テスト: 2006 件 OK (skipped=20)
- `mypy event/services/ --config-file pyproject.toml`: Success（0 errors）
- `event.tests.test_generate_blog` + `event.tests.test_convert_markdown`: 76 件 OK (skipped=5)

---
🤖 Generated with [Codex](https://Codex.com/Codex) / リベースと検証は [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a type annotation, a mocked regression test, and documentation; runtime blog generation behavior is unchanged.
> 
> **Overview**
> **Mypy Phase 1** for `app/event/services/` is documented as **error 0** under warn-only CI, with updated Docker/local run steps and a link from `docs/index.md` to `docs/mypy.md` (resolved stub/OpenAI typing notes; no `# type: ignore` policy).
> 
> In code, `convert_markdown` now assigns `markdown.markdown()` to an explicitly typed **`html: str`** variable. A **regression test** mocks OpenRouter when the chat message has **`content=None`** and no tool calls: it expects the existing empty `BlogOutput`, plus an **ERROR** log containing `OpenRouter response has neither tool_calls nor content`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit befbfe98bf9420a0e42f2c639b9133f942a090c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->