### PR TITLE
fix(event): 曜日を開催日由来に統一する

### DIFF
--- a/app/community/constants.py
+++ b/app/community/constants.py
@@ -5,6 +5,11 @@ models を import せずに参照できるよう軽量モジュールとして�
 曜日表記の正本はここ 1 箇所。
 """
 
+from datetime import date
+
+
+_WEEKDAY_CODES = ('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun')
+
 WEEKDAY_CHOICES = (
     ('Sun', '日曜日'),
     ('Mon', '月曜日'),
@@ -26,3 +31,15 @@ WEEKDAY_ABBR['Other'] = '他'
 
 # 表示順（WEEKDAY_CHOICES の定義順がそのまま並び順）
 WEEKDAY_ORDER = {code: index for index, (code, _label) in enumerate(WEEKDAY_CHOICES)}
+
+
+def weekday_code(value: date) -> str:
+    """開催日からロケール非依存の曜日コードを返す。
+
+    Args:
+        value: 曜日コードへ変換する日付
+
+    Returns:
+        ``Mon`` から ``Sun`` の固定曜日コード
+    """
+    return _WEEKDAY_CODES[value.weekday()]

--- a/app/community/tests/test_constants.py
+++ b/app/community/tests/test_constants.py
@@ -1,0 +1,33 @@
+"""community.constants の曜日コード変換を検証する。"""
+
+from datetime import date, timedelta
+
+from django.test import SimpleTestCase
+
+from community.constants import weekday_code
+
+
+class WeekdayCodeTests(SimpleTestCase):
+    """ロケールに依存しない曜日コード変換を検証する。"""
+
+    def test_returns_fixed_codes_for_all_weekdays(self):
+        monday = date(2026, 8, 3)
+
+        actual = [
+            weekday_code(monday + timedelta(days=offset))
+            for offset in range(7)
+        ]
+
+        self.assertEqual(
+            actual,
+            ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+        )
+
+    def test_does_not_use_locale_dependent_strftime(self):
+        class DateWithoutStrftime(date):
+            def strftime(self, _format):
+                raise AssertionError('strftime must not be used')
+
+        value = DateWithoutStrftime(2026, 8, 3)
+
+        self.assertEqual(weekday_code(value), 'Mon')

--- a/app/event/admin.py
+++ b/app/event/admin.py
@@ -4,6 +4,9 @@ from django.utils.html import format_html
 from django.urls import path
 from django.shortcuts import render, redirect
 from django.utils import timezone
+
+from community.constants import weekday_code
+
 from .models import Event, EventDetail, RecurrenceRule
 
 
@@ -162,7 +165,13 @@ class EventAdmin(admin.ModelAdmin):
     list_filter = ('date', 'is_recurring_master')
     search_fields = ('community__name', 'date')
     inlines = [EventDetailInline]
+    readonly_fields = ('weekday',)
     raw_id_fields = ('recurring_master', 'recurrence_rule')
+
+    def save_model(self, request, obj, form, change):
+        """開催日を正本として曜日を設定し、イベントを保存する。"""
+        obj.weekday = weekday_code(obj.date)
+        super().save_model(request, obj, form, change)
 
     def get_community_name(self, obj):
         return obj.community.name

--- a/app/event/management/commands/generate_recurring_events.py
+++ b/app/event/management/commands/generate_recurring_events.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.utils import timezone
 
+from community.constants import weekday_code
 from event.models import Event
 from event.recurrence_service import RecurrenceService
 from event.services.recurrence_override import exclude_tombstoned_dates
@@ -40,6 +41,7 @@ class Command(BaseCommand):
         # リセットオプションが指定された場合
         if reset_future and not dry_run:
             self.stdout.write('未来のイベントを削除しています...')
+            reset_date = today - timedelta(days=1)
             
             # 定期ルールに紐づく未来のイベントを削除
             deleted_count = Event.objects.filter(
@@ -52,7 +54,10 @@ class Command(BaseCommand):
                 date__gte=today,
                 is_recurring_master=True,
                 recurrence_rule__isnull=False
-            ).update(date=today - timedelta(days=1))  # マスターは過去日付に変更
+            ).update(
+                date=reset_date,
+                weekday=weekday_code(reset_date),
+            )  # マスターは過去日付に変更
             
             self.stdout.write(
                 self.style.WARNING(
@@ -184,7 +189,7 @@ class Command(BaseCommand):
                             date=date,
                             start_time=community.start_time,
                             duration=community.duration,
-                            weekday=date.strftime('%a').upper()[:3],
+                            weekday=weekday_code(date),
                             recurring_master=master
                         )
                         created_count += 1

--- a/app/event/management/commands/normalize_event_weekdays.py
+++ b/app/event/management/commands/normalize_event_weekdays.py
@@ -1,0 +1,122 @@
+"""Event.weekday を開催日由来の固定コードへ正規化する。"""
+
+from collections.abc import Iterable
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from community.constants import WEEKDAY_CHOICES, weekday_code
+from event.models import Event
+
+
+_CATEGORY_KEYS = (
+    'format_only',
+    'valid_mismatch',
+    'outside_choices',
+    'other',
+    'empty',
+)
+_CANONICAL_CODES = {
+    code for code, _label in WEEKDAY_CHOICES if code != 'Other'
+}
+_ALIASES = {
+    alias.casefold(): code
+    for code, label in WEEKDAY_CHOICES
+    if code != 'Other'
+    for alias in (code, label)
+}
+_BATCH_SIZE = 1000
+
+
+def _classify_weekday(value: str, expected: str) -> str | None:
+    if not value:
+        return 'empty'
+    if value == 'Other':
+        return 'other'
+    if value in _CANONICAL_CODES:
+        return None if value == expected else 'valid_mismatch'
+    if _ALIASES.get(value.casefold()) == expected:
+        return 'format_only'
+    return 'outside_choices'
+
+
+def _empty_counts() -> dict[str, int]:
+    return {category: 0 for category in _CATEGORY_KEYS}
+
+
+def _collect_changes(events: Iterable[Event]) -> tuple[list[Event], dict[str, int]]:
+    changed_events = []
+    counts = _empty_counts()
+    for event in events:
+        expected = weekday_code(event.date)
+        category = _classify_weekday(event.weekday, expected)
+        if category is None:
+            continue
+        counts[category] += 1
+        event.weekday = expected
+        changed_events.append(event)
+    return changed_events, counts
+
+
+class Command(BaseCommand):
+    """Event.weekday の不整合を検査または一括補正する。"""
+
+    help = 'Event.weekday を Event.date 由来の Mon..Sun に検査・正規化'
+
+    def add_arguments(self, parser):
+        mode = parser.add_mutually_exclusive_group(required=True)
+        mode.add_argument(
+            '--check',
+            action='store_true',
+            help='不整合を分類して表示し、書き込まない',
+        )
+        mode.add_argument(
+            '--apply',
+            action='store_true',
+            help='不整合をトランザクション内で一括補正する',
+        )
+
+    def handle(self, *args, **options):
+        if options['apply']:
+            changed_events, counts = self._apply()
+            self._write_summary(counts, len(changed_events), applied=True)
+            return
+
+        changed_events, counts = _collect_changes(
+            Event.objects.only('id', 'date', 'weekday').iterator(
+                chunk_size=_BATCH_SIZE,
+            )
+        )
+        self._write_summary(counts, len(changed_events), applied=False)
+        if changed_events:
+            raise CommandError(
+                f'{len(changed_events)}件のEvent.weekday不整合があります'
+            )
+
+    def _apply(self) -> tuple[list[Event], dict[str, int]]:
+        with transaction.atomic():
+            changed_events, counts = _collect_changes(
+                Event.objects.only('id', 'date', 'weekday').iterator(
+                    chunk_size=_BATCH_SIZE,
+                )
+            )
+            if changed_events:
+                Event.objects.bulk_update(
+                    changed_events,
+                    ['weekday'],
+                    batch_size=_BATCH_SIZE,
+                )
+        return changed_events, counts
+
+    def _write_summary(
+        self,
+        counts: dict[str, int],
+        changed_count: int,
+        *,
+        applied: bool,
+    ) -> None:
+        for category in _CATEGORY_KEYS:
+            self.stdout.write(f'{category}: {counts[category]}')
+        self.stdout.write(f'total_mismatches: {changed_count}')
+        if applied:
+            self.stdout.write(f'changed: {changed_count}')

--- a/app/event/management/commands/normalize_event_weekdays.py
+++ b/app/event/management/commands/normalize_event_weekdays.py
@@ -7,6 +7,7 @@ from django.db import transaction
 
 from community.constants import WEEKDAY_CHOICES, weekday_code
 from event.models import Event
+from ta_hub.index_cache import clear_index_view_cache
 
 
 _CATEGORY_KEYS = (
@@ -71,6 +72,7 @@ class Command(BaseCommand):
     """Event.weekday を検査し、最大1000件ごとに補正・確定する。
 
     中断時は再実行で収束させ、最後に ``--check`` の不整合0件を確認する。
+    ``--apply`` 終了時は成功・失敗を問わずトップページキャッシュを破棄する。
     """
 
     help = (
@@ -88,13 +90,19 @@ class Command(BaseCommand):
         mode.add_argument(
             '--apply',
             action='store_true',
-            help='最大1000件ごとに行ロック・補正・commitする。中断時は再実行する',
+            help=(
+                '最大1000件ごとに行ロック・補正・commitし、'
+                '終了時にトップページcacheを破棄する。中断時は再実行する'
+            ),
         )
 
     def handle(self, *args, **options):
         if options['apply']:
-            changed_count, counts = self._apply()
-            self._write_summary(counts, changed_count, applied=True)
+            try:
+                changed_count, counts = self._apply()
+                self._write_summary(counts, changed_count, applied=True)
+            finally:
+                clear_index_view_cache()
             return
 
         changed_count, counts = _count_mismatches(

--- a/app/event/management/commands/normalize_event_weekdays.py
+++ b/app/event/management/commands/normalize_event_weekdays.py
@@ -1,5 +1,7 @@
 """Event.weekday を開催日由来の固定コードへ正規化する。"""
 
+from collections.abc import Iterable
+
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
@@ -42,7 +44,9 @@ def _empty_counts() -> dict[str, int]:
     return {category: 0 for category in _CATEGORY_KEYS}
 
 
-def _count_mismatches(events) -> tuple[int, dict[str, int]]:
+def _count_mismatches(
+    events: Iterable[Event],
+) -> tuple[int, dict[str, int]]:
     changed_count = 0
     counts = _empty_counts()
     for event in events:
@@ -93,40 +97,44 @@ class Command(BaseCommand):
     def _apply(self) -> tuple[int, dict[str, int]]:
         counts = _empty_counts()
         changed_count = 0
-        batch = []
+        last_pk = 0
         with transaction.atomic():
-            events = (
-                Event.objects.select_for_update()
-                .only('id', 'date', 'weekday')
-                .order_by('id')
-                .iterator(
-                    chunk_size=_BATCH_SIZE,
-                )
-            )
-            for event in events:
-                expected = weekday_code(event.date)
-                category = _classify_weekday(event.weekday, expected)
-                if category is None:
-                    continue
-                counts[category] += 1
-                changed_count += 1
-                event.weekday = expected
-                batch.append(event)
-                if len(batch) == _BATCH_SIZE:
-                    self._bulk_update(batch)
-                    batch.clear()
-            self._bulk_update(batch)
+            while events := self._locked_batch(last_pk):
+                last_pk = events[-1].pk
+                changed_count += self._normalize_batch(events, counts)
         return changed_count, counts
 
     @staticmethod
-    def _bulk_update(events: list[Event]) -> None:
-        if not events:
-            return
+    def _locked_batch(last_pk: int) -> list[Event]:
+        return list(
+            Event.objects.select_for_update()
+            .filter(pk__gt=last_pk)
+            .only('id', 'date', 'weekday')
+            .order_by('pk')[:_BATCH_SIZE]
+        )
+
+    @staticmethod
+    def _normalize_batch(
+        events: list[Event],
+        counts: dict[str, int],
+    ) -> int:
+        changed_events = []
+        for event in events:
+            expected = weekday_code(event.date)
+            category = _classify_weekday(event.weekday, expected)
+            if category is None:
+                continue
+            counts[category] += 1
+            event.weekday = expected
+            changed_events.append(event)
+        if not changed_events:
+            return 0
         Event.objects.bulk_update(
-            events,
+            changed_events,
             ['weekday'],
             batch_size=_BATCH_SIZE,
         )
+        return len(changed_events)
 
     def _write_summary(
         self,

--- a/app/event/management/commands/normalize_event_weekdays.py
+++ b/app/event/management/commands/normalize_event_weekdays.py
@@ -1,4 +1,4 @@
-"""Event.weekday を開催日由来の固定コードへ正規化する。"""
+"""Event.weekday を開催日由来の固定コードへバッチ単位で正規化する。"""
 
 from collections.abc import Iterable
 
@@ -44,6 +44,14 @@ def _empty_counts() -> dict[str, int]:
     return {category: 0 for category in _CATEGORY_KEYS}
 
 
+def _merge_counts(
+    destination: dict[str, int],
+    source: dict[str, int],
+) -> None:
+    for category in _CATEGORY_KEYS:
+        destination[category] += source[category]
+
+
 def _count_mismatches(
     events: Iterable[Event],
 ) -> tuple[int, dict[str, int]]:
@@ -60,21 +68,27 @@ def _count_mismatches(
 
 
 class Command(BaseCommand):
-    """Event.weekday の不整合を検査または一括補正する。"""
+    """Event.weekday を検査し、最大1000件ごとに補正・確定する。
 
-    help = 'Event.weekday を Event.date 由来の Mon..Sun に検査・正規化'
+    中断時は再実行で収束させ、最後に ``--check`` の不整合0件を確認する。
+    """
+
+    help = (
+        'Event.weekdayを最大1000件ずつ確定する。'
+        '再実行後の--check不整合0件が完了条件'
+    )
 
     def add_arguments(self, parser):
         mode = parser.add_mutually_exclusive_group(required=True)
         mode.add_argument(
             '--check',
             action='store_true',
-            help='不整合を分類して表示し、書き込まない',
+            help='完了ゲートとして不整合を分類し、0件なら正常終了する',
         )
         mode.add_argument(
             '--apply',
             action='store_true',
-            help='行ロックを取得し、不整合をトランザクション内で一括補正する',
+            help='最大1000件ごとに行ロック・補正・commitする。中断時は再実行する',
         )
 
     def handle(self, *args, **options):
@@ -98,11 +112,25 @@ class Command(BaseCommand):
         counts = _empty_counts()
         changed_count = 0
         last_pk = 0
+        while True:
+            next_pk, batch_changed, batch_counts = self._apply_batch(last_pk)
+            if next_pk is None:
+                return changed_count, counts
+            last_pk = next_pk
+            changed_count += batch_changed
+            _merge_counts(counts, batch_counts)
+
+    def _apply_batch(
+        self,
+        last_pk: int,
+    ) -> tuple[int | None, int, dict[str, int]]:
         with transaction.atomic():
-            while events := self._locked_batch(last_pk):
-                last_pk = events[-1].pk
-                changed_count += self._normalize_batch(events, counts)
-        return changed_count, counts
+            events = self._locked_batch(last_pk)
+            if not events:
+                return None, 0, _empty_counts()
+            batch_counts = _empty_counts()
+            changed_count = self._normalize_batch(events, batch_counts)
+            return events[-1].pk, changed_count, batch_counts
 
     @staticmethod
     def _locked_batch(last_pk: int) -> list[Event]:

--- a/app/event/management/commands/normalize_event_weekdays.py
+++ b/app/event/management/commands/normalize_event_weekdays.py
@@ -1,7 +1,5 @@
 """Event.weekday を開催日由来の固定コードへ正規化する。"""
 
-from collections.abc import Iterable
-
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
@@ -44,8 +42,8 @@ def _empty_counts() -> dict[str, int]:
     return {category: 0 for category in _CATEGORY_KEYS}
 
 
-def _collect_changes(events: Iterable[Event]) -> tuple[list[Event], dict[str, int]]:
-    changed_events = []
+def _count_mismatches(events) -> tuple[int, dict[str, int]]:
+    changed_count = 0
     counts = _empty_counts()
     for event in events:
         expected = weekday_code(event.date)
@@ -53,9 +51,8 @@ def _collect_changes(events: Iterable[Event]) -> tuple[list[Event], dict[str, in
         if category is None:
             continue
         counts[category] += 1
-        event.weekday = expected
-        changed_events.append(event)
-    return changed_events, counts
+        changed_count += 1
+    return changed_count, counts
 
 
 class Command(BaseCommand):
@@ -73,40 +70,63 @@ class Command(BaseCommand):
         mode.add_argument(
             '--apply',
             action='store_true',
-            help='不整合をトランザクション内で一括補正する',
+            help='行ロックを取得し、不整合をトランザクション内で一括補正する',
         )
 
     def handle(self, *args, **options):
         if options['apply']:
-            changed_events, counts = self._apply()
-            self._write_summary(counts, len(changed_events), applied=True)
+            changed_count, counts = self._apply()
+            self._write_summary(counts, changed_count, applied=True)
             return
 
-        changed_events, counts = _collect_changes(
+        changed_count, counts = _count_mismatches(
             Event.objects.only('id', 'date', 'weekday').iterator(
                 chunk_size=_BATCH_SIZE,
             )
         )
-        self._write_summary(counts, len(changed_events), applied=False)
-        if changed_events:
+        self._write_summary(counts, changed_count, applied=False)
+        if changed_count:
             raise CommandError(
-                f'{len(changed_events)}件のEvent.weekday不整合があります'
+                f'{changed_count}件のEvent.weekday不整合があります'
             )
 
-    def _apply(self) -> tuple[list[Event], dict[str, int]]:
+    def _apply(self) -> tuple[int, dict[str, int]]:
+        counts = _empty_counts()
+        changed_count = 0
+        batch = []
         with transaction.atomic():
-            changed_events, counts = _collect_changes(
-                Event.objects.only('id', 'date', 'weekday').iterator(
+            events = (
+                Event.objects.select_for_update()
+                .only('id', 'date', 'weekday')
+                .order_by('id')
+                .iterator(
                     chunk_size=_BATCH_SIZE,
                 )
             )
-            if changed_events:
-                Event.objects.bulk_update(
-                    changed_events,
-                    ['weekday'],
-                    batch_size=_BATCH_SIZE,
-                )
-        return changed_events, counts
+            for event in events:
+                expected = weekday_code(event.date)
+                category = _classify_weekday(event.weekday, expected)
+                if category is None:
+                    continue
+                counts[category] += 1
+                changed_count += 1
+                event.weekday = expected
+                batch.append(event)
+                if len(batch) == _BATCH_SIZE:
+                    self._bulk_update(batch)
+                    batch.clear()
+            self._bulk_update(batch)
+        return changed_count, counts
+
+    @staticmethod
+    def _bulk_update(events: list[Event]) -> None:
+        if not events:
+            return
+        Event.objects.bulk_update(
+            events,
+            ['weekday'],
+            batch_size=_BATCH_SIZE,
+        )
 
     def _write_summary(
         self,

--- a/app/event/management/commands/normalize_event_weekdays.py
+++ b/app/event/management/commands/normalize_event_weekdays.py
@@ -1,5 +1,6 @@
 """Event.weekday を開催日由来の固定コードへバッチ単位で正規化する。"""
 
+import logging
 from collections.abc import Iterable
 
 from django.core.management.base import BaseCommand, CommandError
@@ -10,6 +11,7 @@ from event.models import Event
 from ta_hub.index_cache import clear_index_view_cache
 
 
+logger = logging.getLogger(__name__)
 _CATEGORY_KEYS = (
     'format_only',
     'valid_mismatch',
@@ -51,6 +53,15 @@ def _merge_counts(
 ) -> None:
     for category in _CATEGORY_KEYS:
         destination[category] += source[category]
+
+
+def _clear_index_cache_after_apply_failure() -> None:
+    try:
+        clear_index_view_cache()
+    except Exception:
+        logger.error(
+            '曜日正規化失敗後のトップページキャッシュ破棄にも失敗しました'
+        )
 
 
 def _count_mismatches(
@@ -101,8 +112,10 @@ class Command(BaseCommand):
             try:
                 changed_count, counts = self._apply()
                 self._write_summary(counts, changed_count, applied=True)
-            finally:
-                clear_index_view_cache()
+            except BaseException:
+                _clear_index_cache_after_apply_failure()
+                raise
+            clear_index_view_cache()
             return
 
         changed_count, counts = _count_mismatches(

--- a/app/event/recurrence/persistence.py
+++ b/app/event/recurrence/persistence.py
@@ -7,6 +7,7 @@ import datetime
 from datetime import date
 from typing import List
 
+from community.constants import weekday_code
 from event.models import Event, RecurrenceRule
 from event.services.recurrence_override import exclude_tombstoned_dates
 
@@ -58,7 +59,7 @@ def create_recurring_events(
         date=master_date,
         start_time=start_time,
         duration=duration,
-        weekday=master_date.strftime('%a').upper()[:3],
+        weekday=weekday_code(master_date),
         recurrence_rule=rule,
         is_recurring_master=True,
     )
@@ -81,7 +82,7 @@ def create_recurring_events(
                 date=event_date,
                 start_time=start_time,
                 duration=duration,
-                weekday=event_date.strftime('%a').upper()[:3],
+                weekday=weekday_code(event_date),
                 recurring_master=master_event,
             )
             created_events.append(event)

--- a/app/event/services/recurrence_override.py
+++ b/app/event/services/recurrence_override.py
@@ -7,6 +7,7 @@ from django.core.cache import cache
 from django.db import transaction
 from django.utils import timezone
 
+from community.constants import weekday_code
 from event.models import Event, EventOccurrenceTombstone
 
 
@@ -82,7 +83,7 @@ def move_event_occurrence(event: Event, new_date: date) -> Event:
             EventOccurrenceTombstone.Reason.RESCHEDULED,
         )
         event.date = new_date
-        event.weekday = new_date.strftime('%a')
+        event.weekday = weekday_code(new_date)
         update_fields = ['date', 'weekday']
         if event.recurring_master_id is not None:
             event.recurring_master = None

--- a/app/event/tests/test_event_date_update.py
+++ b/app/event/tests/test_event_date_update.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.formats import date_format, time_format
 
+from community.constants import weekday_code
 from community.models import Community, CommunityMember
 from event.models import Event, EventOccurrenceTombstone, RecurrenceRule
 from event.tests.tweet_generation import TweetGenerationPatchMixin
@@ -108,7 +109,7 @@ class EventDateUpdateViewTests(TweetGenerationPatchMixin, TestCase):
         self.assertEqual(self.event.start_time, time(22, 0))
         self.assertEqual(
             self.event.weekday,
-            new_date.strftime('%a'),
+            weekday_code(new_date),
         )
         self.assertIsNone(self.event.recurring_master_id)
         tombstone = EventOccurrenceTombstone.objects.get(

--- a/app/event/tests/test_generate_recurring_events_command.py
+++ b/app/event/tests/test_generate_recurring_events_command.py
@@ -6,6 +6,7 @@ from django.test import TestCase, tag
 from django.utils import timezone
 from io import StringIO
 
+from community.constants import weekday_code
 from community.models import Community
 from event.models import Event, EventOccurrenceTombstone, RecurrenceRule
 from event.tests.tweet_generation import TweetGenerationPatchMixin
@@ -82,6 +83,7 @@ class GenerateRecurringEventsCommandTest(TweetGenerationPatchMixin, TestCase):
             self.assertEqual(event.start_time, time(21, 0))
             self.assertEqual(event.duration, 60)
             self.assertEqual(event.community, self.community)
+            self.assertEqual(event.weekday, weekday_code(event.date))
             
     def test_dry_run_option(self):
         """ドライランオプションのテスト"""
@@ -101,6 +103,8 @@ class GenerateRecurringEventsCommandTest(TweetGenerationPatchMixin, TestCase):
         
     def test_reset_future_option(self):
         """未来のイベントリセットオプションのテスト"""
+        self.master_event.date = timezone.now().date() + timedelta(days=7)
+        self.master_event.save(update_fields=['date'])
         # 先に未来のイベントを作成
         future_date = timezone.now().date() + timedelta(days=14)
         future_event = Event.objects.create(
@@ -130,6 +134,11 @@ class GenerateRecurringEventsCommandTest(TweetGenerationPatchMixin, TestCase):
             date__gte=timezone.now().date()
         )
         self.assertGreater(generated_events.count(), 0)
+        self.master_event.refresh_from_db()
+        self.assertEqual(
+            self.master_event.weekday,
+            weekday_code(self.master_event.date),
+        )
         
     def test_multiple_months_generation(self):
         """複数月の生成テスト"""

--- a/app/event/tests/test_normalize_event_weekday_failures.py
+++ b/app/event/tests/test_normalize_event_weekday_failures.py
@@ -1,0 +1,94 @@
+"""曜日正規化とキャッシュ破棄が同時に失敗する境界を検証する。"""
+
+from datetime import date, time
+from unittest import skipUnless
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.db import DatabaseError, connection
+from django.test import TestCase, TransactionTestCase, tag
+
+from community.models import Community
+from event.models import Event
+from event.tests.tweet_generation import TweetGenerationPatchMixin
+
+
+_FAILURE_TRIGGER_NAME = 'test_event_weekday_db_cache_failure'
+_CACHE_FAILURE_DETAIL = 'SENSITIVE_CACHE_DETAIL'
+_COMMAND_LOGGER = 'event.management.commands.normalize_event_weekdays'
+
+
+@tag('offline_external_api')
+class NormalizeEventWeekdayCacheFailureTests(TestCase):
+    """正常なapply後はキャッシュ破棄失敗を呼出元へ通知する。"""
+
+    def test_successful_apply_propagates_cache_clear_failure(self) -> None:
+        with patch(
+            'ta_hub.index_cache.cache.delete',
+            side_effect=RuntimeError('cache unavailable'),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                'cache unavailable',
+            ):
+                call_command('normalize_event_weekdays', '--apply')
+
+
+@tag('offline_external_api')
+@skipUnless(connection.vendor == 'mysql', 'MySQL trigger is required')
+class NormalizeEventWeekdayDualFailureTests(
+    TweetGenerationPatchMixin,
+    TransactionTestCase,
+):
+    """DB失敗をキャッシュ破棄失敗より優先して通知する。"""
+
+    def setUp(self) -> None:
+        community = Community.objects.create(
+            name='曜日DB・キャッシュ同時失敗テスト集会',
+            frequency='不定期',
+        )
+        self.event = Event.objects.create(
+            community=community,
+            date=date(2026, 8, 3),
+            start_time=time(21, 0),
+            weekday='Other',
+        )
+
+    def _create_failure_trigger(self) -> None:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"""
+                CREATE TRIGGER `{_FAILURE_TRIGGER_NAME}`
+                BEFORE UPDATE ON `event`
+                FOR EACH ROW
+                BEGIN
+                    IF NEW.id = {self.event.pk} THEN
+                        SIGNAL SQLSTATE '45000'
+                        SET MESSAGE_TEXT = 'forced database failure';
+                    END IF;
+                END
+                """
+            )
+
+    def _drop_failure_trigger(self) -> None:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f'DROP TRIGGER IF EXISTS `{_FAILURE_TRIGGER_NAME}`'
+            )
+
+    def test_database_error_survives_cache_clear_error(self) -> None:
+        self._create_failure_trigger()
+        self.addCleanup(self._drop_failure_trigger)
+
+        with self.assertLogs(_COMMAND_LOGGER, level='ERROR') as captured:
+            with patch(
+                'ta_hub.index_cache.cache.delete',
+                side_effect=RuntimeError(_CACHE_FAILURE_DETAIL),
+            ):
+                with self.assertRaises(DatabaseError) as raised:
+                    call_command('normalize_event_weekdays', '--apply')
+
+        self.assertIn('forced database failure', str(raised.exception))
+        logs = '\n'.join(captured.output)
+        self.assertIn('キャッシュ破棄にも失敗しました', logs)
+        self.assertNotIn(_CACHE_FAILURE_DETAIL, logs)

--- a/app/event/tests/test_normalize_event_weekday_failures.py
+++ b/app/event/tests/test_normalize_event_weekday_failures.py
@@ -22,6 +22,23 @@ _COMMAND_LOGGER = 'event.management.commands.normalize_event_weekdays'
 class NormalizeEventWeekdayCacheFailureTests(TestCase):
     """正常なapply後はキャッシュ破棄失敗を呼出元へ通知する。"""
 
+    def test_keyboard_interrupt_survives_cache_clear_error(self) -> None:
+        with self.assertLogs(_COMMAND_LOGGER, level='ERROR') as captured:
+            with patch(
+                'event.management.commands.normalize_event_weekdays.Command._apply',
+                side_effect=KeyboardInterrupt,
+            ):
+                with patch(
+                    'ta_hub.index_cache.cache.delete',
+                    side_effect=RuntimeError(_CACHE_FAILURE_DETAIL),
+                ):
+                    with self.assertRaises(KeyboardInterrupt):
+                        call_command('normalize_event_weekdays', '--apply')
+
+        logs = '\n'.join(captured.output)
+        self.assertIn('キャッシュ破棄にも失敗しました', logs)
+        self.assertNotIn(_CACHE_FAILURE_DETAIL, logs)
+
     def test_successful_apply_propagates_cache_clear_failure(self) -> None:
         with patch(
             'ta_hub.index_cache.cache.delete',

--- a/app/event/tests/test_weekday_normalization.py
+++ b/app/event/tests/test_weekday_normalization.py
@@ -8,13 +8,23 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
 from django.db import DatabaseError
-from django.test import Client, RequestFactory, TestCase, tag
+from django.test import (
+    Client,
+    RequestFactory,
+    SimpleTestCase,
+    TestCase,
+    TransactionTestCase,
+    tag,
+)
 from django.urls import reverse
 from django.utils import timezone
 
 from community.constants import weekday_code
 from community.models import Community, CommunityMember
 from event.admin import EventAdmin
+from event.management.commands.normalize_event_weekdays import (
+    _classify_weekday,
+)
 from event.models import Event, RecurrenceRule
 from event.recurrence.persistence import create_recurring_events
 from event.services.recurrence_override import move_event_occurrence
@@ -22,6 +32,33 @@ from event.tests.tweet_generation import TweetGenerationPatchMixin
 
 
 User = get_user_model()
+
+
+class WeekdayClassificationTests(SimpleTestCase):
+    """旧値を日付との関係に応じて分類する。"""
+
+    def test_classifies_supported_and_invalid_values(self):
+        cases = (
+            ('canonical match', 'Mon', 'Mon', None),
+            ('canonical mismatch', 'Tue', 'Mon', 'valid_mismatch'),
+            ('lowercase alias match', 'mon', 'Mon', 'format_only'),
+            ('uppercase alias match', 'MON', 'Mon', 'format_only'),
+            ('lowercase alias mismatch', 'tue', 'Mon', 'outside_choices'),
+            ('uppercase alias mismatch', 'TUE', 'Mon', 'outside_choices'),
+            ('Japanese alias match', '月曜日', 'Mon', 'format_only'),
+            ('Japanese alias mismatch', '火曜日', 'Mon', 'outside_choices'),
+            ('Other', 'Other', 'Mon', 'other'),
+            ('empty', '', 'Mon', 'empty'),
+            ('whitespace', ' ', 'Mon', 'outside_choices'),
+            ('unknown', 'Funday', 'Mon', 'outside_choices'),
+        )
+
+        for label, value, expected, category in cases:
+            with self.subTest(label=label):
+                self.assertEqual(
+                    _classify_weekday(value, expected),
+                    category,
+                )
 
 
 @tag('offline_external_api')
@@ -258,3 +295,39 @@ class NormalizeEventWeekdaysCommandTests(TweetGenerationPatchMixin, TestCase):
         second.refresh_from_db()
         self.assertEqual(first.weekday, 'MON')
         self.assertEqual(second.weekday, '火曜日')
+
+
+@tag('offline_external_api')
+class NormalizeEventWeekdaysLockingTests(
+    TweetGenerationPatchMixin,
+    TransactionTestCase,
+):
+    """apply がロック取得後の日付から曜日を確定する境界を検証する。"""
+
+    def test_apply_selects_for_update_before_normalizing(self):
+        community = Community.objects.create(
+            name='曜日ロック境界テスト集会',
+            frequency='不定期',
+        )
+        event = Event.objects.create(
+            community=community,
+            date=date(2026, 8, 3),
+            start_time=time(21, 0),
+            weekday='TUE',
+        )
+        manager = Event.objects
+
+        with patch.object(
+            manager,
+            'select_for_update',
+            wraps=manager.select_for_update,
+        ) as select_for_update:
+            call_command(
+                'normalize_event_weekdays',
+                '--apply',
+                stdout=StringIO(),
+            )
+
+        select_for_update.assert_called_once_with()
+        event.refresh_from_db()
+        self.assertEqual(event.weekday, weekday_code(event.date))

--- a/app/event/tests/test_weekday_normalization.py
+++ b/app/event/tests/test_weekday_normalization.py
@@ -1,0 +1,260 @@
+"""Event.weekday の書込境界と正規化コマンドを検証する。"""
+
+from datetime import date, time, timedelta
+from io import StringIO
+from unittest.mock import patch
+
+from django.contrib import admin
+from django.contrib.auth import get_user_model
+from django.core.management import CommandError, call_command
+from django.db import DatabaseError
+from django.test import Client, RequestFactory, TestCase, tag
+from django.urls import reverse
+from django.utils import timezone
+
+from community.constants import weekday_code
+from community.models import Community, CommunityMember
+from event.admin import EventAdmin
+from event.models import Event, RecurrenceRule
+from event.recurrence.persistence import create_recurring_events
+from event.services.recurrence_override import move_event_occurrence
+from event.tests.tweet_generation import TweetGenerationPatchMixin
+
+
+User = get_user_model()
+
+
+@tag('offline_external_api')
+class EventWeekdayWriterTests(TweetGenerationPatchMixin, TestCase):
+    """Event を保存する各境界が date 由来の曜日を使うことを検証する。"""
+
+    def setUp(self):
+        self.community = Community.objects.create(
+            name='曜日書込テスト集会',
+            status='approved',
+            weekdays=['Mon'],
+            frequency='毎週',
+            start_time=time(21, 0),
+            duration=60,
+        )
+
+    def test_calendar_create_uses_event_date(self):
+        user = User.objects.create_user(
+            user_name='weekday_calendar_owner',
+            email='weekday-calendar@example.com',
+            password='testpass123',
+        )
+        CommunityMember.objects.create(
+            community=self.community,
+            user=user,
+            role=CommunityMember.Role.OWNER,
+        )
+        client = Client()
+        client.force_login(user)
+        session = client.session
+        session['active_community_id'] = self.community.pk
+        session.save()
+        event_date = timezone.localdate() + timedelta(days=10)
+
+        response = client.post(
+            reverse('event:calendar_create'),
+            {
+                'start_date': event_date.isoformat(),
+                'start_time': '21:00',
+                'duration': 60,
+                'recurrence_type': 'none',
+            },
+        )
+
+        self.assertRedirects(response, reverse('event:my_list'))
+        event = Event.objects.get(community=self.community, date=event_date)
+        self.assertEqual(event.weekday, weekday_code(event_date))
+
+    def test_recurrence_persistence_uses_each_event_date(self):
+        rule = RecurrenceRule.objects.create(
+            community=self.community,
+            frequency='WEEKLY',
+        )
+        dates = [date(2026, 8, 3), date(2026, 8, 11)]
+
+        events = create_recurring_events(
+            self.community,
+            rule,
+            dates,
+            time(21, 0),
+            60,
+        )
+
+        self.assertEqual(
+            [event.weekday for event in events],
+            ['Mon', 'Tue'],
+        )
+
+    def test_recurrence_override_replaces_legacy_weekday(self):
+        original_date = date(2026, 8, 3)
+        event = Event.objects.create(
+            community=self.community,
+            date=original_date,
+            start_time=time(21, 0),
+            weekday='MON',
+        )
+        new_date = date(2026, 8, 5)
+
+        move_event_occurrence(event, new_date)
+
+        event.refresh_from_db()
+        self.assertEqual(event.date, new_date)
+        self.assertEqual(event.weekday, 'Wed')
+
+    def test_admin_makes_weekday_readonly_and_derives_it_on_save(self):
+        event_admin = EventAdmin(Event, admin.site)
+        event = Event(
+            community=self.community,
+            date=date(2026, 8, 6),
+            start_time=time(21, 0),
+            weekday='Other',
+        )
+        request = RequestFactory().post('/admin/event/event/add/')
+
+        self.assertIn(
+            'weekday',
+            event_admin.get_readonly_fields(request, event),
+        )
+        event_admin.save_model(request, event, form=None, change=False)
+
+        event.refresh_from_db()
+        self.assertEqual(event.weekday, 'Thu')
+
+
+@tag('offline_external_api')
+class NormalizeEventWeekdaysCommandTests(TweetGenerationPatchMixin, TestCase):
+    """正規化コマンドの分類、適用、冪等性、rollbackを検証する。"""
+
+    def setUp(self):
+        self.community = Community.objects.create(
+            name='曜日正規化テスト集会',
+            status='approved',
+            weekdays=['Other'],
+            frequency='不定期',
+            start_time=time(21, 0),
+            duration=60,
+        )
+
+    def _create_event(
+        self,
+        event_date: date,
+        weekday: str,
+        *,
+        start_hour: int = 21,
+    ) -> Event:
+        return Event.objects.create(
+            community=self.community,
+            date=event_date,
+            start_time=time(start_hour, 0),
+            weekday=weekday,
+        )
+
+    def _create_classification_examples(self) -> list[Event]:
+        return [
+            self._create_event(date(2026, 8, 3), 'Mon'),
+            self._create_event(
+                date(2026, 8, 3),
+                'MON',
+                start_hour=22,
+            ),
+            self._create_event(date(2026, 8, 5), '水曜日'),
+            self._create_event(date(2026, 8, 7), 'Thu'),
+            self._create_event(date(2026, 8, 8), '???'),
+            self._create_event(date(2026, 8, 9), 'Other'),
+            self._create_event(date(2026, 8, 10), ''),
+        ]
+
+    def test_check_classifies_without_writing_and_returns_nonzero(self):
+        events = self._create_classification_examples()
+        original_values = {
+            event.pk: event.weekday
+            for event in events
+        }
+        stdout = StringIO()
+
+        with self.assertRaises(CommandError):
+            call_command(
+                'normalize_event_weekdays',
+                '--check',
+                stdout=stdout,
+            )
+
+        self.assertIn('format_only: 2', stdout.getvalue())
+        self.assertIn('valid_mismatch: 1', stdout.getvalue())
+        self.assertIn('outside_choices: 1', stdout.getvalue())
+        self.assertIn('other: 1', stdout.getvalue())
+        self.assertIn('empty: 1', stdout.getvalue())
+        self.assertIn('total_mismatches: 6', stdout.getvalue())
+        current_values = dict(
+            Event.objects.values_list('pk', 'weekday')
+        )
+        self.assertEqual(current_values, original_values)
+        self.community.refresh_from_db()
+        self.assertEqual(self.community.weekdays, ['Other'])
+
+    def test_apply_normalizes_all_rows_and_second_check_is_clean(self):
+        self._create_classification_examples()
+        first_apply = StringIO()
+
+        call_command(
+            'normalize_event_weekdays',
+            '--apply',
+            stdout=first_apply,
+        )
+
+        self.assertIn('changed: 6', first_apply.getvalue())
+        for event in Event.objects.all():
+            self.assertEqual(event.weekday, weekday_code(event.date))
+
+        second_apply = StringIO()
+        call_command(
+            'normalize_event_weekdays',
+            '--apply',
+            stdout=second_apply,
+        )
+        self.assertIn('changed: 0', second_apply.getvalue())
+
+        check = StringIO()
+        call_command(
+            'normalize_event_weekdays',
+            '--check',
+            stdout=check,
+        )
+        self.assertIn('total_mismatches: 0', check.getvalue())
+
+    def test_requires_exactly_one_mode(self):
+        with self.assertRaises(CommandError):
+            call_command('normalize_event_weekdays')
+        with self.assertRaises(CommandError):
+            call_command(
+                'normalize_event_weekdays',
+                '--check',
+                '--apply',
+            )
+
+    def test_apply_rolls_back_partial_update_on_database_error(self):
+        first = self._create_event(date(2026, 8, 3), 'MON')
+        second = self._create_event(date(2026, 8, 4), '火曜日')
+
+        def update_one_then_fail(events, _fields, **_kwargs):
+            Event.objects.filter(pk=events[0].pk).update(
+                weekday=events[0].weekday,
+            )
+            raise DatabaseError('forced bulk update failure')
+
+        with patch(
+            'django.db.models.query.QuerySet.bulk_update',
+            side_effect=update_one_then_fail,
+        ):
+            with self.assertRaises(DatabaseError):
+                call_command('normalize_event_weekdays', '--apply')
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertEqual(first.weekday, 'MON')
+        self.assertEqual(second.weekday, '火曜日')

--- a/app/event/tests/test_weekday_normalization.py
+++ b/app/event/tests/test_weekday_normalization.py
@@ -2,18 +2,21 @@
 
 from datetime import date, time, timedelta
 from io import StringIO
-from unittest.mock import patch
+from queue import Empty, Queue
+from threading import Event as ThreadEvent
+from threading import Thread
 
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
-from django.db import DatabaseError
+from django.db import close_old_connections, transaction
 from django.test import (
     Client,
     RequestFactory,
     SimpleTestCase,
     TestCase,
     TransactionTestCase,
+    skipUnlessDBFeature,
     tag,
 )
 from django.urls import reverse
@@ -32,6 +35,9 @@ from event.tests.tweet_generation import TweetGenerationPatchMixin
 
 
 User = get_user_model()
+_KEYSET_TEST_EVENT_COUNT = 1001
+_THREAD_TIMEOUT_SECONDS = 10
+_LOCK_WAIT_OBSERVATION_SECONDS = 0.25
 
 
 class WeekdayClassificationTests(SimpleTestCase):
@@ -65,7 +71,7 @@ class WeekdayClassificationTests(SimpleTestCase):
 class EventWeekdayWriterTests(TweetGenerationPatchMixin, TestCase):
     """Event を保存する各境界が date 由来の曜日を使うことを検証する。"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.community = Community.objects.create(
             name='曜日書込テスト集会',
             status='approved',
@@ -165,9 +171,9 @@ class EventWeekdayWriterTests(TweetGenerationPatchMixin, TestCase):
 
 @tag('offline_external_api')
 class NormalizeEventWeekdaysCommandTests(TweetGenerationPatchMixin, TestCase):
-    """正規化コマンドの分類、適用、冪等性、rollbackを検証する。"""
+    """正規化コマンドの分類、適用、冪等性を検証する。"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.community = Community.objects.create(
             name='曜日正規化テスト集会',
             status='approved',
@@ -274,27 +280,36 @@ class NormalizeEventWeekdaysCommandTests(TweetGenerationPatchMixin, TestCase):
                 '--apply',
             )
 
-    def test_apply_rolls_back_partial_update_on_database_error(self):
-        first = self._create_event(date(2026, 8, 3), 'MON')
-        second = self._create_event(date(2026, 8, 4), '火曜日')
+    def test_apply_normalizes_rows_beyond_first_keyset_batch(self):
+        start_date = date(2026, 1, 1)
+        Event.objects.bulk_create(
+            [
+                Event(
+                    community=self.community,
+                    date=start_date + timedelta(days=offset),
+                    start_time=time(21, 0),
+                    weekday='Other',
+                )
+                for offset in range(_KEYSET_TEST_EVENT_COUNT)
+            ]
+        )
+        stdout = StringIO()
 
-        def update_one_then_fail(events, _fields, **_kwargs):
-            Event.objects.filter(pk=events[0].pk).update(
-                weekday=events[0].weekday,
+        call_command(
+            'normalize_event_weekdays',
+            '--apply',
+            stdout=stdout,
+        )
+
+        self.assertIn(
+            f'changed: {_KEYSET_TEST_EVENT_COUNT}',
+            stdout.getvalue(),
+        )
+        for event in Event.objects.all():
+            self.assertEqual(
+                event.weekday,
+                weekday_code(event.date),
             )
-            raise DatabaseError('forced bulk update failure')
-
-        with patch(
-            'django.db.models.query.QuerySet.bulk_update',
-            side_effect=update_one_then_fail,
-        ):
-            with self.assertRaises(DatabaseError):
-                call_command('normalize_event_weekdays', '--apply')
-
-        first.refresh_from_db()
-        second.refresh_from_db()
-        self.assertEqual(first.weekday, 'MON')
-        self.assertEqual(second.weekday, '火曜日')
 
 
 @tag('offline_external_api')
@@ -302,32 +317,103 @@ class NormalizeEventWeekdaysLockingTests(
     TweetGenerationPatchMixin,
     TransactionTestCase,
 ):
-    """apply がロック取得後の日付から曜日を確定する境界を検証する。"""
+    """apply が競合する日付更新後も曜日整合性を維持する。"""
 
-    def test_apply_selects_for_update_before_normalizing(self):
+    def setUp(self) -> None:
         community = Community.objects.create(
             name='曜日ロック境界テスト集会',
             frequency='不定期',
         )
-        event = Event.objects.create(
+        self.event = Event.objects.create(
             community=community,
             date=date(2026, 8, 3),
             start_time=time(21, 0),
             weekday='TUE',
         )
-        manager = Event.objects
+        self.writer_locked = ThreadEvent()
+        self.release_writer = ThreadEvent()
+        self.normalizer_started = ThreadEvent()
+        self.normalizer_finished = ThreadEvent()
+        self.errors: Queue[Exception] = Queue()
+        self.writer = Thread(target=self._run_writer)
+        self.normalizer = Thread(target=self._run_normalizer)
 
-        with patch.object(
-            manager,
-            'select_for_update',
-            wraps=manager.select_for_update,
-        ) as select_for_update:
+    def _run_writer(self) -> None:
+        close_old_connections()
+        try:
+            with transaction.atomic():
+                event = Event.objects.select_for_update().get(
+                    pk=self.event.pk,
+                )
+                event.date = date(2026, 8, 5)
+                event.weekday = weekday_code(event.date)
+                event.save(update_fields=['date', 'weekday'])
+                self.writer_locked.set()
+                if not self.release_writer.wait(_THREAD_TIMEOUT_SECONDS):
+                    raise TimeoutError('writer lock release timed out')
+        except Exception as exc:
+            self.errors.put(exc)
+            self.writer_locked.set()
+        finally:
+            close_old_connections()
+
+    def _run_normalizer(self) -> None:
+        close_old_connections()
+        self.normalizer_started.set()
+        try:
             call_command(
                 'normalize_event_weekdays',
                 '--apply',
                 stdout=StringIO(),
             )
+        except Exception as exc:
+            self.errors.put(exc)
+        finally:
+            self.normalizer_finished.set()
+            close_old_connections()
 
-        select_for_update.assert_called_once_with()
-        event.refresh_from_db()
-        self.assertEqual(event.weekday, weekday_code(event.date))
+    def _drain_errors(self) -> list[Exception]:
+        found = []
+        while True:
+            try:
+                found.append(self.errors.get_nowait())
+            except Empty:
+                return found
+
+    def _release_and_join_threads(self) -> None:
+        self.release_writer.set()
+        for thread in (self.writer, self.normalizer):
+            if thread.ident is not None:
+                thread.join(_THREAD_TIMEOUT_SECONDS)
+
+    @skipUnlessDBFeature('has_select_for_update')
+    def test_apply_waits_for_concurrent_date_update_and_stays_consistent(self):
+        self.writer.start()
+        try:
+            self.assertTrue(
+                self.writer_locked.wait(_THREAD_TIMEOUT_SECONDS),
+                'writer did not acquire the row lock',
+            )
+            self.assertEqual(self._drain_errors(), [])
+            self.normalizer.start()
+            self.assertTrue(
+                self.normalizer_started.wait(_THREAD_TIMEOUT_SECONDS),
+                'normalizer did not start',
+            )
+            self.assertFalse(
+                self.normalizer_finished.wait(
+                    _LOCK_WAIT_OBSERVATION_SECONDS
+                ),
+                'normalizer finished while the writer held the row lock',
+            )
+        finally:
+            self._release_and_join_threads()
+
+        self.assertFalse(self.writer.is_alive())
+        self.assertFalse(self.normalizer.is_alive())
+        self.assertEqual(self._drain_errors(), [])
+        self.event.refresh_from_db()
+        self.assertEqual(
+            self.event.weekday,
+            weekday_code(self.event.date),
+        )

--- a/app/event/tests/test_weekday_normalization.py
+++ b/app/event/tests/test_weekday_normalization.py
@@ -9,6 +9,7 @@ from unittest import skipUnless
 
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.core.management import CommandError, call_command
 from django.db import (
     DatabaseError,
@@ -34,6 +35,11 @@ from event.models import Event, RecurrenceRule
 from event.recurrence.persistence import create_recurring_events
 from event.services.recurrence_override import move_event_occurrence
 from event.tests.tweet_generation import TweetGenerationPatchMixin
+from ta_hub.index_cache import (
+    build_index_database_context,
+    get_index_view_cache_key,
+)
+from utils.vrchat_time import get_vrchat_today
 
 
 User = get_user_model()
@@ -256,6 +262,27 @@ class NormalizeEventWeekdaysCommandTests(TweetGenerationPatchMixin, TestCase):
         )
         self.assertIn('total_mismatches: 0', check.getvalue())
 
+    def test_apply_invalidates_stale_index_cache(self):
+        today = get_vrchat_today()
+        self.community.poster_image = 'poster/weekday-cache.png'
+        self.community.save(update_fields=['poster_image'])
+        event = self._create_event(today, 'Other')
+        cache_key = get_index_view_cache_key(today)
+        self.addCleanup(cache.delete, cache_key)
+        request = RequestFactory().get('/')
+
+        cached = build_index_database_context(request, today, cache_key)
+        self.assertEqual(cached['upcoming_events'][0]['weekday'], 'Other')
+
+        call_command('normalize_event_weekdays', '--apply')
+
+        self.assertIsNone(cache.get(cache_key))
+        rebuilt = build_index_database_context(request, today, cache_key)
+        self.assertEqual(
+            rebuilt['upcoming_events'][0]['weekday'],
+            weekday_code(event.date),
+        )
+
     def test_requires_exactly_one_mode(self):
         with self.assertRaises(CommandError):
             call_command('normalize_event_weekdays')
@@ -426,12 +453,15 @@ class NormalizeEventWeekdaysBatchCommitTests(
             )
 
     def test_apply_commits_each_batch_and_retry_converges(self):
+        cache_key = get_index_view_cache_key()
+        cache.set(cache_key, {'weekday': 'Other'})
         self._create_failure_trigger()
         try:
             with self.assertRaises(DatabaseError):
                 call_command('normalize_event_weekdays', '--apply')
         finally:
             self._drop_failure_trigger()
+        self.assertIsNone(cache.get(cache_key))
 
         first_batch = Event.objects.filter(
             pk__lte=self.event_pks[-2],

--- a/app/event/tests/test_weekday_normalization.py
+++ b/app/event/tests/test_weekday_normalization.py
@@ -5,15 +5,20 @@ from io import StringIO
 from queue import Empty, Queue
 from threading import Event as ThreadEvent
 from threading import Thread
+from unittest import skipUnless
 
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
-from django.db import close_old_connections, transaction
+from django.db import (
+    DatabaseError,
+    close_old_connections,
+    connection,
+    transaction,
+)
 from django.test import (
     Client,
     RequestFactory,
-    SimpleTestCase,
     TestCase,
     TransactionTestCase,
     skipUnlessDBFeature,
@@ -25,9 +30,6 @@ from django.utils import timezone
 from community.constants import weekday_code
 from community.models import Community, CommunityMember
 from event.admin import EventAdmin
-from event.management.commands.normalize_event_weekdays import (
-    _classify_weekday,
-)
 from event.models import Event, RecurrenceRule
 from event.recurrence.persistence import create_recurring_events
 from event.services.recurrence_override import move_event_occurrence
@@ -38,33 +40,7 @@ User = get_user_model()
 _KEYSET_TEST_EVENT_COUNT = 1001
 _THREAD_TIMEOUT_SECONDS = 10
 _LOCK_WAIT_OBSERVATION_SECONDS = 0.25
-
-
-class WeekdayClassificationTests(SimpleTestCase):
-    """旧値を日付との関係に応じて分類する。"""
-
-    def test_classifies_supported_and_invalid_values(self):
-        cases = (
-            ('canonical match', 'Mon', 'Mon', None),
-            ('canonical mismatch', 'Tue', 'Mon', 'valid_mismatch'),
-            ('lowercase alias match', 'mon', 'Mon', 'format_only'),
-            ('uppercase alias match', 'MON', 'Mon', 'format_only'),
-            ('lowercase alias mismatch', 'tue', 'Mon', 'outside_choices'),
-            ('uppercase alias mismatch', 'TUE', 'Mon', 'outside_choices'),
-            ('Japanese alias match', '月曜日', 'Mon', 'format_only'),
-            ('Japanese alias mismatch', '火曜日', 'Mon', 'outside_choices'),
-            ('Other', 'Other', 'Mon', 'other'),
-            ('empty', '', 'Mon', 'empty'),
-            ('whitespace', ' ', 'Mon', 'outside_choices'),
-            ('unknown', 'Funday', 'Mon', 'outside_choices'),
-        )
-
-        for label, value, expected, category in cases:
-            with self.subTest(label=label):
-                self.assertEqual(
-                    _classify_weekday(value, expected),
-                    category,
-                )
+_FAILURE_TRIGGER_NAME = 'test_event_weekday_batch_failure'
 
 
 @tag('offline_external_api')
@@ -198,18 +174,28 @@ class NormalizeEventWeekdaysCommandTests(TweetGenerationPatchMixin, TestCase):
         )
 
     def _create_classification_examples(self) -> list[Event]:
+        event_date = date(2026, 8, 3)
+        values = (
+            'Mon',
+            'Tue',
+            'mon',
+            'MON',
+            'tue',
+            'TUE',
+            '月曜日',
+            '火曜日',
+            'Other',
+            '',
+            ' ',
+            'Xday',
+        )
         return [
-            self._create_event(date(2026, 8, 3), 'Mon'),
             self._create_event(
-                date(2026, 8, 3),
-                'MON',
-                start_hour=22,
-            ),
-            self._create_event(date(2026, 8, 5), '水曜日'),
-            self._create_event(date(2026, 8, 7), 'Thu'),
-            self._create_event(date(2026, 8, 8), '???'),
-            self._create_event(date(2026, 8, 9), 'Other'),
-            self._create_event(date(2026, 8, 10), ''),
+                event_date,
+                value,
+                start_hour=start_hour,
+            )
+            for start_hour, value in enumerate(values)
         ]
 
     def test_check_classifies_without_writing_and_returns_nonzero(self):
@@ -227,12 +213,12 @@ class NormalizeEventWeekdaysCommandTests(TweetGenerationPatchMixin, TestCase):
                 stdout=stdout,
             )
 
-        self.assertIn('format_only: 2', stdout.getvalue())
+        self.assertIn('format_only: 3', stdout.getvalue())
         self.assertIn('valid_mismatch: 1', stdout.getvalue())
-        self.assertIn('outside_choices: 1', stdout.getvalue())
+        self.assertIn('outside_choices: 5', stdout.getvalue())
         self.assertIn('other: 1', stdout.getvalue())
         self.assertIn('empty: 1', stdout.getvalue())
-        self.assertIn('total_mismatches: 6', stdout.getvalue())
+        self.assertIn('total_mismatches: 11', stdout.getvalue())
         current_values = dict(
             Event.objects.values_list('pk', 'weekday')
         )
@@ -250,7 +236,7 @@ class NormalizeEventWeekdaysCommandTests(TweetGenerationPatchMixin, TestCase):
             stdout=first_apply,
         )
 
-        self.assertIn('changed: 6', first_apply.getvalue())
+        self.assertIn('changed: 11', first_apply.getvalue())
         for event in Event.objects.all():
             self.assertEqual(event.weekday, weekday_code(event.date))
 
@@ -279,38 +265,6 @@ class NormalizeEventWeekdaysCommandTests(TweetGenerationPatchMixin, TestCase):
                 '--check',
                 '--apply',
             )
-
-    def test_apply_normalizes_rows_beyond_first_keyset_batch(self):
-        start_date = date(2026, 1, 1)
-        Event.objects.bulk_create(
-            [
-                Event(
-                    community=self.community,
-                    date=start_date + timedelta(days=offset),
-                    start_time=time(21, 0),
-                    weekday='Other',
-                )
-                for offset in range(_KEYSET_TEST_EVENT_COUNT)
-            ]
-        )
-        stdout = StringIO()
-
-        call_command(
-            'normalize_event_weekdays',
-            '--apply',
-            stdout=stdout,
-        )
-
-        self.assertIn(
-            f'changed: {_KEYSET_TEST_EVENT_COUNT}',
-            stdout.getvalue(),
-        )
-        for event in Event.objects.all():
-            self.assertEqual(
-                event.weekday,
-                weekday_code(event.date),
-            )
-
 
 @tag('offline_external_api')
 class NormalizeEventWeekdaysLockingTests(
@@ -417,3 +371,87 @@ class NormalizeEventWeekdaysLockingTests(
             self.event.weekday,
             weekday_code(self.event.date),
         )
+
+
+@tag('offline_external_api')
+@skipUnless(connection.vendor == 'mysql', 'MySQL trigger is required')
+class NormalizeEventWeekdaysBatchCommitTests(
+    TweetGenerationPatchMixin,
+    TransactionTestCase,
+):
+    """失敗済みバッチを再実行で収束させる公開契約を検証する。"""
+
+    def setUp(self) -> None:
+        community = Community.objects.create(
+            name='曜日バッチ確定テスト集会',
+            frequency='不定期',
+        )
+        start_date = date(2026, 1, 1)
+        Event.objects.bulk_create(
+            [
+                Event(
+                    community=community,
+                    date=start_date + timedelta(days=offset),
+                    start_time=time(21, 0),
+                    weekday='Other',
+                )
+                for offset in range(_KEYSET_TEST_EVENT_COUNT)
+            ]
+        )
+        self.event_pks = list(
+            Event.objects.order_by('pk').values_list('pk', flat=True)
+        )
+
+    def _create_failure_trigger(self) -> None:
+        failed_pk = self.event_pks[-1]
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"""
+                CREATE TRIGGER `{_FAILURE_TRIGGER_NAME}`
+                BEFORE UPDATE ON `event`
+                FOR EACH ROW
+                BEGIN
+                    IF NEW.id = {failed_pk} THEN
+                        SIGNAL SQLSTATE '45000'
+                        SET MESSAGE_TEXT = 'forced batch failure';
+                    END IF;
+                END
+                """
+            )
+
+    def _drop_failure_trigger(self) -> None:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f'DROP TRIGGER IF EXISTS `{_FAILURE_TRIGGER_NAME}`'
+            )
+
+    def test_apply_commits_each_batch_and_retry_converges(self):
+        self._create_failure_trigger()
+        try:
+            with self.assertRaises(DatabaseError):
+                call_command('normalize_event_weekdays', '--apply')
+        finally:
+            self._drop_failure_trigger()
+
+        first_batch = Event.objects.filter(
+            pk__lte=self.event_pks[-2],
+        )
+        for event in first_batch:
+            self.assertEqual(event.weekday, weekday_code(event.date))
+        failed_event = Event.objects.get(pk=self.event_pks[-1])
+        self.assertEqual(failed_event.weekday, 'Other')
+
+        retry = StringIO()
+        call_command(
+            'normalize_event_weekdays',
+            '--apply',
+            stdout=retry,
+        )
+        self.assertIn('changed: 1', retry.getvalue())
+        check = StringIO()
+        call_command(
+            'normalize_event_weekdays',
+            '--check',
+            stdout=check,
+        )
+        self.assertIn('total_mismatches: 0', check.getvalue())

--- a/app/event/views/calendar_create.py
+++ b/app/event/views/calendar_create.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -8,6 +7,7 @@ from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import FormView
 
+from community.constants import weekday_code
 from event.forms import GoogleCalendarEventForm
 from event.models import Event
 
@@ -85,8 +85,6 @@ class GoogleCalendarEventCreateView(LoginRequiredMixin, FormView):
                 messages.error(self.request, f'同じ日時（{start_date} {start_time}）にすでにイベントが登録されています。')
                 return self.form_invalid(form)
 
-            # 開始時刻と終了時刻を設定
-            start_datetime = datetime.combine(start_date, start_time)
             duration = form.cleaned_data['duration']
 
             # 新しいイベントをDBに保存
@@ -96,7 +94,7 @@ class GoogleCalendarEventCreateView(LoginRequiredMixin, FormView):
                     date=start_date,
                     start_time=start_time,
                     duration=duration,
-                    weekday=start_datetime.strftime("%a")
+                    weekday=weekday_code(start_date),
                     # google_calendar_event_idは同期時に設定される
                 )
                 logger.info(f'イベントをDBに登録: ID={new_event.id}, 日付={start_date}, 開始時間={start_time}')

--- a/app/event/views/crud_event.py
+++ b/app/event/views/crud_event.py
@@ -10,6 +10,7 @@ from django.urls import reverse_lazy
 from django.utils import timezone
 from django.views.generic import UpdateView, DeleteView
 
+from community.constants import weekday_code
 from event.forms import EventDateUpdateForm, EventUpdateForm
 from event.models import Event, EventDetail
 from event.services.recurrence_override import (
@@ -61,7 +62,6 @@ class EventDateUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     def get_form_kwargs(self):
         """ModelFormがinstanceを書き換える前の開催日を保持する。"""
         self.original_date = self.object.date
-        self.original_weekday = self.object.weekday
         return super().get_form_kwargs()
 
     def get_context_data(self, **kwargs):
@@ -106,7 +106,7 @@ class EventDateUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     def _restore_original_schedule(self, event: Event) -> None:
         """ModelFormが未保存instanceへ反映した日付を変更前へ戻す。"""
         event.date = self.original_date
-        event.weekday = self.original_weekday
+        event.weekday = weekday_code(self.original_date)
 
     def _get_vket_lock_message(self, event: Event, new_date) -> str:
         """変更前後のどちらかがVketロック対象ならメッセージを返す。"""
@@ -460,4 +460,3 @@ class EventDeleteView(LoginRequiredMixin, DeleteView):
                 )
                 error_count += 1
         return error_count
-

--- a/app/twitter/generators/community.py
+++ b/app/twitter/generators/community.py
@@ -3,6 +3,7 @@
 新しく登録された集会の最初の告知。初回開催日が決まっていれば日程も含める。
 """
 
+from community.constants import weekday_code
 from twitter.generators.common import (
     WEEKDAY_NAMES,
     BODY_LINE_CONSTRAINT,
@@ -21,7 +22,7 @@ def _fallback_new_community_tweet(community, first_event=None) -> str | None:
     hashtag_suffix = _build_hashtag_suffix(community)
 
     if first_event:
-        weekday = WEEKDAY_NAMES.get(first_event.date.strftime("%a"), "")
+        weekday = WEEKDAY_NAMES.get(weekday_code(first_event.date), "")
         schedule = f"{first_event.date.strftime('%-m/%-d')}({weekday}) {first_event.start_time.strftime('%H:%M')}~"
     else:
         schedule = f"{community.frequency} {weekdays_str}曜日 {community.start_time.strftime('%H:%M')}~"
@@ -57,8 +58,9 @@ def generate_new_community_tweet(
 
     event_info = ""
     if first_event:
+        weekday = WEEKDAY_NAMES.get(weekday_code(first_event.date), "")
         event_info = (
-            f"\n初回開催日: {first_event.date.strftime('%-m/%-d')}({WEEKDAY_NAMES.get(first_event.date.strftime('%a'), '')})"
+            f"\n初回開催日: {first_event.date.strftime('%-m/%-d')}({weekday})"
             f" {first_event.start_time.strftime('%H:%M')}~"
         )
 

--- a/app/twitter/generators/lt_tweet.py
+++ b/app/twitter/generators/lt_tweet.py
@@ -4,6 +4,7 @@ LLM 呼び出し本体 (`_call_llm`) は `twitter.tweet_generator` 経由で参�
 これは `@patch("twitter.tweet_generator._call_llm")` を使う既存テストとの後方互換性のため。
 """
 
+from community.constants import weekday_code
 from twitter.generators.common import (
     WEEKDAY_NAMES,
     BODY_LINE_CONSTRAINT,
@@ -18,7 +19,7 @@ from website.constants import build_site_url
 def _fallback_presentation_tweet(event_detail, *, special: bool = False) -> str | None:
     event = event_detail.event
     community = event.community
-    weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
+    weekday = WEEKDAY_NAMES.get(weekday_code(event.date), "")
     label = " 特別回" if special else ""
     speaker_display = _format_speaker_display(event_detail)
     body_lines = [
@@ -48,7 +49,7 @@ def generate_lt_tweet(event_detail, target_chars=140, validation_feedback="") ->
     community = event.community
     hashtag_suffix = _build_hashtag_suffix(community)
     community_url = build_site_url(f"/community/{community.pk}/")
-    weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
+    weekday = WEEKDAY_NAMES.get(weekday_code(event.date), "")
 
     name = _sanitize_for_prompt(community.name)
     speaker_display = _format_speaker_display(event_detail)
@@ -113,7 +114,7 @@ def generate_special_event_tweet(event_detail, target_chars=140, validation_feed
     community = event.community
     hashtag_suffix = _build_hashtag_suffix(community)
     community_url = build_site_url(f"/community/{community.pk}/")
-    weekday = WEEKDAY_NAMES.get(event.date.strftime("%a"), "")
+    weekday = WEEKDAY_NAMES.get(weekday_code(event.date), "")
 
     name = _sanitize_for_prompt(community.name)
     speaker = _sanitize_for_prompt(event_detail.speaker)

--- a/app/twitter/tests/test_auto_tweet.py
+++ b/app/twitter/tests/test_auto_tweet.py
@@ -2349,6 +2349,7 @@ class TweetGeneratorTest(TestCase):
         self.assertIn("ポスト", system_prompt)
         self.assertNotIn("ツイート", system_prompt)
         self.assertIn("Generator Test Community", call_args[0][1])
+        self.assertIn("5/1(金)", user_prompt)
         self.assertIn("告知ポスト", user_prompt)
         self.assertNotIn("告知ツイート", user_prompt)
 
@@ -2377,6 +2378,7 @@ class TweetGeneratorTest(TestCase):
         self.assertNotIn("告知ツイート", system_prompt)
         self.assertIn("テスト太郎", user_prompt)
         self.assertIn("Pythonのテスト技法", user_prompt)
+        self.assertIn("5/1(金)", user_prompt)
         self.assertIn("告知ポスト", user_prompt)
         self.assertNotIn("告知ツイート", user_prompt)
 
@@ -2527,6 +2529,7 @@ class TweetGeneratorTest(TestCase):
         self.assertIn("告知ポスト", system_prompt)
         self.assertNotIn("告知ツイート", system_prompt)
         self.assertIn("ゲスト講師", user_prompt)
+        self.assertIn("5/1(金)", user_prompt)
         self.assertIn("告知ポスト", user_prompt)
         self.assertNotIn("告知ツイート", user_prompt)
 

--- a/app/vket/services.py
+++ b/app/vket/services.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 
+from community.constants import weekday_code
 from event.models import Event, EventDetail
 from vket.models import VketParticipation, VketPresentation
 
@@ -81,10 +82,6 @@ def get_vket_lock_message(event) -> str:
     return message
 
 
-def _weekday_code(date_value) -> str:
-    return ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][date_value.weekday()]
-
-
 def _resolve_publication_event(participation: VketParticipation) -> tuple[Event, bool]:
     existing_event = Event.objects.filter(
         community=participation.community,
@@ -98,7 +95,7 @@ def _resolve_publication_event(participation: VketParticipation) -> tuple[Event,
             participation.save(update_fields=["published_event", "updated_at"])
         return existing_event, changed
 
-    weekday = _weekday_code(participation.confirmed_date)
+    weekday = weekday_code(participation.confirmed_date)
     if participation.published_event_id:
         event = participation.published_event
         changed = (

--- a/app/vket/tests/test_vket.py
+++ b/app/vket/tests/test_vket.py
@@ -1470,6 +1470,10 @@ class VketManageViewsTests(TestCase):
 
         self.event1.refresh_from_db()
         self.assertEqual(self.event1.date, new_date)
+        self.assertEqual(
+            self.event1.weekday,
+            ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][new_date.weekday()],
+        )
         self.assertFalse(
             EventOccurrenceTombstone.objects.filter(
                 community=self.community1,
@@ -3231,6 +3235,10 @@ class VketPublishViewTests(TestCase):
         self.assertEqual(event.community, self.community)
         self.assertEqual(event.start_time.strftime('%H:%M'), '21:00')
         self.assertEqual(event.duration, 60)
+        self.assertEqual(
+            event.weekday,
+            ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][event.date.weekday()],
+        )
 
     def test_publish_skips_declined_participation(self):
         """不参加の参加情報は公開同期の対象外になる"""


### PR DESCRIPTION
## なぜこの変更が必要か

`Event.weekday` がコード経路によって `MON` / `Mon` に揺れ、`strftime('%a')` のlocale依存でchoices外の値も保存され得ました。`Event.date` を正本として全経路を統一し、既存データを安全に検査・補正できるようにします。

## 変更内容

- locale非依存の `weekday_code(date)` を共通化
- calendar、recurrence、定期生成、日付移動、Vket、Twitter表示を統一
- adminのweekdayをreadonlyにし、保存時にdateから導出
- `normalize_event_weekdays --check/--apply` を追加
- PK keyset・最大1000件・batch単位transactionで本番補正を再実行可能にする

## 意思決定

- schema/data migrationは作らず、旧revisionの再汚染を避けるため100%切替後に管理コマンドを適用します。
- 途中失敗時は確定済みbatchを保持し、冪等な再実行と最終 `--check` 0件を完了ゲートにします。
- Event上の空値・`Other`・正しいchoices内だがdateと異なる値もdate由来へ補正します。Communityの`weekdays`は対象外です。

## Failure mode

| DB操作 | 失敗時 | 復旧・担保 |
|---|---|---|
| `--check` | 書込なし、不整合があれば非0終了 | 分類件数を確認 |
| `--apply` のbatch | 当該batchだけrollback、前batchは確定 | 再実行後 `--check` 0件 |
| 同時更新 | 行ロック解放後のdateから曜日を算出 | MySQL別接続競合テスト |

## テスト

- [x] community/event/vket/twitter offline: 1293件成功、1件skip
- [x] Docker MySQL関連: 23件成功、1件skip
- [x] SQLite command tests: 9件成功、2件skip
- [x] 1001件keyset境界
- [x] MySQL別接続ロック競合
- [x] 2batch目失敗→再実行→check 0
- [x] Ruff / mypy / makemigrations check / file-size-guard
- [x] code/security/architecture review loop完了

## 本番適用

本PRのマージだけではデータを書き換えません。全Issueの最終revisionへ100%切替後、backupと明示承認を経て `--apply` し、`--check` 0件を確認します。

Refs #543
Refs #554

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many event write paths and a production data-migration command that bulk-updates events and clears index cache; behavior is well-tested but rollout still depends on running `--apply` after deploy.
> 
> **Overview**
> **`Event.weekday` is now always derived from `Event.date`** using a shared, locale-independent `weekday_code()` in `community.constants`, replacing `strftime('%a')` and mixed `MON`/`Mon` spellings across write paths.
> 
> **Write paths updated** include calendar create, recurrence persistence and generation, occurrence moves, Vket publication sync, Twitter prompt/fallback text, Django admin (weekday readonly, set on save), and recurring-event reset when master dates are pushed to the past.
> 
> **New management command `normalize_event_weekdays`** supports `--check` (classify mismatches, exit non-zero if any) and `--apply` (PK keyset batches of up to 1000, row locks, bulk update, index cache clear on completion or failure). Existing rows with wrong casing, Japanese labels, empty/`Other` vs date, etc. are corrected to match the event date; **Community.weekdays is unchanged**.
> 
> **Tests** cover `weekday_code`, each writer boundary, command classification/idempotency/cache/locking/batch-retry, and failure ordering when DB and cache clear both fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a079c8a56b033c10e6ca6c49852fff9072349cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->