### PR TITLE
refactor(discord): Webhook送信境界と失敗処理を統一

### DIFF
--- a/app/community/forms_processor.py
+++ b/app/community/forms_processor.py
@@ -17,8 +17,10 @@ from django.urls import reverse
 from django.utils import timezone
 
 from event.community_cleanup import cleanup_community_future_data
-from website.discord_webhook import post_discord_webhook
-from website.retry import get_webhook_error_context
+from website.discord_webhook import (
+    get_webhook_error_context,
+    post_discord_webhook,
+)
 
 from .models import Community, CommunityMember
 
@@ -60,17 +62,20 @@ def notify_new_community_registration(community: Community, request: HttpRequest
     try:
         post_discord_webhook(settings.DISCORD_WEBHOOK_URL, discord_message)
     except requests.RequestException as error:
-        # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
+        # gateway で回復できなかった最終失敗のみここに到達する
         error_type, status_code = get_webhook_error_context(error)
         logger.warning(
-            'Discord通知送信失敗（リトライ後）: error_type=%s status_code=%s',
+            'Discord通知送信失敗（リトライ後）: '
+            'community_id=%s error_type=%s status_code=%s',
+            community.pk,
             error_type,
             status_code,
         )
     except Exception as error:
         error_type, status_code = get_webhook_error_context(error)
         logger.warning(
-            'Discord通知送信失敗: error_type=%s status_code=%s',
+            'Discord通知送信失敗: community_id=%s error_type=%s status_code=%s',
+            community.pk,
             error_type,
             status_code,
         )

--- a/app/community/forms_processor.py
+++ b/app/community/forms_processor.py
@@ -18,6 +18,7 @@ from django.utils import timezone
 
 from event.community_cleanup import cleanup_community_future_data
 from website.discord_webhook import post_discord_webhook
+from website.retry import get_webhook_error_context
 
 from .models import Community, CommunityMember
 
@@ -58,11 +59,21 @@ def notify_new_community_registration(community: Community, request: HttpRequest
     }
     try:
         post_discord_webhook(settings.DISCORD_WEBHOOK_URL, discord_message)
-    except requests.RequestException as e:
+    except requests.RequestException as error:
         # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
-        logger.warning(f'Discord通知送信失敗（リトライ後）: {e}')
-    except Exception as e:
-        logger.warning(f'Discord通知送信失敗: {e}')
+        error_type, status_code = get_webhook_error_context(error)
+        logger.warning(
+            'Discord通知送信失敗（リトライ後）: error_type=%s status_code=%s',
+            error_type,
+            status_code,
+        )
+    except Exception as error:
+        error_type, status_code = get_webhook_error_context(error)
+        logger.warning(
+            'Discord通知送信失敗: error_type=%s status_code=%s',
+            error_type,
+            status_code,
+        )
 
 
 def approve_community_registration(community: Community, request: HttpRequest) -> None:

--- a/app/community/tests/test_community_report.py
+++ b/app/community/tests/test_community_report.py
@@ -71,11 +71,11 @@ class CommunityReportViewTest(TestCase):
     @override_settings(DISCORD_REPORT_WEBHOOK_URL='https://discord.com/api/webhooks/test')
     def test_webhook_sent_on_report(self):
         """通報時にDiscord Webhookが送信される"""
-        with patch('website.discord_webhook.requests.post') as mock_post:
+        with patch('community.views.helpers.post_discord_webhook') as mock_post:
             mock_post.return_value = MagicMock(status_code=204)
             self.client.post(self.url)
         mock_post.assert_called_once()
-        payload = mock_post.call_args[1]['json']
+        payload = mock_post.call_args.args[1]
         self.assertIn('活動停止が通報されました', payload['content'])
         self.assertEqual(payload['embeds'][0]['title'], 'テスト集会')
         self.assertEqual(payload['embeds'][0]['fields'][0]['value'], '1')
@@ -88,7 +88,7 @@ class CommunityReportViewTest(TestCase):
 
     def test_webhook_not_sent_when_url_empty(self):
         """Webhook URLが空の場合は送信しない"""
-        with patch('website.discord_webhook.requests.post') as mock_post:
+        with patch('community.views.helpers.post_discord_webhook') as mock_post:
             self.client.post(self.url)
         mock_post.assert_not_called()
 
@@ -97,27 +97,21 @@ class CommunityReportViewTest(TestCase):
         """Webhook送信失敗を安全にlogし、通報は成功する."""
         sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
         with patch(
-            'website.discord_webhook.requests.post',
+            'community.views.helpers.post_discord_webhook',
             side_effect=requests_lib.RequestException(
                 f"timeout for {sensitive_url}",
             ),
         ) as mock_post:
-            from website.discord_webhook import post_discord_webhook
-
-            original_sleep = post_discord_webhook.retry.sleep
-            post_discord_webhook.retry.sleep = lambda _seconds: None
-            try:
-                with self.assertLogs(
-                    "community.views.helpers",
-                    level="ERROR",
-                ) as log_context:
-                    response = self.client.post(self.url)
-            finally:
-                post_discord_webhook.retry.sleep = original_sleep
+            with self.assertLogs(
+                "community.views.helpers",
+                level="ERROR",
+            ) as log_context:
+                response = self.client.post(self.url)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(CommunityReport.objects.count(), 1)
-        self.assertEqual(mock_post.call_count, 3)
+        mock_post.assert_called_once()
         logs = "\n".join(log_context.output)
+        self.assertIn(f"community_id={self.community.pk}", logs)
         self.assertIn("error_type=RequestException", logs)
         self.assertIn("status_code=None", logs)
         self.assertNotIn(sensitive_url, logs)

--- a/app/community/tests/test_community_report.py
+++ b/app/community/tests/test_community_report.py
@@ -94,22 +94,36 @@ class CommunityReportViewTest(TestCase):
 
     @override_settings(DISCORD_REPORT_WEBHOOK_URL='https://discord.com/api/webhooks/test')
     def test_webhook_failure_does_not_block_report(self):
-        """Webhook送信失敗でも通報は成功する"""
+        """Webhook送信失敗を安全にlogし、通報は成功する."""
+        sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
         with patch(
             'website.discord_webhook.requests.post',
-            side_effect=requests_lib.RequestException("timeout"),
+            side_effect=requests_lib.RequestException(
+                f"timeout for {sensitive_url}",
+            ),
         ) as mock_post:
             from website.discord_webhook import post_discord_webhook
 
             original_sleep = post_discord_webhook.retry.sleep
             post_discord_webhook.retry.sleep = lambda _seconds: None
             try:
-                response = self.client.post(self.url)
+                with self.assertLogs(
+                    "community.views.helpers",
+                    level="ERROR",
+                ) as log_context:
+                    response = self.client.post(self.url)
             finally:
                 post_discord_webhook.retry.sleep = original_sleep
         self.assertEqual(response.status_code, 302)
         self.assertEqual(CommunityReport.objects.count(), 1)
         self.assertEqual(mock_post.call_count, 3)
+        logs = "\n".join(log_context.output)
+        self.assertIn("error_type=RequestException", logs)
+        self.assertIn("status_code=None", logs)
+        self.assertNotIn(sensitive_url, logs)
+        self.assertNotIn("secret-token", logs)
+        self.assertNotIn("timeout for", logs)
+        self.assertNotIn("Traceback", logs)
 
 
 class GetClientIpTest(TestCase):

--- a/app/community/tests/test_community_report.py
+++ b/app/community/tests/test_community_report.py
@@ -71,8 +71,8 @@ class CommunityReportViewTest(TestCase):
     @override_settings(DISCORD_REPORT_WEBHOOK_URL='https://discord.com/api/webhooks/test')
     def test_webhook_sent_on_report(self):
         """通報時にDiscord Webhookが送信される"""
-        with patch('community.views.helpers.requests.post') as mock_post:
-            mock_post.return_value = MagicMock(ok=True)
+        with patch('website.discord_webhook.requests.post') as mock_post:
+            mock_post.return_value = MagicMock(status_code=204)
             self.client.post(self.url)
         mock_post.assert_called_once()
         payload = mock_post.call_args[1]['json']
@@ -88,17 +88,28 @@ class CommunityReportViewTest(TestCase):
 
     def test_webhook_not_sent_when_url_empty(self):
         """Webhook URLが空の場合は送信しない"""
-        with patch('community.views.helpers.requests.post') as mock_post:
+        with patch('website.discord_webhook.requests.post') as mock_post:
             self.client.post(self.url)
         mock_post.assert_not_called()
 
     @override_settings(DISCORD_REPORT_WEBHOOK_URL='https://discord.com/api/webhooks/test')
     def test_webhook_failure_does_not_block_report(self):
         """Webhook送信失敗でも通報は成功する"""
-        with patch('community.views.helpers.requests.post', side_effect=requests_lib.RequestException("timeout")):
-            response = self.client.post(self.url)
+        with patch(
+            'website.discord_webhook.requests.post',
+            side_effect=requests_lib.RequestException("timeout"),
+        ) as mock_post:
+            from website.discord_webhook import post_discord_webhook
+
+            original_sleep = post_discord_webhook.retry.sleep
+            post_discord_webhook.retry.sleep = lambda _seconds: None
+            try:
+                response = self.client.post(self.url)
+            finally:
+                post_discord_webhook.retry.sleep = original_sleep
         self.assertEqual(response.status_code, 302)
         self.assertEqual(CommunityReport.objects.count(), 1)
+        self.assertEqual(mock_post.call_count, 3)
 
 
 class GetClientIpTest(TestCase):

--- a/app/community/tests/test_forms_processor.py
+++ b/app/community/tests/test_forms_processor.py
@@ -118,51 +118,38 @@ class NotifyNewCommunityRegistrationTest(TestCase):
     @override_settings(DISCORD_WEBHOOK_URL="")
     def test_skipped_when_webhook_url_empty(self):
         """DISCORD_WEBHOOK_URL 空で何もしない"""
-        with patch("website.discord_webhook.requests.post") as mock_post:
+        with patch("community.forms_processor.post_discord_webhook") as mock_post:
             notify_new_community_registration(self.community, self.request)
             mock_post.assert_not_called()
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/123/abc")
-    @patch("website.discord_webhook.requests.post")
+    @patch("community.forms_processor.post_discord_webhook")
     def test_posts_to_webhook_when_url_set(self, mock_post):
         """DISCORD_WEBHOOK_URL 設定時に POST される"""
         mock_post.return_value = MagicMock(ok=True, status_code=200)
         notify_new_community_registration(self.community, self.request)
         mock_post.assert_called_once()
-        args, kwargs = mock_post.call_args
+        args = mock_post.call_args.args
         self.assertEqual(args[0], "https://discord.com/api/webhooks/123/abc")
-        self.assertIn("content", kwargs["json"])
-        self.assertIn(self.community.name, kwargs["json"]["content"])
+        self.assertIn("content", args[1])
+        self.assertIn(self.community.name, args[1]["content"])
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/123/abc")
-    @patch("website.discord_webhook.requests.post")
+    @patch("community.forms_processor.post_discord_webhook")
     def test_swallows_request_exception(self, mock_post):
-        """requests 例外を安全にlogし、呼び出し元へ伝播しない.
-
-        tenacity リトライ導入後は 3 回まで再試行されるため、回数ではなく
-        「例外を吸い込んで完了する」ことと「実際にリトライが行われた」ことを検証する。
-        テスト中はバックオフ待機を 0 秒化して高速化する。
-        """
-        from website.discord_webhook import post_discord_webhook
-
+        """gateway最終失敗を安全にlogし、呼び出し元へ伝播しない."""
         sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
         mock_post.side_effect = requests.RequestException(
             f"network down for {sensitive_url}",
         )
-        # tenacity のラップド関数経由でリトライ間 sleep を 0 秒に上書き
-        original_sleep = post_discord_webhook.retry.sleep
-        post_discord_webhook.retry.sleep = lambda *args, **kwargs: None
-        try:
-            with self.assertLogs(
-                "community.forms_processor",
-                level="WARNING",
-            ) as log_context:
-                notify_new_community_registration(self.community, self.request)
-        finally:
-            post_discord_webhook.retry.sleep = original_sleep
-        # 3 回再試行された（初回 + リトライ2回）
-        self.assertEqual(mock_post.call_count, 3)
+        with self.assertLogs(
+            "community.forms_processor",
+            level="WARNING",
+        ) as log_context:
+            notify_new_community_registration(self.community, self.request)
+        mock_post.assert_called_once()
         logs = "\n".join(log_context.output)
+        self.assertIn(f"community_id={self.community.pk}", logs)
         self.assertIn("error_type=RequestException", logs)
         self.assertIn("status_code=None", logs)
         self.assertNotIn(sensitive_url, logs)

--- a/app/community/tests/test_forms_processor.py
+++ b/app/community/tests/test_forms_processor.py
@@ -137,7 +137,7 @@ class NotifyNewCommunityRegistrationTest(TestCase):
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/123/abc")
     @patch("website.discord_webhook.requests.post")
     def test_swallows_request_exception(self, mock_post):
-        """requests 例外時もクラッシュしない (silent failure).
+        """requests 例外を安全にlogし、呼び出し元へ伝播しない.
 
         tenacity リトライ導入後は 3 回まで再試行されるため、回数ではなく
         「例外を吸い込んで完了する」ことと「実際にリトライが行われた」ことを検証する。
@@ -145,17 +145,30 @@ class NotifyNewCommunityRegistrationTest(TestCase):
         """
         from website.discord_webhook import post_discord_webhook
 
-        mock_post.side_effect = requests.RequestException("network down")
+        sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
+        mock_post.side_effect = requests.RequestException(
+            f"network down for {sensitive_url}",
+        )
         # tenacity のラップド関数経由でリトライ間 sleep を 0 秒に上書き
         original_sleep = post_discord_webhook.retry.sleep
         post_discord_webhook.retry.sleep = lambda *args, **kwargs: None
         try:
-            # 例外を投げずに完了する
-            notify_new_community_registration(self.community, self.request)
+            with self.assertLogs(
+                "community.forms_processor",
+                level="WARNING",
+            ) as log_context:
+                notify_new_community_registration(self.community, self.request)
         finally:
             post_discord_webhook.retry.sleep = original_sleep
         # 3 回再試行された（初回 + リトライ2回）
         self.assertEqual(mock_post.call_count, 3)
+        logs = "\n".join(log_context.output)
+        self.assertIn("error_type=RequestException", logs)
+        self.assertIn("status_code=None", logs)
+        self.assertNotIn(sensitive_url, logs)
+        self.assertNotIn("secret-token", logs)
+        self.assertNotIn("network down", logs)
+        self.assertNotIn("Traceback", logs)
 
 
 class CloseCommunityAndCleanupTest(TestCase):

--- a/app/community/tests/test_settings.py
+++ b/app/community/tests/test_settings.py
@@ -468,7 +468,7 @@ class WebhookSettingsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'テスト送信')
 
-    @patch('website.discord_webhook.requests.post')
+    @patch('community.views.settings.post_discord_webhook')
     def test_test_webhook_success(self, mock_post):
         """Webhookテスト送信は任意の2xxで成功する"""
         self.community.notification_webhook_url = 'https://discord.com/api/webhooks/123/abc'
@@ -487,58 +487,45 @@ class WebhookSettingsTest(TestCase):
         self.assertContains(response, 'テスト通知を送信しました。Discordを確認してください。')
         mock_post.assert_called_once()
         # 送信されたJSONにテスト通知のメッセージが含まれていることを確認
-        call_kwargs = mock_post.call_args[1]
-        self.assertIn('テスト通知', call_kwargs['json']['content'])
+        payload = mock_post.call_args.args[1]
+        self.assertIn('テスト通知', payload['content'])
 
-    @patch('website.discord_webhook.requests.post')
+    @patch('community.views.settings.post_discord_webhook')
     def test_test_webhook_failure(self, mock_post):
         """HTTP失敗はステータスコード付きメッセージを表示する"""
         self.community.notification_webhook_url = 'https://discord.com/api/webhooks/123/abc'
         self.community.save()
 
-        mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_post.return_value = mock_response
+        mock_post.side_effect = requests.HTTPError(
+            "bad request",
+            response=MagicMock(status_code=400),
+        )
 
         self.client.login(username='主催者ユーザー', password='testpass123')
-        from website.discord_webhook import post_discord_webhook
-
-        original_sleep = post_discord_webhook.retry.sleep
-        post_discord_webhook.retry.sleep = lambda _seconds: None
-        try:
-            response = self.client.post(
-                reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
-                follow=True,
-            )
-        finally:
-            post_discord_webhook.retry.sleep = original_sleep
+        response = self.client.post(
+            reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
+            follow=True,
+        )
 
         self.assertContains(response, '通知の送信に失敗しました。(ステータスコード: 400)')
-        self.assertEqual(mock_post.call_count, 3)
+        mock_post.assert_called_once()
 
-    @patch('website.discord_webhook.requests.post')
+    @patch('community.views.settings.post_discord_webhook')
     def test_test_webhook_timeout_message(self, mock_post):
         """タイムアウトは専用メッセージを表示する."""
         self.community.notification_webhook_url = 'https://discord.com/api/webhooks/123/abc'
         self.community.save()
         mock_post.side_effect = requests.Timeout("timed out")
         self.client.login(username='主催者ユーザー', password='testpass123')
-        from website.discord_webhook import post_discord_webhook
-
-        original_sleep = post_discord_webhook.retry.sleep
-        post_discord_webhook.retry.sleep = lambda _seconds: None
-        try:
-            response = self.client.post(
-                reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
-                follow=True,
-            )
-        finally:
-            post_discord_webhook.retry.sleep = original_sleep
+        response = self.client.post(
+            reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
+            follow=True,
+        )
 
         self.assertContains(response, '通知の送信がタイムアウトしました。')
-        self.assertEqual(mock_post.call_count, 3)
+        mock_post.assert_called_once()
 
-    @patch('website.discord_webhook.requests.post')
+    @patch('community.views.settings.post_discord_webhook')
     def test_test_webhook_request_error_message(self, mock_post):
         """接続エラーは安全にlogし、汎用メッセージを表示する."""
         sensitive_url = 'https://discord.com/api/webhooks/123456789/secret-token'
@@ -548,25 +535,19 @@ class WebhookSettingsTest(TestCase):
             f"connection failed for {sensitive_url}",
         )
         self.client.login(username='主催者ユーザー', password='testpass123')
-        from website.discord_webhook import post_discord_webhook
-
-        original_sleep = post_discord_webhook.retry.sleep
-        post_discord_webhook.retry.sleep = lambda _seconds: None
-        try:
-            with self.assertLogs(
-                'community.views.settings',
-                level='WARNING',
-            ) as log_context:
-                response = self.client.post(
-                    reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
-                    follow=True,
-                )
-        finally:
-            post_discord_webhook.retry.sleep = original_sleep
+        with self.assertLogs(
+            'community.views.settings',
+            level='WARNING',
+        ) as log_context:
+            response = self.client.post(
+                reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
+                follow=True,
+            )
 
         self.assertContains(response, '通知の送信中にエラーが発生しました。')
-        self.assertEqual(mock_post.call_count, 3)
+        mock_post.assert_called_once()
         logs = '\n'.join(log_context.output)
+        self.assertIn(f'community_id={self.community.pk}', logs)
         self.assertIn('error_type=ConnectionError', logs)
         self.assertIn('status_code=None', logs)
         self.assertNotIn(sensitive_url, logs)

--- a/app/community/tests/test_settings.py
+++ b/app/community/tests/test_settings.py
@@ -1,6 +1,7 @@
 """CommunitySettingsViewのテスト"""
 from unittest.mock import patch, MagicMock
 
+import requests
 from django.test import TestCase, Client, override_settings
 from django.urls import reverse
 from django.contrib.auth import get_user_model
@@ -467,30 +468,31 @@ class WebhookSettingsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'テスト送信')
 
-    @patch('community.views.settings.requests.post')
+    @patch('website.discord_webhook.requests.post')
     def test_test_webhook_success(self, mock_post):
-        """Webhookテスト送信が成功する"""
+        """Webhookテスト送信は任意の2xxで成功する"""
         self.community.notification_webhook_url = 'https://discord.com/api/webhooks/123/abc'
         self.community.save()
 
         mock_response = MagicMock()
-        mock_response.status_code = 204
+        mock_response.status_code = 201
         mock_post.return_value = mock_response
 
         self.client.login(username='主催者ユーザー', password='testpass123')
         response = self.client.post(
-            reverse('community:test_webhook', kwargs={'pk': self.community.pk})
+            reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
+            follow=True,
         )
 
-        self.assertRedirects(response, reverse('community:settings'))
+        self.assertContains(response, 'テスト通知を送信しました。Discordを確認してください。')
         mock_post.assert_called_once()
         # 送信されたJSONにテスト通知のメッセージが含まれていることを確認
         call_kwargs = mock_post.call_args[1]
         self.assertIn('テスト通知', call_kwargs['json']['content'])
 
-    @patch('community.views.settings.requests.post')
+    @patch('website.discord_webhook.requests.post')
     def test_test_webhook_failure(self, mock_post):
-        """Webhookテスト送信が失敗した場合のエラーハンドリング"""
+        """HTTP失敗はステータスコード付きメッセージを表示する"""
         self.community.notification_webhook_url = 'https://discord.com/api/webhooks/123/abc'
         self.community.save()
 
@@ -499,11 +501,64 @@ class WebhookSettingsTest(TestCase):
         mock_post.return_value = mock_response
 
         self.client.login(username='主催者ユーザー', password='testpass123')
-        response = self.client.post(
-            reverse('community:test_webhook', kwargs={'pk': self.community.pk})
-        )
+        from website.discord_webhook import post_discord_webhook
 
-        self.assertRedirects(response, reverse('community:settings'))
+        original_sleep = post_discord_webhook.retry.sleep
+        post_discord_webhook.retry.sleep = lambda _seconds: None
+        try:
+            response = self.client.post(
+                reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
+                follow=True,
+            )
+        finally:
+            post_discord_webhook.retry.sleep = original_sleep
+
+        self.assertContains(response, '通知の送信に失敗しました。(ステータスコード: 400)')
+        self.assertEqual(mock_post.call_count, 3)
+
+    @patch('website.discord_webhook.requests.post')
+    def test_test_webhook_timeout_message(self, mock_post):
+        """タイムアウトは専用メッセージを表示する."""
+        self.community.notification_webhook_url = 'https://discord.com/api/webhooks/123/abc'
+        self.community.save()
+        mock_post.side_effect = requests.Timeout("timed out")
+        self.client.login(username='主催者ユーザー', password='testpass123')
+        from website.discord_webhook import post_discord_webhook
+
+        original_sleep = post_discord_webhook.retry.sleep
+        post_discord_webhook.retry.sleep = lambda _seconds: None
+        try:
+            response = self.client.post(
+                reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
+                follow=True,
+            )
+        finally:
+            post_discord_webhook.retry.sleep = original_sleep
+
+        self.assertContains(response, '通知の送信がタイムアウトしました。')
+        self.assertEqual(mock_post.call_count, 3)
+
+    @patch('website.discord_webhook.requests.post')
+    def test_test_webhook_request_error_message(self, mock_post):
+        """接続エラーは汎用メッセージを表示する."""
+        self.community.notification_webhook_url = 'https://discord.com/api/webhooks/123/abc'
+        self.community.save()
+        mock_post.side_effect = requests.ConnectionError("connection failed")
+        self.client.login(username='主催者ユーザー', password='testpass123')
+        from website.discord_webhook import post_discord_webhook
+
+        original_sleep = post_discord_webhook.retry.sleep
+        post_discord_webhook.retry.sleep = lambda _seconds: None
+        try:
+            response = self.client.post(
+                reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
+                follow=True,
+            )
+        finally:
+            post_discord_webhook.retry.sleep = original_sleep
+
+        self.assertContains(response, '通知の送信中にエラーが発生しました。')
+        self.assertEqual(mock_post.call_count, 3)
 
     def test_test_webhook_without_url(self):
         """Webhook URLが設定されていない場合はエラー"""

--- a/app/community/tests/test_settings.py
+++ b/app/community/tests/test_settings.py
@@ -540,25 +540,39 @@ class WebhookSettingsTest(TestCase):
 
     @patch('website.discord_webhook.requests.post')
     def test_test_webhook_request_error_message(self, mock_post):
-        """接続エラーは汎用メッセージを表示する."""
+        """接続エラーは安全にlogし、汎用メッセージを表示する."""
+        sensitive_url = 'https://discord.com/api/webhooks/123456789/secret-token'
         self.community.notification_webhook_url = 'https://discord.com/api/webhooks/123/abc'
         self.community.save()
-        mock_post.side_effect = requests.ConnectionError("connection failed")
+        mock_post.side_effect = requests.ConnectionError(
+            f"connection failed for {sensitive_url}",
+        )
         self.client.login(username='主催者ユーザー', password='testpass123')
         from website.discord_webhook import post_discord_webhook
 
         original_sleep = post_discord_webhook.retry.sleep
         post_discord_webhook.retry.sleep = lambda _seconds: None
         try:
-            response = self.client.post(
-                reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
-                follow=True,
-            )
+            with self.assertLogs(
+                'community.views.settings',
+                level='WARNING',
+            ) as log_context:
+                response = self.client.post(
+                    reverse('community:test_webhook', kwargs={'pk': self.community.pk}),
+                    follow=True,
+                )
         finally:
             post_discord_webhook.retry.sleep = original_sleep
 
         self.assertContains(response, '通知の送信中にエラーが発生しました。')
         self.assertEqual(mock_post.call_count, 3)
+        logs = '\n'.join(log_context.output)
+        self.assertIn('error_type=ConnectionError', logs)
+        self.assertIn('status_code=None', logs)
+        self.assertNotIn(sensitive_url, logs)
+        self.assertNotIn('secret-token', logs)
+        self.assertNotIn('connection failed', logs)
+        self.assertNotIn('Traceback', logs)
 
     def test_test_webhook_without_url(self):
         """Webhook URLが設定されていない場合はエラー"""

--- a/app/community/views/helpers.py
+++ b/app/community/views/helpers.py
@@ -5,8 +5,10 @@ import requests
 from django.conf import settings
 
 from website.constants import build_site_url
-from website.discord_webhook import post_discord_webhook
-from website.retry import get_webhook_error_context
+from website.discord_webhook import (
+    get_webhook_error_context,
+    post_discord_webhook,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +52,8 @@ def _send_report_webhook(community, report_count):
     except requests.RequestException as error:
         error_type, status_code = get_webhook_error_context(error)
         logger.error(
-            "通報Webhook送信失敗: error_type=%s status_code=%s",
+            "通報Webhook送信失敗: community_id=%s error_type=%s status_code=%s",
+            community.pk,
             error_type,
             status_code,
         )

--- a/app/community/views/helpers.py
+++ b/app/community/views/helpers.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 from website.constants import build_site_url
 from website.discord_webhook import post_discord_webhook
+from website.retry import get_webhook_error_context
 
 logger = logging.getLogger(__name__)
 
@@ -46,5 +47,10 @@ def _send_report_webhook(community, report_count):
         logger.info(
             f"通報Webhook送信成功: Community={community.name}"
         )
-    except requests.RequestException:
-        logger.exception("通報Webhook送信で例外が発生")
+    except requests.RequestException as error:
+        error_type, status_code = get_webhook_error_context(error)
+        logger.error(
+            "通報Webhook送信失敗: error_type=%s status_code=%s",
+            error_type,
+            status_code,
+        )

--- a/app/community/views/helpers.py
+++ b/app/community/views/helpers.py
@@ -5,11 +5,10 @@ import requests
 from django.conf import settings
 
 from website.constants import build_site_url
+from website.discord_webhook import post_discord_webhook
 
 logger = logging.getLogger(__name__)
 
-# Discord Webhook 送信タイムアウト（秒）
-DISCORD_REPORT_TIMEOUT_SECONDS = 10
 # 重複通報ブロック期間（秒）= 30日
 REPORT_DUPLICATE_TTL_SECONDS = 30 * 24 * 60 * 60
 # 同一IPからの月間通報上限（全集会合計）
@@ -43,16 +42,9 @@ def _send_report_webhook(community, report_count):
     }
 
     try:
-        response = requests.post(
-            webhook_url, json=message, timeout=DISCORD_REPORT_TIMEOUT_SECONDS
+        post_discord_webhook(webhook_url, message)
+        logger.info(
+            f"通報Webhook送信成功: Community={community.name}"
         )
-        if response.ok:
-            logger.info(
-                f"通報Webhook送信成功: Community={community.name}"
-            )
-        else:
-            logger.warning(
-                f"通報Webhook送信失敗: status={response.status_code}"
-            )
     except requests.RequestException:
         logger.exception("通報Webhook送信で例外が発生")

--- a/app/community/views/settings.py
+++ b/app/community/views/settings.py
@@ -11,6 +11,7 @@ from django.views import View
 from django.views.generic import TemplateView
 
 from ta_hub.access_mixins import AuthenticatedForbiddenMixin
+from website.discord_webhook import post_discord_webhook
 
 from ..models import Community, CommunityMember, CommunityInvitation, INVITATION_EXPIRATION_DAYS
 
@@ -276,19 +277,17 @@ class TestWebhookView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
                        "このメッセージはテスト送信です。Webhook設定が正しく動作しています。"
         }
 
-        webhook_timeout_seconds = 10
         try:
-            response = requests.post(
+            post_discord_webhook(
                 community.notification_webhook_url,
-                json=test_message,
-                timeout=webhook_timeout_seconds
+                test_message,
             )
-            if response.status_code == 204:
-                messages.success(request, 'テスト通知を送信しました。Discordを確認してください。')
-            else:
-                messages.error(request, f'通知の送信に失敗しました。(ステータスコード: {response.status_code})')
+            messages.success(request, 'テスト通知を送信しました。Discordを確認してください。')
         except requests.Timeout:
             messages.error(request, '通知の送信がタイムアウトしました。')
+        except requests.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else '不明'
+            messages.error(request, f'通知の送信に失敗しました。(ステータスコード: {status_code})')
         except requests.RequestException as e:
             # ユーザーが入力した Webhook URL の不備など想定内の失敗のため
             # WARNING に降格 (docs/logging.md 規約: ユーザー操作で直せるものは WARNING)

--- a/app/community/views/settings.py
+++ b/app/community/views/settings.py
@@ -12,6 +12,7 @@ from django.views.generic import TemplateView
 
 from ta_hub.access_mixins import AuthenticatedForbiddenMixin
 from website.discord_webhook import post_discord_webhook
+from website.retry import get_webhook_error_context
 
 from ..models import Community, CommunityMember, CommunityInvitation, INVITATION_EXPIRATION_DAYS
 
@@ -283,15 +284,35 @@ class TestWebhookView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
                 test_message,
             )
             messages.success(request, 'テスト通知を送信しました。Discordを確認してください。')
-        except requests.Timeout:
+        except requests.Timeout as error:
+            error_type, status_code = get_webhook_error_context(error)
+            logger.warning(
+                "Webhookテスト送信失敗: error_type=%s status_code=%s",
+                error_type,
+                status_code,
+            )
             messages.error(request, '通知の送信がタイムアウトしました。')
-        except requests.HTTPError as e:
-            status_code = e.response.status_code if e.response is not None else '不明'
-            messages.error(request, f'通知の送信に失敗しました。(ステータスコード: {status_code})')
-        except requests.RequestException as e:
+        except requests.HTTPError as error:
+            error_type, status_code = get_webhook_error_context(error)
+            logger.warning(
+                "Webhookテスト送信失敗: error_type=%s status_code=%s",
+                error_type,
+                status_code,
+            )
+            display_status_code = status_code if status_code is not None else '不明'
+            messages.error(
+                request,
+                f'通知の送信に失敗しました。(ステータスコード: {display_status_code})',
+            )
+        except requests.RequestException as error:
             # ユーザーが入力した Webhook URL の不備など想定内の失敗のため
             # WARNING に降格 (docs/logging.md 規約: ユーザー操作で直せるものは WARNING)
-            logger.warning(f'Webhook送信エラー: {e}')
+            error_type, status_code = get_webhook_error_context(error)
+            logger.warning(
+                "Webhookテスト送信失敗: error_type=%s status_code=%s",
+                error_type,
+                status_code,
+            )
             messages.error(request, '通知の送信中にエラーが発生しました。')
 
         return redirect('community:settings')

--- a/app/community/views/settings.py
+++ b/app/community/views/settings.py
@@ -11,8 +11,10 @@ from django.views import View
 from django.views.generic import TemplateView
 
 from ta_hub.access_mixins import AuthenticatedForbiddenMixin
-from website.discord_webhook import post_discord_webhook
-from website.retry import get_webhook_error_context
+from website.discord_webhook import (
+    get_webhook_error_context,
+    post_discord_webhook,
+)
 
 from ..models import Community, CommunityMember, CommunityInvitation, INVITATION_EXPIRATION_DAYS
 
@@ -287,7 +289,9 @@ class TestWebhookView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
         except requests.Timeout as error:
             error_type, status_code = get_webhook_error_context(error)
             logger.warning(
-                "Webhookテスト送信失敗: error_type=%s status_code=%s",
+                "Webhookテスト送信失敗: community_id=%s "
+                "error_type=%s status_code=%s",
+                community.pk,
                 error_type,
                 status_code,
             )
@@ -295,7 +299,9 @@ class TestWebhookView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
         except requests.HTTPError as error:
             error_type, status_code = get_webhook_error_context(error)
             logger.warning(
-                "Webhookテスト送信失敗: error_type=%s status_code=%s",
+                "Webhookテスト送信失敗: community_id=%s "
+                "error_type=%s status_code=%s",
+                community.pk,
                 error_type,
                 status_code,
             )
@@ -309,7 +315,9 @@ class TestWebhookView(LoginRequiredMixin, AuthenticatedForbiddenMixin, View):
             # WARNING に降格 (docs/logging.md 規約: ユーザー操作で直せるものは WARNING)
             error_type, status_code = get_webhook_error_context(error)
             logger.warning(
-                "Webhookテスト送信失敗: error_type=%s status_code=%s",
+                "Webhookテスト送信失敗: community_id=%s "
+                "error_type=%s status_code=%s",
+                community.pk,
                 error_type,
                 status_code,
             )

--- a/app/event/notifications.py
+++ b/app/event/notifications.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from event.models import EventDetail
 from website.constants import build_site_url
 from website.discord_webhook import post_discord_webhook
+from website.retry import get_webhook_error_context
 
 logger = logging.getLogger(__name__)
 
@@ -248,11 +249,23 @@ def _send_discord_notification_for_new_application(
             f"Discord Webhook通知成功（新規申請）: Community={community.name}, "
             f"status={response.status_code}"
         )
-    except requests.RequestException as e:
+    except requests.RequestException as error:
         # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
-        logger.error(f"Discord Webhook通知エラー（新規申請、リトライ後）: {e}")
-    except Exception as e:
-        logger.error(f"Discord Webhook通知エラー（新規申請）: {e}")
+        error_type, status_code = get_webhook_error_context(error)
+        logger.error(
+            "Discord Webhook通知エラー（新規申請、リトライ後）: "
+            "error_type=%s status_code=%s",
+            error_type,
+            status_code,
+        )
+    except Exception as error:
+        error_type, status_code = get_webhook_error_context(error)
+        logger.error(
+            "Discord Webhook通知エラー（新規申請）: "
+            "error_type=%s status_code=%s",
+            error_type,
+            status_code,
+        )
 
 
 def _send_discord_notification_for_result(event_detail: EventDetail) -> None:
@@ -302,11 +315,23 @@ def _send_discord_notification_for_result(event_detail: EventDetail) -> None:
             f"Discord Webhook通知成功（申請結果）: Community={community.name}, "
             f"status={event_detail.status}"
         )
-    except requests.RequestException as e:
+    except requests.RequestException as error:
         # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
-        logger.error(f"Discord Webhook通知エラー（申請結果、リトライ後）: {e}")
-    except Exception as e:
-        logger.error(f"Discord Webhook通知エラー（申請結果）: {e}")
+        error_type, status_code = get_webhook_error_context(error)
+        logger.error(
+            "Discord Webhook通知エラー（申請結果、リトライ後）: "
+            "error_type=%s status_code=%s",
+            error_type,
+            status_code,
+        )
+    except Exception as error:
+        error_type, status_code = get_webhook_error_context(error)
+        logger.error(
+            "Discord Webhook通知エラー（申請結果）: "
+            "error_type=%s status_code=%s",
+            error_type,
+            status_code,
+        )
 
 
 def notify_slide_material_published(event_detail: EventDetail) -> None:
@@ -373,16 +398,20 @@ def notify_slide_material_published(event_detail: EventDetail) -> None:
             community.name,
             event_detail.pk,
         )
-    except requests.RequestException as e:
+    except requests.RequestException as error:
         # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
+        error_type, status_code = get_webhook_error_context(error)
         logger.error(
-            "Discord Webhook通知エラー（資料公開、リトライ後）: EventDetail=%s, error=%s",
-            event_detail.pk,
-            e,
+            "Discord Webhook通知エラー（資料公開、リトライ後）: "
+            "error_type=%s status_code=%s",
+            error_type,
+            status_code,
         )
-    except Exception as e:
+    except Exception as error:
+        error_type, status_code = get_webhook_error_context(error)
         logger.error(
-            "Discord Webhook通知エラー（資料公開）: EventDetail=%s, error=%s",
-            event_detail.pk,
-            e,
+            "Discord Webhook通知エラー（資料公開）: "
+            "error_type=%s status_code=%s",
+            error_type,
+            status_code,
         )

--- a/app/event/notifications.py
+++ b/app/event/notifications.py
@@ -254,7 +254,9 @@ def _send_discord_notification_for_new_application(
         error_type, status_code = get_webhook_error_context(error)
         logger.error(
             "Discord Webhook通知エラー（新規申請、リトライ後）: "
-            "error_type=%s status_code=%s",
+            "community_id=%s event_detail_id=%s error_type=%s status_code=%s",
+            community.pk,
+            event_detail.pk,
             error_type,
             status_code,
         )
@@ -262,7 +264,9 @@ def _send_discord_notification_for_new_application(
         error_type, status_code = get_webhook_error_context(error)
         logger.error(
             "Discord Webhook通知エラー（新規申請）: "
-            "error_type=%s status_code=%s",
+            "community_id=%s event_detail_id=%s error_type=%s status_code=%s",
+            community.pk,
+            event_detail.pk,
             error_type,
             status_code,
         )
@@ -320,7 +324,9 @@ def _send_discord_notification_for_result(event_detail: EventDetail) -> None:
         error_type, status_code = get_webhook_error_context(error)
         logger.error(
             "Discord Webhook通知エラー（申請結果、リトライ後）: "
-            "error_type=%s status_code=%s",
+            "community_id=%s event_detail_id=%s error_type=%s status_code=%s",
+            community.pk,
+            event_detail.pk,
             error_type,
             status_code,
         )
@@ -328,7 +334,9 @@ def _send_discord_notification_for_result(event_detail: EventDetail) -> None:
         error_type, status_code = get_webhook_error_context(error)
         logger.error(
             "Discord Webhook通知エラー（申請結果）: "
-            "error_type=%s status_code=%s",
+            "community_id=%s event_detail_id=%s error_type=%s status_code=%s",
+            community.pk,
+            event_detail.pk,
             error_type,
             status_code,
         )
@@ -403,7 +411,9 @@ def notify_slide_material_published(event_detail: EventDetail) -> None:
         error_type, status_code = get_webhook_error_context(error)
         logger.error(
             "Discord Webhook通知エラー（資料公開、リトライ後）: "
-            "error_type=%s status_code=%s",
+            "community_id=%s event_detail_id=%s error_type=%s status_code=%s",
+            community.pk,
+            event_detail.pk,
             error_type,
             status_code,
         )
@@ -411,7 +421,9 @@ def notify_slide_material_published(event_detail: EventDetail) -> None:
         error_type, status_code = get_webhook_error_context(error)
         logger.error(
             "Discord Webhook通知エラー（資料公開）: "
-            "error_type=%s status_code=%s",
+            "community_id=%s event_detail_id=%s error_type=%s status_code=%s",
+            community.pk,
+            event_detail.pk,
             error_type,
             status_code,
         )

--- a/app/event/notifications.py
+++ b/app/event/notifications.py
@@ -9,8 +9,10 @@ from django.urls import reverse
 
 from event.models import EventDetail
 from website.constants import build_site_url
-from website.discord_webhook import post_discord_webhook
-from website.retry import get_webhook_error_context
+from website.discord_webhook import (
+    get_webhook_error_context,
+    post_discord_webhook,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -250,7 +252,7 @@ def _send_discord_notification_for_new_application(
             f"status={response.status_code}"
         )
     except requests.RequestException as error:
-        # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
+        # gateway で回復できなかった最終失敗のみここに到達する
         error_type, status_code = get_webhook_error_context(error)
         logger.error(
             "Discord Webhook通知エラー（新規申請、リトライ後）: "
@@ -320,7 +322,7 @@ def _send_discord_notification_for_result(event_detail: EventDetail) -> None:
             f"status={event_detail.status}"
         )
     except requests.RequestException as error:
-        # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
+        # gateway で回復できなかった最終失敗のみここに到達する
         error_type, status_code = get_webhook_error_context(error)
         logger.error(
             "Discord Webhook通知エラー（申請結果、リトライ後）: "
@@ -407,7 +409,7 @@ def notify_slide_material_published(event_detail: EventDetail) -> None:
             event_detail.pk,
         )
     except requests.RequestException as error:
-        # tenacity が 3 回まで再試行した上での最終失敗のみここに到達する
+        # gateway で回復できなかった最終失敗のみここに到達する
         error_type, status_code = get_webhook_error_context(error)
         logger.error(
             "Discord Webhook通知エラー（資料公開、リトライ後）: "

--- a/app/event/tests/test_notifications.py
+++ b/app/event/tests/test_notifications.py
@@ -258,10 +258,20 @@ class DiscordNotificationForNewApplicationTest(TweetGenerationPatchMixin, TestCa
 
     @patch("website.discord_webhook.requests.post")
     def test_handles_non_ok_response(self, mock_post):
-        """4xx/5xx 応答時もクラッシュしない（log warning のみ）"""
+        """4xx/5xx 応答を3回試行後も呼び出し元は継続する."""
+        from website.discord_webhook import post_discord_webhook
+
         mock_post.return_value = MagicMock(ok=False, status_code=500)
-        _send_discord_notification_for_new_application(self.event_detail, "https://example.com/review/1")
-        mock_post.assert_called_once()
+        original_sleep = post_discord_webhook.retry.sleep
+        post_discord_webhook.retry.sleep = lambda _seconds: None
+        try:
+            _send_discord_notification_for_new_application(
+                self.event_detail,
+                "https://example.com/review/1",
+            )
+        finally:
+            post_discord_webhook.retry.sleep = original_sleep
+        self.assertEqual(mock_post.call_count, 3)
 
 
 class DiscordNotificationForResultTest(TweetGenerationPatchMixin, TestCase):

--- a/app/event/tests/test_notifications.py
+++ b/app/event/tests/test_notifications.py
@@ -14,6 +14,7 @@ from community.models import CommunityMember
 from event.notifications import (
     notify_owners_of_new_application,
     notify_applicant_of_result,
+    notify_slide_material_published,
     _send_discord_notification_for_new_application,
     _send_discord_notification_for_result,
 )
@@ -319,6 +320,73 @@ class DiscordNotificationForResultTest(TweetGenerationPatchMixin, TestCase):
         event_detail = _make_event_detail(self.event, applicant=self.applicant, status="approved")
         _send_discord_notification_for_result(event_detail)
         mock_post.assert_not_called()
+
+
+class DiscordWebhookSafeLoggingTest(TweetGenerationPatchMixin, TestCase):
+    """event.notifications の3つのWebhook経路で安全な最終ログを検証する."""
+
+    def setUp(self):
+        self.owner = _make_user("owner1", "owner1@example.com")
+        self.applicant = _make_user("applicant1", "applicant1@example.com")
+        self.community = _make_community(
+            owner=self.owner,
+            webhook_url=WEBHOOK_URL,
+        )
+        self.event = _make_event(self.community)
+        self.event_detail = _make_event_detail(
+            self.event,
+            applicant=self.applicant,
+            status="approved",
+        )
+
+    @patch("website.discord_webhook.requests.post")
+    def test_all_webhook_failures_exclude_url_and_exception_message(self, mock_post):
+        """全3経路の最終ログからURL・token・例外本文・tracebackを除外する."""
+        from website.discord_webhook import post_discord_webhook
+
+        sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
+        senders = (
+            (
+                "new_application",
+                lambda: _send_discord_notification_for_new_application(
+                    self.event_detail,
+                    "https://example.com/review/1",
+                ),
+            ),
+            (
+                "application_result",
+                lambda: _send_discord_notification_for_result(self.event_detail),
+            ),
+            (
+                "slide_published",
+                lambda: notify_slide_material_published(self.event_detail),
+            ),
+        )
+        original_sleep = post_discord_webhook.retry.sleep
+        post_discord_webhook.retry.sleep = lambda _seconds: None
+        try:
+            for label, send in senders:
+                with self.subTest(label=label):
+                    mock_post.reset_mock()
+                    mock_post.side_effect = requests.RequestException(
+                        f"request failed for {sensitive_url}",
+                    )
+                    with self.assertLogs(
+                        "event.notifications",
+                        level="ERROR",
+                    ) as log_context:
+                        send()
+
+                    logs = "\n".join(log_context.output)
+                    self.assertEqual(mock_post.call_count, 3)
+                    self.assertIn("error_type=RequestException", logs)
+                    self.assertIn("status_code=None", logs)
+                    self.assertNotIn(sensitive_url, logs)
+                    self.assertNotIn("secret-token", logs)
+                    self.assertNotIn("request failed", logs)
+                    self.assertNotIn("Traceback", logs)
+        finally:
+            post_discord_webhook.retry.sleep = original_sleep
 
 
 class DiscordWebhookRetryTest(TweetGenerationPatchMixin, TestCase):

--- a/app/event/tests/test_notifications.py
+++ b/app/event/tests/test_notifications.py
@@ -379,6 +379,8 @@ class DiscordWebhookSafeLoggingTest(TweetGenerationPatchMixin, TestCase):
 
                     logs = "\n".join(log_context.output)
                     self.assertEqual(mock_post.call_count, 3)
+                    self.assertIn(f"community_id={self.community.pk}", logs)
+                    self.assertIn(f"event_detail_id={self.event_detail.pk}", logs)
                     self.assertIn("error_type=RequestException", logs)
                     self.assertIn("status_code=None", logs)
                     self.assertNotIn(sensitive_url, logs)

--- a/app/event/tests/test_notifications.py
+++ b/app/event/tests/test_notifications.py
@@ -117,7 +117,7 @@ class NotifyOwnersOfNewApplicationTest(TweetGenerationPatchMixin, TestCase):
         notify_owners_of_new_application(self.event_detail)
         mock_send_mail.assert_called_once()
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     def test_calls_discord_webhook_when_url_set(self, mock_post):
         """webhook_url 設定済みなら Discord 通知が呼ばれる"""
         self.community.notification_webhook_url = WEBHOOK_URL
@@ -198,19 +198,18 @@ class DiscordNotificationForNewApplicationTest(TweetGenerationPatchMixin, TestCa
         self.event = _make_event(self.community)
         self.event_detail = _make_event_detail(self.event, applicant=self.applicant)
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     def test_posts_to_webhook_when_url_set(self, mock_post):
         """webhook_url 設定時に POST される"""
         mock_post.return_value = MagicMock(ok=True, status_code=200)
         _send_discord_notification_for_new_application(self.event_detail, "https://example.com/review/1")
         mock_post.assert_called_once()
-        kwargs = mock_post.call_args.kwargs
-        self.assertIn("json", kwargs)
+        payload = mock_post.call_args.args[1]
         # content / embeds 構造の最小検証
-        self.assertIn("content", kwargs["json"])
-        self.assertIn("embeds", kwargs["json"])
+        self.assertIn("content", payload)
+        self.assertIn("embeds", payload)
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     def test_skipped_when_webhook_url_empty(self, mock_post):
         """webhook_url 空なら POST されない"""
         self.community.notification_webhook_url = ""
@@ -218,7 +217,7 @@ class DiscordNotificationForNewApplicationTest(TweetGenerationPatchMixin, TestCa
         _send_discord_notification_for_new_application(self.event_detail, "https://example.com/review/1")
         mock_post.assert_not_called()
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     def test_truncates_long_additional_info(self, mock_post):
         """additional_info が 1000 文字超なら切り詰め + ... サフィックス"""
         long_text = "a" * 1500
@@ -226,7 +225,7 @@ class DiscordNotificationForNewApplicationTest(TweetGenerationPatchMixin, TestCa
         self.event_detail.save()
         mock_post.return_value = MagicMock(ok=True, status_code=200)
         _send_discord_notification_for_new_application(self.event_detail, "https://example.com/review/1")
-        payload = mock_post.call_args.kwargs["json"]
+        payload = mock_post.call_args.args[1]
         additional_field = next(
             (f for f in payload["embeds"][0]["fields"] if "追加情報" in f["name"]),
             None,
@@ -236,43 +235,28 @@ class DiscordNotificationForNewApplicationTest(TweetGenerationPatchMixin, TestCa
         self.assertTrue(additional_field["value"].endswith("..."))
         self.assertEqual(len(additional_field["value"]), 1003)
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     def test_swallows_request_exception(self, mock_post):
-        """requests 例外時もクラッシュしない（silent failure 検出）.
-
-        tenacity リトライ導入後は 3 回まで再試行される。回数ではなく
-        「例外を吸い込んで完了する」ことを検証する。
-        テスト中はバックオフ待機を 0 秒化して高速化する。
-        """
-        from website.discord_webhook import post_discord_webhook
-
+        """gateway最終失敗時も呼び出し元処理を継続する."""
         mock_post.side_effect = requests.RequestException("network down")
-        original_sleep = post_discord_webhook.retry.sleep
-        post_discord_webhook.retry.sleep = lambda *args, **kwargs: None
-        try:
-            # 例外を投げずに完了する
-            _send_discord_notification_for_new_application(self.event_detail, "https://example.com/review/1")
-        finally:
-            post_discord_webhook.retry.sleep = original_sleep
-        # 3 回再試行された（初回 + リトライ2回）
-        self.assertEqual(mock_post.call_count, 3)
+        _send_discord_notification_for_new_application(
+            self.event_detail,
+            "https://example.com/review/1",
+        )
+        mock_post.assert_called_once()
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     def test_handles_non_ok_response(self, mock_post):
-        """4xx/5xx 応答を3回試行後も呼び出し元は継続する."""
-        from website.discord_webhook import post_discord_webhook
-
-        mock_post.return_value = MagicMock(ok=False, status_code=500)
-        original_sleep = post_discord_webhook.retry.sleep
-        post_discord_webhook.retry.sleep = lambda _seconds: None
-        try:
-            _send_discord_notification_for_new_application(
-                self.event_detail,
-                "https://example.com/review/1",
-            )
-        finally:
-            post_discord_webhook.retry.sleep = original_sleep
-        self.assertEqual(mock_post.call_count, 3)
+        """gatewayのHTTP最終失敗後も呼び出し元は継続する."""
+        mock_post.side_effect = requests.HTTPError(
+            "server error",
+            response=MagicMock(status_code=500),
+        )
+        _send_discord_notification_for_new_application(
+            self.event_detail,
+            "https://example.com/review/1",
+        )
+        mock_post.assert_called_once()
 
 
 class DiscordNotificationForResultTest(TweetGenerationPatchMixin, TestCase):
@@ -284,17 +268,17 @@ class DiscordNotificationForResultTest(TweetGenerationPatchMixin, TestCase):
         self.community = _make_community(owner=self.owner, webhook_url=WEBHOOK_URL)
         self.event = _make_event(self.community)
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     def test_approved_uses_green_color(self, mock_post):
         """承認時の embed color が緑 (5763719)"""
         event_detail = _make_event_detail(self.event, applicant=self.applicant, status="approved")
         mock_post.return_value = MagicMock(ok=True, status_code=200)
         _send_discord_notification_for_result(event_detail)
-        payload = mock_post.call_args.kwargs["json"]
+        payload = mock_post.call_args.args[1]
         self.assertEqual(payload["embeds"][0]["color"], 5763719)
         self.assertIn("✅", payload["embeds"][0]["title"])
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     def test_rejected_uses_red_color_and_includes_reason(self, mock_post):
         """却下時の embed color が赤 (15548997)、却下理由が fields に含まれる"""
         event_detail = _make_event_detail(self.event, applicant=self.applicant, status="rejected")
@@ -302,7 +286,7 @@ class DiscordNotificationForResultTest(TweetGenerationPatchMixin, TestCase):
         event_detail.save()
         mock_post.return_value = MagicMock(ok=True, status_code=200)
         _send_discord_notification_for_result(event_detail)
-        payload = mock_post.call_args.kwargs["json"]
+        payload = mock_post.call_args.args[1]
         self.assertEqual(payload["embeds"][0]["color"], 15548997)
         self.assertIn("❌", payload["embeds"][0]["title"])
         reason_field = next(
@@ -312,7 +296,7 @@ class DiscordNotificationForResultTest(TweetGenerationPatchMixin, TestCase):
         self.assertIsNotNone(reason_field)
         self.assertEqual(reason_field["value"], "テーマが要件に合致しません")
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     def test_skipped_when_webhook_url_empty(self, mock_post):
         """webhook_url 空なら POST されない"""
         self.community.notification_webhook_url = ""
@@ -339,11 +323,9 @@ class DiscordWebhookSafeLoggingTest(TweetGenerationPatchMixin, TestCase):
             status="approved",
         )
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     def test_all_webhook_failures_exclude_url_and_exception_message(self, mock_post):
         """全3経路の最終ログからURL・token・例外本文・tracebackを除外する."""
-        from website.discord_webhook import post_discord_webhook
-
         sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
         senders = (
             (
@@ -362,106 +344,25 @@ class DiscordWebhookSafeLoggingTest(TweetGenerationPatchMixin, TestCase):
                 lambda: notify_slide_material_published(self.event_detail),
             ),
         )
-        original_sleep = post_discord_webhook.retry.sleep
-        post_discord_webhook.retry.sleep = lambda _seconds: None
-        try:
-            for label, send in senders:
-                with self.subTest(label=label):
-                    mock_post.reset_mock()
-                    mock_post.side_effect = requests.RequestException(
-                        f"request failed for {sensitive_url}",
-                    )
-                    with self.assertLogs(
-                        "event.notifications",
-                        level="ERROR",
-                    ) as log_context:
-                        send()
+        for label, send in senders:
+            with self.subTest(label=label):
+                mock_post.reset_mock()
+                mock_post.side_effect = requests.RequestException(
+                    f"request failed for {sensitive_url}",
+                )
+                with self.assertLogs(
+                    "event.notifications",
+                    level="ERROR",
+                ) as log_context:
+                    send()
 
-                    logs = "\n".join(log_context.output)
-                    self.assertEqual(mock_post.call_count, 3)
-                    self.assertIn(f"community_id={self.community.pk}", logs)
-                    self.assertIn(f"event_detail_id={self.event_detail.pk}", logs)
-                    self.assertIn("error_type=RequestException", logs)
-                    self.assertIn("status_code=None", logs)
-                    self.assertNotIn(sensitive_url, logs)
-                    self.assertNotIn("secret-token", logs)
-                    self.assertNotIn("request failed", logs)
-                    self.assertNotIn("Traceback", logs)
-        finally:
-            post_discord_webhook.retry.sleep = original_sleep
-
-
-class DiscordWebhookRetryTest(TweetGenerationPatchMixin, TestCase):
-    """tenacity リトライ機構の挙動検証
-
-    一過性ネットワーク失敗で webhook が永遠に失われる問題を解消するため、
-    `post_discord_webhook` に tenacity による 3 回まで指数バックオフリトライを
-    導入した。本テストはその振る舞いを mock で検証する。
-    """
-
-    def setUp(self):
-        self.owner = _make_user("owner1", "owner1@example.com")
-        self.applicant = _make_user("applicant1", "applicant1@example.com")
-        self.community = _make_community(owner=self.owner, webhook_url=WEBHOOK_URL)
-        self.event = _make_event(self.community)
-        self.event_detail = _make_event_detail(self.event, applicant=self.applicant)
-
-        # tenacity 内部の sleep を 0 秒化（テスト高速化）
-        from website.discord_webhook import post_discord_webhook
-        self._wrapped = post_discord_webhook
-        self._original_sleep = self._wrapped.retry.sleep
-        self._wrapped.retry.sleep = lambda *args, **kwargs: None
-
-    def tearDown(self):
-        # sleep を元に戻す（他テストへの副作用を防ぐ）
-        self._wrapped.retry.sleep = self._original_sleep
-
-    @patch("website.discord_webhook.requests.post")
-    def test_retries_until_success_on_second_attempt(self, mock_post):
-        """1 回目失敗 → 2 回目成功でリトライが動作する"""
-        success_response = MagicMock(ok=True, status_code=200)
-        # raise_for_status は成功時は何もしない（デフォルト MagicMock 挙動）
-        mock_post.side_effect = [
-            requests.RequestException("transient network error"),
-            success_response,
-        ]
-        _send_discord_notification_for_new_application(
-            self.event_detail, "https://example.com/review/1"
-        )
-        # 2 回呼ばれた（1 回目失敗 + 2 回目成功）
-        self.assertEqual(mock_post.call_count, 2)
-
-    @patch("website.discord_webhook.requests.post")
-    def test_silent_failure_after_three_consecutive_failures(self, mock_post):
-        """3 回連続失敗で例外を吸い込み silent failure になる"""
-        mock_post.side_effect = requests.RequestException("network down")
-        # 例外を投げずに完了する（呼び出し元の try/except が最終失敗をキャッチ）
-        _send_discord_notification_for_new_application(
-            self.event_detail, "https://example.com/review/1"
-        )
-        # 3 回再試行された（初回 + リトライ2回）
-        self.assertEqual(mock_post.call_count, 3)
-
-    @patch("website.discord_webhook.requests.post")
-    def test_no_retry_on_first_success(self, mock_post):
-        """1 回成功時の挙動が変わらない（後方互換性: リトライ無し）"""
-        mock_post.return_value = MagicMock(ok=True, status_code=200)
-        _send_discord_notification_for_new_application(
-            self.event_detail, "https://example.com/review/1"
-        )
-        # 成功なら 1 回しか呼ばれない（リトライしない）
-        self.assertEqual(mock_post.call_count, 1)
-
-    @patch("website.discord_webhook.requests.post")
-    def test_retries_on_timeout_exception(self, mock_post):
-        """requests.Timeout もリトライ対象になる"""
-        mock_post.side_effect = [
-            requests.Timeout("read timeout"),
-            requests.Timeout("read timeout"),
-            MagicMock(ok=True, status_code=200),
-        ]
-        _send_discord_notification_for_new_application(
-            self.event_detail, "https://example.com/review/1"
-        )
-        # 3 回で成功
-        self.assertEqual(mock_post.call_count, 3)
+                logs = "\n".join(log_context.output)
+                mock_post.assert_called_once()
+                self.assertIn(f"community_id={self.community.pk}", logs)
+                self.assertIn(f"event_detail_id={self.event_detail.pk}", logs)
+                self.assertIn("error_type=RequestException", logs)
+                self.assertIn("status_code=None", logs)
+                self.assertNotIn(sensitive_url, logs)
+                self.assertNotIn("secret-token", logs)
+                self.assertNotIn("request failed", logs)
+                self.assertNotIn("Traceback", logs)

--- a/app/twitter/notifications.py
+++ b/app/twitter/notifications.py
@@ -8,8 +8,10 @@ from django.conf import settings
 
 from twitter.x_api import PostTweetResult
 from website.constants import build_site_url
-from website.discord_webhook import post_discord_webhook
-from website.retry import get_webhook_error_context
+from website.discord_webhook import (
+    get_webhook_error_context,
+    post_discord_webhook,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/app/twitter/notifications.py
+++ b/app/twitter/notifications.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from twitter.x_api import PostTweetResult
 from website.constants import build_site_url
 from website.discord_webhook import post_discord_webhook
+from website.retry import get_webhook_error_context
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,12 @@ def notify_tweet_post_failure(queue_item, result: PostTweetResult) -> None:
         logger.info(
             "Admin Webhook通知成功（投稿失敗）: queue #%s", queue_item.pk,
         )
-    except Exception:
-        logger.exception(
-            "Admin Webhook通知エラー（投稿失敗）: queue #%s", queue_item.pk,
+    except Exception as error:
+        error_type, status_code = get_webhook_error_context(error)
+        logger.error(
+            "Admin Webhook通知エラー（投稿失敗）: queue=%s "
+            "error_type=%s status_code=%s",
+            queue_item.pk,
+            error_type,
+            status_code,
         )

--- a/app/twitter/notifications.py
+++ b/app/twitter/notifications.py
@@ -4,15 +4,14 @@
 """
 import logging
 
-import requests
 from django.conf import settings
 
 from twitter.x_api import PostTweetResult
 from website.constants import build_site_url
+from website.discord_webhook import post_discord_webhook
 
 logger = logging.getLogger(__name__)
 
-DISCORD_TIMEOUT_SECONDS = 10
 DISCORD_FIELD_MAX_LENGTH = 1024
 DISCORD_DESC_MAX_LENGTH = 4000
 COLOR_RED = 15548997
@@ -61,19 +60,10 @@ def notify_tweet_post_failure(queue_item, result: PostTweetResult) -> None:
     }
 
     try:
-        response = requests.post(
-            webhook_url, json=message, timeout=DISCORD_TIMEOUT_SECONDS,
+        post_discord_webhook(webhook_url, message)
+        logger.info(
+            "Admin Webhook通知成功（投稿失敗）: queue #%s", queue_item.pk,
         )
-        if response.ok:
-            logger.info(
-                "Admin Webhook通知成功（投稿失敗）: queue #%s", queue_item.pk,
-            )
-        else:
-            logger.warning(
-                "Admin Webhook通知失敗（投稿失敗）: queue #%s, status=%s",
-                queue_item.pk,
-                response.status_code,
-            )
     except Exception:
         logger.exception(
             "Admin Webhook通知エラー（投稿失敗）: queue #%s", queue_item.pk,

--- a/app/twitter/services/tweet_scheduling_service.py
+++ b/app/twitter/services/tweet_scheduling_service.py
@@ -135,7 +135,7 @@ def post_tweet_queue_item(
     upload_media_func: UploadMediaCallable = upload_media_to_x,
     notify_failure_func: FailureNotifier = notify_tweet_post_failure,
 ) -> dict[str, object]:
-    """TweetQueue 1件を X API に投稿し、失敗状態を通知前に保存する."""
+    """TweetQueue 1件を X API に投稿し、結果を保存してから返す."""
     media_ids = None
     if queue_item.image_url:
         media_id = upload_media_func(queue_item.image_url)
@@ -149,6 +149,12 @@ def post_tweet_queue_item(
         queue_item.tweet_id = (result["data"] or {}).get('id', '')
         queue_item.posted_at = timezone.now()
         queue_item.error_message = ''
+        run_with_db_reconnect(
+            lambda: queue_item.save(
+                update_fields=['status', 'tweet_id', 'posted_at', 'error_message'],
+            ),
+            context=f"post_tweet_queue_item_save_success queue={queue_item.pk}",
+        )
         return {
             "id": queue_item.pk, "status": "posted", "tweet_id": queue_item.tweet_id,
         }
@@ -296,10 +302,6 @@ def process_scheduled_tweets(
         else:
             logger.warning("Tweet post failed for queue %d", queue_item.pk)
 
-        run_with_db_reconnect(
-            queue_item.save,
-            context=f"post_scheduled_tweets_save_result queue={queue_item.pk}",
-        )
         posted_attempted = True
         break
 

--- a/app/twitter/services/tweet_scheduling_service.py
+++ b/app/twitter/services/tweet_scheduling_service.py
@@ -135,7 +135,7 @@ def post_tweet_queue_item(
     upload_media_func: UploadMediaCallable = upload_media_to_x,
     notify_failure_func: FailureNotifier = notify_tweet_post_failure,
 ) -> dict[str, object]:
-    """TweetQueue 1件を X API に投稿し、保存前の結果を返す."""
+    """TweetQueue 1件を X API に投稿し、失敗状態を通知前に保存する."""
     media_ids = None
     if queue_item.image_url:
         media_id = upload_media_func(queue_item.image_url)
@@ -159,8 +159,16 @@ def post_tweet_queue_item(
     queue_item.error_message = (
         f'X API投稿に失敗 (status={status_code})' if status_code else 'X API投稿に失敗'
     )
-    if result.get("error_body"):
-        queue_item.error_message = f"{queue_item.error_message}: {result['error_body'][:300]}"
+    error_body = result.get("error_body")
+    if error_body:
+        queue_item.error_message = f"{queue_item.error_message}: {error_body[:300]}"
+    failure_update_fields = ['error_message']
+    if failure_status is not None:
+        failure_update_fields.append('status')
+    run_with_db_reconnect(
+        lambda: queue_item.save(update_fields=failure_update_fields),
+        context=f"post_tweet_queue_item_save_failure queue={queue_item.pk}",
+    )
     notify_failure_func(queue_item, result)
     return {
         "id": queue_item.pk, "status": "failed", "error": "post_failed",

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -998,7 +998,7 @@ class PostScheduledTweetsViewTest(AutoTweetTestBase):
         self.assertEqual(second.status, "ready")
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("website.discord_webhook.requests.post")
+    @patch("twitter.notifications.post_discord_webhook")
     @patch("twitter.views.post_tweet")
     def test_post_scheduled_tweets_post_failure(self, mock_post, mock_webhook_post):
         """X API 投稿失敗時にキューが failed になり管理者へ通知が送られる"""
@@ -3022,7 +3022,7 @@ class SlideShareSignalTest(AutoTweetTestBase):
         self.assertEqual(timezone.localtime(queue.scheduled_at).hour, 10)
         mock_thread_cls.assert_called_once()
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_share_sends_community_webhook(self, mock_thread_cls, mock_post):
         """資料公開時は集会に設定したWebhookへ通知を送る"""
@@ -3036,7 +3036,7 @@ class SlideShareSignalTest(AutoTweetTestBase):
 
         mock_post.assert_called_once()
         self.assertEqual(mock_post.call_args[0][0], self.community.notification_webhook_url)
-        payload = mock_post.call_args[1]["json"]
+        payload = mock_post.call_args.args[1]
         self.assertEqual(payload["content"], "📚 **資料公開のお知らせ**")
         self.assertEqual(payload["embeds"][0]["title"], "登壇資料が公開されました")
         self.assertEqual(payload["embeds"][0]["description"], f"**{self.detail.theme}**")
@@ -3047,7 +3047,7 @@ class SlideShareSignalTest(AutoTweetTestBase):
         AWS_S3_CUSTOM_DOMAIN="data.vrc-ta-hub.com",
         MEDIA_URL="https://data.vrc-ta-hub.com/",
     )
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_share_webhook_uses_event_detail_thumbnail_image(
         self, mock_thread_cls, mock_post,
@@ -3062,7 +3062,7 @@ class SlideShareSignalTest(AutoTweetTestBase):
         self.detail.slide_url = "https://example.com/slides"
         self.detail.save()
 
-        payload = mock_post.call_args[1]["json"]
+        payload = mock_post.call_args.args[1]
         image_url = payload["embeds"][0]["image"]["url"]
         self.assertEqual(image_url, "https://data.vrc-ta-hub.com/thumbnail/generated.jpg")
 
@@ -3070,7 +3070,7 @@ class SlideShareSignalTest(AutoTweetTestBase):
         AWS_S3_CUSTOM_DOMAIN="data.vrc-ta-hub.com",
         MEDIA_URL="https://data.vrc-ta-hub.com/",
     )
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_share_webhook_falls_back_to_community_poster_image(
         self, mock_thread_cls, mock_post,
@@ -3085,11 +3085,11 @@ class SlideShareSignalTest(AutoTweetTestBase):
         self.detail.slide_url = "https://example.com/slides"
         self.detail.save()
 
-        payload = mock_post.call_args[1]["json"]
+        payload = mock_post.call_args.args[1]
         image_url = payload["embeds"][0]["image"]["url"]
         self.assertEqual(image_url, "https://data.vrc-ta-hub.com/poster/community.webp")
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_share_without_webhook_does_not_send_notification(self, mock_thread_cls, mock_post):
         """Webhook未設定なら資料公開通知は送らない"""
@@ -3100,14 +3100,12 @@ class SlideShareSignalTest(AutoTweetTestBase):
 
         mock_post.assert_not_called()
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_share_webhook_failure_does_not_block_queue_creation(
         self, mock_thread_cls, mock_post,
     ):
         """Webhook失敗を安全にlogし、slide_shareキュー作成は継続する."""
-        from website.discord_webhook import post_discord_webhook
-
         sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
         mock_post.side_effect = requests.RequestException(
             f"timeout for {sensitive_url}",
@@ -3116,20 +3114,15 @@ class SlideShareSignalTest(AutoTweetTestBase):
         self.community.notification_webhook_url = "https://discord.com/api/webhooks/123/abc"
         self.community.save(update_fields=["notification_webhook_url"])
 
-        original_sleep = post_discord_webhook.retry.sleep
-        post_discord_webhook.retry.sleep = lambda _seconds: None
-        try:
-            with self.assertLogs(
-                "event.notifications",
-                level="ERROR",
-            ) as log_context:
-                self.detail.slide_url = "https://example.com/slides"
-                self.detail.save()
-        finally:
-            post_discord_webhook.retry.sleep = original_sleep
+        with self.assertLogs(
+            "event.notifications",
+            level="ERROR",
+        ) as log_context:
+            self.detail.slide_url = "https://example.com/slides"
+            self.detail.save()
 
         self.assertEqual(TweetQueue.objects.count(), 1)
-        self.assertEqual(mock_post.call_count, 3)
+        mock_post.assert_called_once()
         logs = "\n".join(log_context.output)
         self.assertIn("error_type=RequestException", logs)
         self.assertIn("status_code=None", logs)
@@ -3150,7 +3143,7 @@ class SlideShareSignalTest(AutoTweetTestBase):
         queue = TweetQueue.objects.first()
         self.assertEqual(queue.tweet_type, "slide_share")
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_youtube_only_does_not_send_slide_webhook(self, mock_thread_cls, mock_post):
         """YouTubeのみ追加した場合はスライドWebhook通知を送らない"""
@@ -3261,7 +3254,7 @@ class SlideShareSignalTest(AutoTweetTestBase):
         self.assertEqual(TweetQueue.objects.count(), 1)
         self.assertEqual(queue.image_url, poster_url)
 
-    @patch("website.discord_webhook.requests.post")
+    @patch("event.notifications.post_discord_webhook")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_webhook_still_sent_when_youtube_queue_already_exists(
         self, mock_thread_cls, mock_post,

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -8,6 +8,7 @@ import datetime
 from django.db import DatabaseError, IntegrityError, OperationalError, transaction
 from unittest.mock import MagicMock, Mock, patch
 
+import requests
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase, TransactionTestCase, override_settings, tag
@@ -3021,12 +3022,12 @@ class SlideShareSignalTest(AutoTweetTestBase):
         self.assertEqual(timezone.localtime(queue.scheduled_at).hour, 10)
         mock_thread_cls.assert_called_once()
 
-    @patch("event.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_share_sends_community_webhook(self, mock_thread_cls, mock_post):
         """資料公開時は集会に設定したWebhookへ通知を送る"""
         mock_thread_cls.return_value = MagicMock()
-        mock_post.return_value = MagicMock(ok=True)
+        mock_post.return_value = MagicMock(status_code=200)
         self.community.notification_webhook_url = "https://discord.com/api/webhooks/123/abc"
         self.community.save(update_fields=["notification_webhook_url"])
 
@@ -3046,14 +3047,14 @@ class SlideShareSignalTest(AutoTweetTestBase):
         AWS_S3_CUSTOM_DOMAIN="data.vrc-ta-hub.com",
         MEDIA_URL="https://data.vrc-ta-hub.com/",
     )
-    @patch("event.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_share_webhook_uses_event_detail_thumbnail_image(
         self, mock_thread_cls, mock_post,
     ):
         """資料公開通知にはEventDetailのOGP画像を表示する."""
         mock_thread_cls.return_value = MagicMock()
-        mock_post.return_value = MagicMock(ok=True)
+        mock_post.return_value = MagicMock(status_code=200)
         self.community.notification_webhook_url = "https://discord.com/api/webhooks/123/abc"
         self.community.save(update_fields=["notification_webhook_url"])
 
@@ -3069,14 +3070,14 @@ class SlideShareSignalTest(AutoTweetTestBase):
         AWS_S3_CUSTOM_DOMAIN="data.vrc-ta-hub.com",
         MEDIA_URL="https://data.vrc-ta-hub.com/",
     )
-    @patch("event.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_share_webhook_falls_back_to_community_poster_image(
         self, mock_thread_cls, mock_post,
     ):
         """EventDetail画像がない場合は集会ポスターを表示する."""
         mock_thread_cls.return_value = MagicMock()
-        mock_post.return_value = MagicMock(ok=True)
+        mock_post.return_value = MagicMock(status_code=200)
         self.community.notification_webhook_url = "https://discord.com/api/webhooks/123/abc"
         self.community.poster_image = "poster/community.webp"
         self.community.save(update_fields=["notification_webhook_url", "poster_image"])
@@ -3088,7 +3089,7 @@ class SlideShareSignalTest(AutoTweetTestBase):
         image_url = payload["embeds"][0]["image"]["url"]
         self.assertEqual(image_url, "https://data.vrc-ta-hub.com/poster/community.webp")
 
-    @patch("event.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_share_without_webhook_does_not_send_notification(self, mock_thread_cls, mock_post):
         """Webhook未設定なら資料公開通知は送らない"""
@@ -3099,21 +3100,43 @@ class SlideShareSignalTest(AutoTweetTestBase):
 
         mock_post.assert_not_called()
 
-    @patch("event.notifications.requests.post", side_effect=Exception("timeout"))
+    @patch("website.discord_webhook.requests.post")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_share_webhook_failure_does_not_block_queue_creation(
         self, mock_thread_cls, mock_post,
     ):
-        """Webhook送信失敗でもslide_shareキュー作成は継続する"""
+        """Webhook失敗を安全にlogし、slide_shareキュー作成は継続する."""
+        from website.discord_webhook import post_discord_webhook
+
+        sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
+        mock_post.side_effect = requests.RequestException(
+            f"timeout for {sensitive_url}",
+        )
         mock_thread_cls.return_value = MagicMock()
         self.community.notification_webhook_url = "https://discord.com/api/webhooks/123/abc"
         self.community.save(update_fields=["notification_webhook_url"])
 
-        self.detail.slide_url = "https://example.com/slides"
-        self.detail.save()
+        original_sleep = post_discord_webhook.retry.sleep
+        post_discord_webhook.retry.sleep = lambda _seconds: None
+        try:
+            with self.assertLogs(
+                "event.notifications",
+                level="ERROR",
+            ) as log_context:
+                self.detail.slide_url = "https://example.com/slides"
+                self.detail.save()
+        finally:
+            post_discord_webhook.retry.sleep = original_sleep
 
         self.assertEqual(TweetQueue.objects.count(), 1)
-        mock_post.assert_called_once()
+        self.assertEqual(mock_post.call_count, 3)
+        logs = "\n".join(log_context.output)
+        self.assertIn("error_type=RequestException", logs)
+        self.assertIn("status_code=None", logs)
+        self.assertNotIn(sensitive_url, logs)
+        self.assertNotIn("secret-token", logs)
+        self.assertNotIn("timeout for", logs)
+        self.assertNotIn("Traceback", logs)
 
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_youtube_url_first_set_creates_queue(self, mock_thread_cls):
@@ -3127,7 +3150,7 @@ class SlideShareSignalTest(AutoTweetTestBase):
         queue = TweetQueue.objects.first()
         self.assertEqual(queue.tweet_type, "slide_share")
 
-    @patch("event.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_youtube_only_does_not_send_slide_webhook(self, mock_thread_cls, mock_post):
         """YouTubeのみ追加した場合はスライドWebhook通知を送らない"""
@@ -3238,14 +3261,14 @@ class SlideShareSignalTest(AutoTweetTestBase):
         self.assertEqual(TweetQueue.objects.count(), 1)
         self.assertEqual(queue.image_url, poster_url)
 
-    @patch("event.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_slide_webhook_still_sent_when_youtube_queue_already_exists(
         self, mock_thread_cls, mock_post,
     ):
         """YouTube先行でキュー済みでも、後からスライド追加したらWebhookは送る"""
         mock_thread_cls.return_value = MagicMock()
-        mock_post.return_value = MagicMock(ok=True)
+        mock_post.return_value = MagicMock(status_code=200)
         self.community.notification_webhook_url = "https://discord.com/api/webhooks/123/abc"
         self.community.save(update_fields=["notification_webhook_url"])
 

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -997,11 +997,12 @@ class PostScheduledTweetsViewTest(AutoTweetTestBase):
         self.assertEqual(second.status, "ready")
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("twitter.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     @patch("twitter.views.post_tweet")
     def test_post_scheduled_tweets_post_failure(self, mock_post, mock_webhook_post):
         """X API 投稿失敗時にキューが failed になり管理者へ通知が送られる"""
         mock_post.return_value = {"ok": False, "data": None, "status_code": 403, "error_body": "You are not permitted to perform this action."}
+        mock_webhook_post.return_value = MagicMock(status_code=204)
 
         TweetQueue.objects.create(
             tweet_type="new_community",

--- a/app/twitter/tests/test_post_failure_notification.py
+++ b/app/twitter/tests/test_post_failure_notification.py
@@ -6,11 +6,14 @@ notify_tweet_post_failure が settings.DISCORD_WEBHOOK_URL 設定下で
 import datetime
 from unittest.mock import MagicMock, patch
 
+import requests
 from django.test import TestCase, override_settings
 
 from community.models import Community
 from twitter.models import TweetQueue
 from twitter.notifications import notify_tweet_post_failure
+from twitter.services.tweet_scheduling_service import post_tweet_queue_item
+from website.discord_webhook import post_discord_webhook
 
 
 class NotifyTweetPostFailureTest(TestCase):
@@ -36,7 +39,7 @@ class NotifyTweetPostFailureTest(TestCase):
         )
 
     @override_settings(DISCORD_WEBHOOK_URL="")
-    @patch("twitter.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     def test_no_notification_when_webhook_url_not_set(self, mock_post):
         """DISCORD_WEBHOOK_URL 未設定時は通知しない"""
         result = {
@@ -47,12 +50,10 @@ class NotifyTweetPostFailureTest(TestCase):
         mock_post.assert_not_called()
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("twitter.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     def test_notification_sent_with_correct_payload(self, mock_post):
         """Webhook URL 設定時は requests.post が正しいペイロードで呼ばれる"""
-        mock_response = MagicMock()
-        mock_response.ok = True
-        mock_response.status_code = 204
+        mock_response = MagicMock(status_code=204)
         mock_post.return_value = mock_response
 
         result = {
@@ -69,11 +70,10 @@ class NotifyTweetPostFailureTest(TestCase):
         self.assertIn("timeout", kwargs)
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("twitter.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     def test_description_contains_generated_text(self, mock_post):
         """description にツイート本文が含まれる"""
-        mock_response = MagicMock()
-        mock_response.ok = True
+        mock_response = MagicMock(status_code=204)
         mock_post.return_value = mock_response
 
         result = {
@@ -88,11 +88,10 @@ class NotifyTweetPostFailureTest(TestCase):
         self.assertIn("#VRChat", description)
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("twitter.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     def test_fields_contain_status_code_and_error_body(self, mock_post):
         """fields に status_code と error_body と詳細URLが含まれる"""
-        mock_response = MagicMock()
-        mock_response.ok = True
+        mock_response = MagicMock(status_code=204)
         mock_post.return_value = mock_response
 
         result = {
@@ -122,11 +121,10 @@ class NotifyTweetPostFailureTest(TestCase):
         self.assertEqual(field_values_by_name["集会"], self.community.name)
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("twitter.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     def test_long_error_body_is_truncated(self, mock_post):
         """長いエラーボディは 1024 文字制限で切り詰められる"""
-        mock_response = MagicMock()
-        mock_response.ok = True
+        mock_response = MagicMock(status_code=204)
         mock_post.return_value = mock_response
 
         long_body = "A" * 5000
@@ -143,11 +141,10 @@ class NotifyTweetPostFailureTest(TestCase):
         self.assertTrue(error_value.endswith("..."))
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("twitter.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     def test_none_status_code_rendered_as_na(self, mock_post):
         """status_code が None のときは N/A と表示される"""
-        mock_response = MagicMock()
-        mock_response.ok = True
+        mock_response = MagicMock(status_code=204)
         mock_post.return_value = mock_response
 
         result = {
@@ -163,7 +160,7 @@ class NotifyTweetPostFailureTest(TestCase):
         self.assertEqual(field_values_by_name["エラー内容"], "(なし)")
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("twitter.notifications.requests.post")
+    @patch("website.discord_webhook.requests.post")
     def test_request_exception_does_not_propagate(self, mock_post):
         """requests.post が例外を投げても呼び出し元に伝播しない"""
         mock_post.side_effect = Exception("network error")
@@ -174,3 +171,40 @@ class NotifyTweetPostFailureTest(TestCase):
         }
         # 例外が外に伝播しないことを確認
         notify_tweet_post_failure(self.queue_item, result)
+
+    @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
+    @patch("website.discord_webhook.requests.post")
+    def test_final_notification_failure_keeps_saved_queue_state(self, mock_post):
+        """通知が最終失敗しても、その前に失敗状態がDBへ保存される."""
+        self.queue_item.status = "ready"
+        self.queue_item.error_message = ""
+        self.queue_item.save(update_fields=["status", "error_message"])
+        observed_statuses = []
+
+        def fail_after_reading_saved_state(*_args, **_kwargs):
+            saved_queue = TweetQueue.objects.get(pk=self.queue_item.pk)
+            observed_statuses.append(saved_queue.status)
+            raise requests.ConnectionError("network error")
+
+        mock_post.side_effect = fail_after_reading_saved_state
+        original_sleep = post_discord_webhook.retry.sleep
+        post_discord_webhook.retry.sleep = lambda _seconds: None
+        try:
+            result = post_tweet_queue_item(
+                self.queue_item,
+                post_tweet_func=lambda *_args, **_kwargs: {
+                    "ok": False,
+                    "data": None,
+                    "status_code": 503,
+                    "error_body": "service unavailable",
+                },
+                notify_failure_func=notify_tweet_post_failure,
+            )
+        finally:
+            post_discord_webhook.retry.sleep = original_sleep
+
+        self.queue_item.refresh_from_db()
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(self.queue_item.status, "failed")
+        self.assertIn("service unavailable", self.queue_item.error_message)
+        self.assertEqual(observed_statuses, ["failed", "failed", "failed"])

--- a/app/twitter/tests/test_post_failure_notification.py
+++ b/app/twitter/tests/test_post_failure_notification.py
@@ -13,7 +13,6 @@ from community.models import Community
 from twitter.models import TweetQueue
 from twitter.notifications import notify_tweet_post_failure
 from twitter.services.tweet_scheduling_service import post_tweet_queue_item
-from website.discord_webhook import post_discord_webhook
 
 
 class NotifyTweetPostFailureTest(TestCase):
@@ -39,7 +38,7 @@ class NotifyTweetPostFailureTest(TestCase):
         )
 
     @override_settings(DISCORD_WEBHOOK_URL="")
-    @patch("website.discord_webhook.requests.post")
+    @patch("twitter.notifications.post_discord_webhook")
     def test_no_notification_when_webhook_url_not_set(self, mock_post):
         """DISCORD_WEBHOOK_URL 未設定時は通知しない"""
         result = {
@@ -50,9 +49,9 @@ class NotifyTweetPostFailureTest(TestCase):
         mock_post.assert_not_called()
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("website.discord_webhook.requests.post")
+    @patch("twitter.notifications.post_discord_webhook")
     def test_notification_sent_with_correct_payload(self, mock_post):
-        """Webhook URL 設定時は requests.post が正しいペイロードで呼ばれる"""
+        """Webhook URL 設定時はgatewayが正しいペイロードで呼ばれる."""
         mock_response = MagicMock(status_code=204)
         mock_post.return_value = mock_response
 
@@ -64,13 +63,12 @@ class NotifyTweetPostFailureTest(TestCase):
         notify_tweet_post_failure(self.queue_item, result)
 
         mock_post.assert_called_once()
-        args, kwargs = mock_post.call_args
+        args = mock_post.call_args.args
         self.assertEqual(args[0], "https://discord.com/api/webhooks/test/token")
-        self.assertIn("json", kwargs)
-        self.assertIn("timeout", kwargs)
+        self.assertIn("embeds", args[1])
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("website.discord_webhook.requests.post")
+    @patch("twitter.notifications.post_discord_webhook")
     def test_description_contains_generated_text(self, mock_post):
         """description にツイート本文が含まれる"""
         mock_response = MagicMock(status_code=204)
@@ -82,13 +80,13 @@ class NotifyTweetPostFailureTest(TestCase):
         }
         notify_tweet_post_failure(self.queue_item, result)
 
-        payload = mock_post.call_args.kwargs["json"]
+        payload = mock_post.call_args.args[1]
         description = payload["embeds"][0]["description"]
         self.assertIn("テストツイート本文です", description)
         self.assertIn("#VRChat", description)
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("website.discord_webhook.requests.post")
+    @patch("twitter.notifications.post_discord_webhook")
     def test_fields_contain_status_code_and_error_body(self, mock_post):
         """fields に status_code と error_body と詳細URLが含まれる"""
         mock_response = MagicMock(status_code=204)
@@ -101,7 +99,7 @@ class NotifyTweetPostFailureTest(TestCase):
         }
         notify_tweet_post_failure(self.queue_item, result)
 
-        payload = mock_post.call_args.kwargs["json"]
+        payload = mock_post.call_args.args[1]
         fields = payload["embeds"][0]["fields"]
 
         field_values_by_name = {f["name"]: f["value"] for f in fields}
@@ -121,7 +119,7 @@ class NotifyTweetPostFailureTest(TestCase):
         self.assertEqual(field_values_by_name["集会"], self.community.name)
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("website.discord_webhook.requests.post")
+    @patch("twitter.notifications.post_discord_webhook")
     def test_long_error_body_is_truncated(self, mock_post):
         """長いエラーボディは 1024 文字制限で切り詰められる"""
         mock_response = MagicMock(status_code=204)
@@ -134,14 +132,14 @@ class NotifyTweetPostFailureTest(TestCase):
         }
         notify_tweet_post_failure(self.queue_item, result)
 
-        payload = mock_post.call_args.kwargs["json"]
+        payload = mock_post.call_args.args[1]
         fields = payload["embeds"][0]["fields"]
         error_value = next(f["value"] for f in fields if f["name"] == "エラー内容")
         self.assertLessEqual(len(error_value), 1024)
         self.assertTrue(error_value.endswith("..."))
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("website.discord_webhook.requests.post")
+    @patch("twitter.notifications.post_discord_webhook")
     def test_none_status_code_rendered_as_na(self, mock_post):
         """status_code が None のときは N/A と表示される"""
         mock_response = MagicMock(status_code=204)
@@ -153,14 +151,14 @@ class NotifyTweetPostFailureTest(TestCase):
         }
         notify_tweet_post_failure(self.queue_item, result)
 
-        payload = mock_post.call_args.kwargs["json"]
+        payload = mock_post.call_args.args[1]
         fields = payload["embeds"][0]["fields"]
         field_values_by_name = {f["name"]: f["value"] for f in fields}
         self.assertEqual(field_values_by_name["HTTPステータス"], "N/A")
         self.assertEqual(field_values_by_name["エラー内容"], "(なし)")
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("website.discord_webhook.requests.post")
+    @patch("twitter.notifications.post_discord_webhook")
     def test_request_exception_does_not_propagate(self, mock_post):
         """最終失敗を安全にlogし、呼び出し元に伝播しない."""
         sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
@@ -182,7 +180,7 @@ class NotifyTweetPostFailureTest(TestCase):
         self.assertNotIn("Traceback", logs)
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
-    @patch("website.discord_webhook.requests.post")
+    @patch("twitter.notifications.post_discord_webhook")
     def test_final_notification_failure_keeps_saved_queue_state(self, mock_post):
         """通知が最終失敗しても、その前に失敗状態がDBへ保存される."""
         self.queue_item.status = "ready"
@@ -196,24 +194,38 @@ class NotifyTweetPostFailureTest(TestCase):
             raise requests.ConnectionError("network error")
 
         mock_post.side_effect = fail_after_reading_saved_state
-        original_sleep = post_discord_webhook.retry.sleep
-        post_discord_webhook.retry.sleep = lambda _seconds: None
-        try:
-            result = post_tweet_queue_item(
-                self.queue_item,
-                post_tweet_func=lambda *_args, **_kwargs: {
-                    "ok": False,
-                    "data": None,
-                    "status_code": 503,
-                    "error_body": "service unavailable",
-                },
-                notify_failure_func=notify_tweet_post_failure,
-            )
-        finally:
-            post_discord_webhook.retry.sleep = original_sleep
+        result = post_tweet_queue_item(
+            self.queue_item,
+            post_tweet_func=lambda *_args, **_kwargs: {
+                "ok": False,
+                "data": None,
+                "status_code": 503,
+                "error_body": "service unavailable",
+            },
+            notify_failure_func=notify_tweet_post_failure,
+        )
 
         self.queue_item.refresh_from_db()
         self.assertEqual(result["status"], "failed")
         self.assertEqual(self.queue_item.status, "failed")
         self.assertIn("service unavailable", self.queue_item.error_message)
-        self.assertEqual(observed_statuses, ["failed", "failed", "failed"])
+        self.assertEqual(observed_statuses, ["failed"])
+
+    def test_success_state_is_persisted_by_application_service(self):
+        """成功時もapplication serviceが投稿結果をDBへ保存する."""
+        result = post_tweet_queue_item(
+            self.queue_item,
+            post_tweet_func=lambda *_args, **_kwargs: {
+                "ok": True,
+                "data": {"id": "posted-by-service"},
+                "status_code": None,
+                "error_body": None,
+            },
+        )
+
+        self.queue_item.refresh_from_db()
+        self.assertEqual(result["status"], "posted")
+        self.assertEqual(self.queue_item.status, "posted")
+        self.assertEqual(self.queue_item.tweet_id, "posted-by-service")
+        self.assertIsNotNone(self.queue_item.posted_at)
+        self.assertEqual(self.queue_item.error_message, "")

--- a/app/twitter/tests/test_post_failure_notification.py
+++ b/app/twitter/tests/test_post_failure_notification.py
@@ -7,12 +7,16 @@ import datetime
 from unittest.mock import MagicMock, patch
 
 import requests
+from django.db import OperationalError
 from django.test import TestCase, override_settings
 
 from community.models import Community
 from twitter.models import TweetQueue
 from twitter.notifications import notify_tweet_post_failure
 from twitter.services.tweet_scheduling_service import post_tweet_queue_item
+
+MYSQL_RETRY_ERROR_CODES = (2006, 2013)
+MYSQL_NON_RETRY_ERROR_CODE = 1048
 
 
 class NotifyTweetPostFailureTest(TestCase):
@@ -229,3 +233,185 @@ class NotifyTweetPostFailureTest(TestCase):
         self.assertEqual(self.queue_item.tweet_id, "posted-by-service")
         self.assertIsNotNone(self.queue_item.posted_at)
         self.assertEqual(self.queue_item.error_message, "")
+
+    def _flaky_save(self, error_code, update_fields_history):
+        """初回だけ接続断にし、2回目は実DBへ保存するsaveを返す."""
+        real_save = self.queue_item.save
+
+        def save(*args, **kwargs):
+            update_fields = kwargs.get("update_fields")
+            update_fields_history.append(tuple(update_fields or ()))
+            if len(update_fields_history) == 1:
+                raise OperationalError(error_code, "lost database connection")
+            return real_save(*args, **kwargs)
+
+        return save
+
+    def _reset_queue_state(self, *, status="ready", error_message="previous error"):
+        """再接続ケースごとに永続化済みキューを初期状態へ戻す."""
+        TweetQueue.objects.filter(pk=self.queue_item.pk).update(
+            status=status,
+            tweet_id="",
+            posted_at=None,
+            error_message=error_message,
+        )
+        self.queue_item.refresh_from_db()
+
+    def _run_failure_retry_case(self, error_code, *, failure_status):
+        """接続断後に失敗状態を保存し、通知時点のDB状態を返す."""
+        self._reset_queue_state(status="ready", error_message="")
+        update_fields_history = []
+        notified_states = []
+        flaky_save = self._flaky_save(error_code, update_fields_history)
+
+        def observe_saved_state(_queue_item, _result):
+            saved = TweetQueue.objects.get(pk=self.queue_item.pk)
+            notified_states.append((saved.status, saved.error_message))
+
+        with patch.object(self.queue_item, "save", side_effect=flaky_save):
+            result = post_tweet_queue_item(
+                self.queue_item,
+                failure_status=failure_status,
+                post_tweet_func=lambda *_args, **_kwargs: {
+                    "ok": False,
+                    "data": None,
+                    "status_code": 503,
+                    "error_body": "service unavailable",
+                },
+                notify_failure_func=observe_saved_state,
+            )
+
+        saved_queue = TweetQueue.objects.get(pk=self.queue_item.pk)
+        return result, saved_queue, notified_states, update_fields_history
+
+    @patch("twitter.db.connections.close_all")
+    def test_success_save_retries_lost_connection_and_persists_fields(
+        self,
+        mock_close_all,
+    ):
+        """成功保存はMySQL 2006/2013を再試行して全結果フィールドを永続化する."""
+        expected_fields = ("status", "tweet_id", "posted_at", "error_message")
+        for error_code in MYSQL_RETRY_ERROR_CODES:
+            with self.subTest(error_code=error_code):
+                self._reset_queue_state()
+                update_fields_history = []
+                notifier = MagicMock()
+                flaky_save = self._flaky_save(error_code, update_fields_history)
+
+                with patch.object(self.queue_item, "save", side_effect=flaky_save):
+                    result = post_tweet_queue_item(
+                        self.queue_item,
+                        post_tweet_func=lambda *_args, **_kwargs: {
+                            "ok": True,
+                            "data": {"id": f"tweet-{error_code}"},
+                            "status_code": None,
+                            "error_body": None,
+                        },
+                        notify_failure_func=notifier,
+                    )
+
+                saved_queue = TweetQueue.objects.get(pk=self.queue_item.pk)
+                self.assertEqual(result["status"], "posted")
+                self.assertEqual(saved_queue.status, "posted")
+                self.assertEqual(saved_queue.tweet_id, f"tweet-{error_code}")
+                self.assertIsNotNone(saved_queue.posted_at)
+                self.assertEqual(saved_queue.error_message, "")
+                self.assertEqual(
+                    update_fields_history,
+                    [expected_fields, expected_fields],
+                )
+                notifier.assert_not_called()
+        self.assertEqual(mock_close_all.call_count, 2)
+
+    @patch("twitter.db.connections.close_all")
+    def test_failure_save_retries_before_notification(
+        self,
+        mock_close_all,
+    ):
+        """失敗保存はMySQL 2006/2013を再試行し、保存後に通知する."""
+        expected_fields = ("error_message", "status")
+        for error_code in MYSQL_RETRY_ERROR_CODES:
+            with self.subTest(error_code=error_code):
+                result, saved_queue, notified_states, fields = (
+                    self._run_failure_retry_case(
+                        error_code,
+                        failure_status="failed",
+                    )
+                )
+                self.assertEqual(result["status"], "failed")
+                self.assertEqual(saved_queue.status, "failed")
+                self.assertIn("service unavailable", saved_queue.error_message)
+                self.assertEqual(
+                    notified_states,
+                    [("failed", saved_queue.error_message)],
+                )
+                self.assertEqual(
+                    fields,
+                    [expected_fields, expected_fields],
+                )
+        self.assertEqual(mock_close_all.call_count, 2)
+
+    @patch("twitter.db.connections.close_all")
+    def test_failure_without_status_change_retries_and_preserves_status(
+        self,
+        mock_close_all,
+    ):
+        """failure_status=Noneでも接続断を再試行し、元statusのまま通知する."""
+        expected_fields = ("error_message",)
+        for error_code in MYSQL_RETRY_ERROR_CODES:
+            with self.subTest(error_code=error_code):
+                result, saved_queue, notified_states, fields = (
+                    self._run_failure_retry_case(
+                        error_code,
+                        failure_status=None,
+                    )
+                )
+                self.assertEqual(result["status"], "failed")
+                self.assertEqual(saved_queue.status, "ready")
+                self.assertIn("service unavailable", saved_queue.error_message)
+                self.assertEqual(
+                    notified_states,
+                    [("ready", saved_queue.error_message)],
+                )
+                self.assertEqual(
+                    fields,
+                    [expected_fields, expected_fields],
+                )
+        self.assertEqual(mock_close_all.call_count, 2)
+
+    @patch("twitter.db.connections.close_all")
+    def test_non_connection_operational_error_propagates_without_persisting(
+        self,
+        mock_close_all,
+    ):
+        """非接続系OperationalErrorは再試行・保存・通知せず伝播する."""
+        self._reset_queue_state(status="ready", error_message="before save")
+        notifier = MagicMock()
+        update_fields_history = []
+
+        def fail_save(*_args, **kwargs):
+            update_fields_history.append(tuple(kwargs.get("update_fields") or ()))
+            raise OperationalError(
+                MYSQL_NON_RETRY_ERROR_CODE,
+                "Column cannot be null",
+            )
+
+        with patch.object(self.queue_item, "save", side_effect=fail_save):
+            with self.assertRaises(OperationalError):
+                post_tweet_queue_item(
+                    self.queue_item,
+                    post_tweet_func=lambda *_args, **_kwargs: {
+                        "ok": False,
+                        "data": None,
+                        "status_code": 500,
+                        "error_body": "failure",
+                    },
+                    notify_failure_func=notifier,
+                )
+
+        saved_queue = TweetQueue.objects.get(pk=self.queue_item.pk)
+        self.assertEqual(saved_queue.status, "ready")
+        self.assertEqual(saved_queue.error_message, "before save")
+        self.assertEqual(update_fields_history, [("error_message", "status")])
+        notifier.assert_not_called()
+        mock_close_all.assert_not_called()

--- a/app/twitter/tests/test_post_failure_notification.py
+++ b/app/twitter/tests/test_post_failure_notification.py
@@ -162,15 +162,24 @@ class NotifyTweetPostFailureTest(TestCase):
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
     @patch("website.discord_webhook.requests.post")
     def test_request_exception_does_not_propagate(self, mock_post):
-        """requests.post が例外を投げても呼び出し元に伝播しない"""
-        mock_post.side_effect = Exception("network error")
+        """最終失敗を安全にlogし、呼び出し元に伝播しない."""
+        sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
+        mock_post.side_effect = Exception(f"network error: {sensitive_url}")
 
         result = {
             "ok": False, "data": None,
             "status_code": 403, "error_body": "forbidden",
         }
-        # 例外が外に伝播しないことを確認
-        notify_tweet_post_failure(self.queue_item, result)
+        with self.assertLogs("twitter.notifications", level="ERROR") as log_context:
+            notify_tweet_post_failure(self.queue_item, result)
+
+        logs = "\n".join(log_context.output)
+        self.assertIn("error_type=Exception", logs)
+        self.assertIn("status_code=None", logs)
+        self.assertNotIn(sensitive_url, logs)
+        self.assertNotIn("secret-token", logs)
+        self.assertNotIn("network error", logs)
+        self.assertNotIn("Traceback", logs)
 
     @override_settings(DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token")
     @patch("website.discord_webhook.requests.post")

--- a/app/twitter/tests/test_tweet_queue_views.py
+++ b/app/twitter/tests/test_tweet_queue_views.py
@@ -384,7 +384,7 @@ class TweetQueueDetailViewTest(TweetQueueViewTestBase):
         self.assertIsNotNone(self.queue_item.posted_at)
 
     @override_settings(DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/test/token')
-    @patch('website.discord_webhook.requests.post')
+    @patch('twitter.notifications.post_discord_webhook')
     @patch('twitter.views.post_tweet')
     @patch('twitter.views.upload_media')
     def test_post_now_failure(self, mock_upload, mock_post, mock_webhook_post):

--- a/app/twitter/tests/test_tweet_queue_views.py
+++ b/app/twitter/tests/test_tweet_queue_views.py
@@ -384,13 +384,14 @@ class TweetQueueDetailViewTest(TweetQueueViewTestBase):
         self.assertIsNotNone(self.queue_item.posted_at)
 
     @override_settings(DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/test/token')
-    @patch('twitter.notifications.requests.post')
+    @patch('website.discord_webhook.requests.post')
     @patch('twitter.views.post_tweet')
     @patch('twitter.views.upload_media')
     def test_post_now_failure(self, mock_upload, mock_post, mock_webhook_post):
         """手動投稿が失敗した場合は元ステータスを維持し管理者へ通知する"""
         mock_post.return_value = {'ok': False, 'data': None, 'status_code': 403, 'error_body': 'Forbidden'}
         mock_upload.return_value = None
+        mock_webhook_post.return_value = MagicMock(status_code=204)
 
         self.client.login(username='admin_user', password='testpassword')
         url = reverse('twitter:tweet_queue_detail', kwargs={'pk': self.queue_item.pk})

--- a/app/twitter/views.py
+++ b/app/twitter/views.py
@@ -184,7 +184,7 @@ def _post_tweet_queue_item(
     *,
     failure_status: str | None = 'failed',
 ) -> dict[str, object]:
-    """TweetQueue 1件を X API に投稿し、保存前の結果を返す."""
+    """TweetQueue 1件を X API に投稿し、保存済みの結果を返す."""
     return post_tweet_queue_item(
         queue_item,
         failure_status=failure_status,
@@ -444,11 +444,9 @@ class TweetQueueDetailView(TweetQueueViewerMixin, DetailView):
         result = _post_tweet_queue_item(self.object, failure_status=None)
 
         if result["status"] == "posted":
-            self.object.save()
             messages.success(self.request, 'ポストを投稿しました。')
             logger.info("Manual tweet posted for queue %d: %s", self.object.pk, self.object.tweet_id)
         else:
-            self.object.save(update_fields=['error_message'])
             messages.error(self.request, self.object.error_message)
             logger.warning("Manual tweet post failed for queue %d", self.object.pk)
 

--- a/app/website/discord_webhook.py
+++ b/app/website/discord_webhook.py
@@ -17,11 +17,15 @@ DISCORD_TIMEOUT_SECONDS = 10
 def post_discord_webhook(webhook_url: str, payload: dict) -> requests.Response:
     """Discord Webhook へ POST する内部ヘルパー（tenacity リトライ付き）.
 
-    HTTP エラー (4xx/5xx) も raise_for_status で例外化し、リトライ対象とする。
+    2xx 以外の HTTP 応答を例外化し、リトライ対象とする。
     最終的に失敗した場合は requests.RequestException 系を再送出する。
     """
     response = requests.post(
         webhook_url, json=payload, timeout=DISCORD_TIMEOUT_SECONDS
     )
-    response.raise_for_status()
+    if not 200 <= response.status_code < 300:
+        raise requests.HTTPError(
+            f"Discord Webhook returned HTTP {response.status_code}",
+            response=response,
+        )
     return response

--- a/app/website/discord_webhook.py
+++ b/app/website/discord_webhook.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import requests
 
-from website.retry import retry_webhook_post
+from website.retry import get_webhook_error_context, retry_webhook_post
+
+__all__ = ["get_webhook_error_context", "post_discord_webhook"]
 
 # Discord Webhook送信タイムアウト（秒）
 DISCORD_TIMEOUT_SECONDS = 10

--- a/app/website/retry.py
+++ b/app/website/retry.py
@@ -12,6 +12,7 @@ import logging
 
 import requests
 from tenacity import (
+    RetryCallState,
     retry,
     retry_if_exception_type,
     stop_after_attempt,
@@ -30,14 +31,29 @@ WEBHOOK_RETRY_WAIT_MAX_SECONDS = 10
 WEBHOOK_RETRY_WAIT_MULTIPLIER = 1
 
 
-def _log_retry_attempt(retry_state) -> None:
+def get_webhook_error_context(
+    error: BaseException | None,
+) -> tuple[str, int | None]:
+    """Build a log-safe Webhook error type and HTTP status."""
+    if error is None:
+        return "UnknownError", None
+
+    response = getattr(error, "response", None)
+    status_code = getattr(response, "status_code", None)
+    safe_status_code = status_code if type(status_code) is int else None
+    return type(error).__name__, safe_status_code
+
+
+def _log_retry_attempt(retry_state: RetryCallState) -> None:
     """tenacity の before_sleep フック: リトライ直前に warning ログを残す."""
-    exception = retry_state.outcome.exception() if retry_state.outcome else None
+    error = retry_state.outcome.exception() if retry_state.outcome else None
+    error_type, status_code = get_webhook_error_context(error)
     logger.warning(
-        "Webhook retry %s/%s after %s",
+        "Webhook retry attempt=%s/%s error_type=%s status_code=%s",
         retry_state.attempt_number,
         WEBHOOK_RETRY_MAX_ATTEMPTS,
-        exception,
+        error_type,
+        status_code,
     )
 
 

--- a/app/website/retry.py
+++ b/app/website/retry.py
@@ -1,9 +1,9 @@
 """Webhook 等の外部 POST に共有のリトライ戦略を提供する.
 
-`tenacity` を使い、ネットワーク起因の一過性エラー（requests.RequestException /
-requests.Timeout）に対して指数バックオフでリトライする。最終的に失敗した場合は
-例外を呼び出し元に再送出し、既存の try/except による silent failure ハンドリング
-を活かせる設計とする。
+`tenacity` を使い、非2xx応答から変換した HTTPError を含むすべての
+requests.RequestException を最大3回試行し、試行間を1秒・2秒待機する。
+4xx・429も一時的な制限や経路上の問題から回復できるよう意図的に再試行する。
+最終的に失敗した場合は例外を呼び出し元へ再送出する。
 """
 
 from __future__ import annotations
@@ -58,10 +58,12 @@ def _log_retry_attempt(retry_state: RetryCallState) -> None:
 
 
 def retry_webhook_post(func):
-    """Discord Webhook 等の POST を 3 回まで指数バックオフでリトライするデコレータ.
+    """Discord Webhook 等の POST を最大3回試行するデコレータ.
 
-    - 対象例外: requests.RequestException / requests.Timeout（一過性のネットワーク失敗）
-    - リトライ間隔: 1s, 2s, 4s（exponential backoff, max 10s）
+    - 対象例外: すべての requests.RequestException（非2xxのHTTPErrorを含む）
+    - 4xx・429も意図的にリトライ対象とする
+    - 試行回数: 初回を含めて最大3回
+    - リトライ間隔: 1秒、2秒
     - 最終失敗時は元の例外を再送出する（reraise=True）
     """
     return retry(

--- a/app/website/tests/test_discord_webhook.py
+++ b/app/website/tests/test_discord_webhook.py
@@ -1,0 +1,79 @@
+"""Discord Webhook 共通送信境界のテスト."""
+
+from unittest.mock import MagicMock, patch
+
+import requests
+from django.test import SimpleTestCase
+
+from website.discord_webhook import post_discord_webhook
+
+
+class DiscordWebhookTest(SimpleTestCase):
+    """共通送信境界の成功判定とリトライを検証する."""
+
+    def setUp(self):
+        self.original_sleep = post_discord_webhook.retry.sleep
+        post_discord_webhook.retry.sleep = lambda _seconds: None
+
+    def tearDown(self):
+        post_discord_webhook.retry.sleep = self.original_sleep
+
+    @patch("website.discord_webhook.requests.post")
+    def test_accepts_any_2xx_response_without_retry(self, mock_post):
+        """任意の2xx応答を1回で成功とする."""
+        for status_code in (200, 201, 204, 299):
+            with self.subTest(status_code=status_code):
+                mock_post.reset_mock()
+                response = MagicMock(status_code=status_code)
+                mock_post.return_value = response
+
+                result = post_discord_webhook("https://example.com/webhook", {})
+
+                self.assertIs(result, response)
+                mock_post.assert_called_once()
+
+    @patch("website.discord_webhook.requests.post")
+    def test_retries_non_2xx_responses_three_times(self, mock_post):
+        """3xx・4xx・429・5xx応答を合計3回試行して失敗とする."""
+        for status_code in (300, 400, 429, 500):
+            with self.subTest(status_code=status_code):
+                mock_post.reset_mock()
+                mock_post.return_value = MagicMock(status_code=status_code)
+
+                with self.assertRaises(requests.HTTPError) as error:
+                    post_discord_webhook("https://example.com/webhook", {})
+
+                self.assertEqual(error.exception.response.status_code, status_code)
+                self.assertEqual(mock_post.call_count, 3)
+
+    @patch("website.discord_webhook.requests.post")
+    def test_retries_timeout_three_times(self, mock_post):
+        """タイムアウトを合計3回試行して最終例外を送出する."""
+        mock_post.side_effect = requests.Timeout("timed out")
+
+        with self.assertRaises(requests.Timeout):
+            post_discord_webhook("https://example.com/webhook", {})
+
+        self.assertEqual(mock_post.call_count, 3)
+
+    @patch("website.discord_webhook.requests.post")
+    def test_retries_connection_error_three_times(self, mock_post):
+        """接続エラーを合計3回試行して最終例外を送出する."""
+        mock_post.side_effect = requests.ConnectionError("connection failed")
+
+        with self.assertRaises(requests.ConnectionError):
+            post_discord_webhook("https://example.com/webhook", {})
+
+        self.assertEqual(mock_post.call_count, 3)
+
+    @patch("website.discord_webhook.requests.post")
+    def test_waits_one_then_two_seconds(self, mock_post):
+        """最大3試行の間を1秒・2秒待機する."""
+        waits = []
+        post_discord_webhook.retry.sleep = waits.append
+        mock_post.side_effect = requests.ConnectionError("connection failed")
+
+        with self.assertRaises(requests.ConnectionError):
+            post_discord_webhook("https://example.com/webhook", {})
+
+        self.assertEqual(waits, [1.0, 2.0])

--- a/app/website/tests/test_discord_webhook.py
+++ b/app/website/tests/test_discord_webhook.py
@@ -77,3 +77,26 @@ class DiscordWebhookTest(SimpleTestCase):
             post_discord_webhook("https://example.com/webhook", {})
 
         self.assertEqual(waits, [1.0, 2.0])
+
+    @patch("website.discord_webhook.requests.post")
+    def test_retry_logs_exclude_webhook_url_and_exception_message(self, mock_post):
+        """リトライログはURL・token・例外本文・tracebackを出さない."""
+        sensitive_url = "https://discord.com/api/webhooks/123456789/secret-token"
+        response = MagicMock(status_code=429)
+        mock_post.side_effect = requests.HTTPError(
+            f"request failed for {sensitive_url}",
+            response=response,
+        )
+
+        with self.assertLogs("website.retry", level="WARNING") as log_context:
+            with self.assertRaises(requests.HTTPError):
+                post_discord_webhook(sensitive_url, {})
+
+        logs = "\n".join(log_context.output)
+        self.assertIn("attempt=1/3", logs)
+        self.assertIn("error_type=HTTPError", logs)
+        self.assertIn("status_code=429", logs)
+        self.assertNotIn(sensitive_url, logs)
+        self.assertNotIn("secret-token", logs)
+        self.assertNotIn("request failed", logs)
+        self.assertNotIn("Traceback", logs)


### PR DESCRIPTION
## なぜこの変更が必要か

Discord Webhook送信が複数モジュールに分散し、成功判定・再試行・失敗ログが揺れていました。例外文字列にWebhook URLのtokenが含まれる可能性と、X投稿失敗状態が通知待ちの間DBへ保存されない問題も合わせて解消します。

## 変更内容

- Discord POSTを `website.discord_webhook.post_discord_webhook` に統一
- 任意2xxを成功、非2xxと通信例外を最大3 attemptsで再試行
- 全callerの失敗ログからURL・token・例外本文・tracebackを除外
- X投稿結果のDB保存責務をapplication serviceへ集約し、保存後に通知
- retry実装のテストをtransport境界へ集約

## 意思決定

- 4xx・429を含む全 `RequestException` を共通規約どおり最大3 attemptsとしました。
- callerは業務継続・UIメッセージ・安全な相関IDだけを担当し、HTTP分類と待機はtransportへ閉じ込めました。

## Failure mode

| 外部呼び出し | 失敗時の挙動 | 担保 |
|---|---|---|
| X投稿失敗通知 | 投稿結果を保存後、3 attempts失敗を安全に記録して継続 | DB再読込による保存順テスト |
| 活動停止通報 | 通報DB記録を維持し、Webhook失敗を安全に記録して受付継続 | community report tests |
| 設定画面テスト送信 | 任意2xx成功、timeout/HTTP/接続失敗を区別して表示 | settings tests |
| Event通知3経路 | 主処理を止めず、安全な対象IDと例外型だけを記録 | event notification tests |

## テスト

- [x] 対象offline tests: 180件成功
- [x] full offline tests: 2004件成功、1件skip
- [x] DB再接続配線 tests: 13件成功
- [x] Ruff成功
- [x] mypy変更コード成功（既存miscを除外）
- [x] makemigrations差分なし
- [x] loopback HTTP: 204は1 attempt、503は3 attempts
- [x] code/security/impact/architecture review loop完了

Refs #556

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cross-cutting notification and scheduling behavior changes (retry on 4xx, persistence order before Discord admin alerts) affect multiple user-facing flows, though coverage is broad.
> 
> **Overview**
> **Unifies Discord Webhook delivery** behind `post_discord_webhook` and replaces scattered `requests.post` calls in community, event, and twitter code. **Any 2xx counts as success**; non-2xx responses become `HTTPError` and are retried up to three times with shared backoff. Callers only log structured fields via `get_webhook_error_context` (IDs, `error_type`, `status_code`) so webhook URLs, tokens, exception text, and tracebacks never hit logs.
> 
> **Failure handling is aligned per surface:** report and registration paths keep the main flow; settings test webhook distinguishes timeout, HTTP errors, and connection failures in UI messages; event notification paths log `community_id` / `event_detail_id` on final gateway failure.
> 
> **X (Twitter) posting:** `post_tweet_queue_item` now **saves success or failure state to the DB** (with existing `run_with_db_reconnect`) **before** calling `notify_tweet_post_failure`, fixing the case where admin Discord notification ran while the queue row was still unsaved. Manual post and scheduled tweet paths drop redundant `save()` calls because persistence lives in the service.
> 
> Tests mock the gateway instead of HTTP, add transport-level retry/2xx coverage in `test_discord_webhook.py`, assert safe logging across callers, and expand tweet-queue persistence and MySQL reconnect behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d587aa6e2892afa78edd2326d0c786c2fd060f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->