### PR TITLE
refactor(twitter): サービス公開関数の命名を整理する

### DIFF
--- a/app/twitter/services/daily_reminder.py
+++ b/app/twitter/services/daily_reminder.py
@@ -18,7 +18,8 @@ SAME_DAY_INDIVIDUAL_SKIP_REASON = '当日リマインドに統合したため個
 NO_APPROVED_PRESENTATIONS_SKIP_REASON = '承認済みの当日発表がないため投稿対象外'
 
 
-def _is_active_presentation(detail_type, event_date) -> bool:
+def is_active_presentation(detail_type, event_date) -> bool:
+    """発表が当日リマインドの同期対象か判定する。"""
     return detail_type in PRESENTATION_DETAIL_TYPES and event_date >= timezone.localdate()
 
 
@@ -39,19 +40,20 @@ def _should_refresh_daily_reminder(instance, created: bool) -> bool:
 def _iter_event_ids_to_sync(instance):
     event_ids = set()
 
-    if _is_active_presentation(instance.detail_type, instance.event.date):
+    if is_active_presentation(instance.detail_type, instance.event.date):
         event_ids.add(instance.event_id)
 
     old_detail_type = getattr(instance, "_old_detail_type", None)
     old_event_id = getattr(instance, "_old_event_id", None)
     old_event_date = getattr(instance, "_old_event_date", None)
-    if old_event_id and _is_active_presentation(old_detail_type, old_event_date):
+    if old_event_id and is_active_presentation(old_detail_type, old_event_date):
         event_ids.add(old_event_id)
 
     return sorted(event_ids)
 
 
-def _ensure_same_day_individual_queue_skipped(instance, tweet_type: str) -> None:
+def ensure_same_day_individual_queue_skipped(instance, tweet_type: str) -> None:
+    """同日開催の個別告知キューをスキップ状態に揃える。"""
     from twitter.models import TweetQueue
 
     existing_qs = TweetQueue.objects.filter(
@@ -104,7 +106,8 @@ def _ensure_same_day_individual_queue_skipped(instance, tweet_type: str) -> None
     existing_qs.exclude(pk=primary.pk).exclude(status='posted').delete()
 
 
-def _sync_daily_reminder_for_event(event_id: int) -> None:
+def sync_daily_reminder_for_event(event_id: int) -> None:
+    """指定イベントの当日リマインドキューを同期する。"""
     from event.models import Event
     from twitter.models import TweetQueue
 
@@ -154,13 +157,14 @@ def _sync_daily_reminder_for_event(event_id: int) -> None:
         queue.generated_text = ''
         queue.save(update_fields=['community', 'scheduled_at', 'status', 'error_message', 'generated_text'])
 
-    tweet_generation._start_tweet_generation(queue)
+    tweet_generation.start_tweet_generation(queue)
     logger.info("Synced daily reminder tweet for event %d", event.pk)
 
 
-def _sync_daily_reminders_for_instance(instance, created: bool) -> None:
+def sync_daily_reminders_for_instance(instance, created: bool) -> None:
+    """EventDetail の変更に応じて当日リマインドを同期する。"""
     if not _should_refresh_daily_reminder(instance, created):
         return
 
     for event_id in _iter_event_ids_to_sync(instance):
-        _sync_daily_reminder_for_event(event_id)
+        sync_daily_reminder_for_event(event_id)

--- a/app/twitter/services/daily_reminder.py
+++ b/app/twitter/services/daily_reminder.py
@@ -19,7 +19,7 @@ NO_APPROVED_PRESENTATIONS_SKIP_REASON = '承認済みの当日発表がないた
 
 
 def is_active_presentation(detail_type, event_date) -> bool:
-    """発表が当日リマインドの同期対象か判定する。"""
+    """発表種別が LT/SPECIAL かつ開催日が今日以降か判定する。"""
     return detail_type in PRESENTATION_DETAIL_TYPES and event_date >= timezone.localdate()
 
 
@@ -162,7 +162,7 @@ def sync_daily_reminder_for_event(event_id: int) -> None:
 
 
 def sync_daily_reminders_for_instance(instance, created: bool) -> None:
-    """EventDetail の変更に応じて当日リマインドを同期する。"""
+    """pre_save で _old_* 旧値を記録済みの EventDetail に対し、当日リマインドを同期する。"""
     if not _should_refresh_daily_reminder(instance, created):
         return
 

--- a/app/twitter/services/tweet_generation.py
+++ b/app/twitter/services/tweet_generation.py
@@ -129,7 +129,7 @@ def _generate_tweet_async(queue_id: int, generation_token: str = "") -> None:
         connections.close_all()
 
 
-def _start_tweet_generation(queue_item) -> None:
+def start_tweet_generation(queue_item) -> None:
     """TweetQueue の本文生成をバックグラウンドで開始する。"""
     generation_token = uuid.uuid4().hex
     queue_item.generation_token = generation_token

--- a/app/twitter/signals.py
+++ b/app/twitter/signals.py
@@ -14,10 +14,10 @@ from event.models import EventDetail
 from twitter.scheduling import default_scheduled_at
 from twitter.services.daily_reminder import (
     PRESENTATION_DETAIL_TYPES,
-    _ensure_same_day_individual_queue_skipped,
-    _is_active_presentation,
-    _sync_daily_reminder_for_event,
-    _sync_daily_reminders_for_instance,
+    ensure_same_day_individual_queue_skipped,
+    is_active_presentation,
+    sync_daily_reminder_for_event,
+    sync_daily_reminders_for_instance,
 )
 from twitter.services import tweet_generation
 from twitter.services.tweet_generation import sync_slide_share_queue_image
@@ -106,7 +106,7 @@ def _queue_new_community_tweet(instance, created):
     )
     logger.info("Queued new community tweet: %s", instance.name)
 
-    tweet_generation._start_tweet_generation(queue_item)
+    tweet_generation.start_tweet_generation(queue_item)
 
 
 @receiver(post_save, sender=EventDetail)
@@ -173,7 +173,7 @@ def _queue_slide_share_tweet(instance, created):
         "Queued slide share tweet: %s - %s", instance.speaker, instance.theme,
     )
 
-    tweet_generation._start_tweet_generation(queue_item)
+    tweet_generation.start_tweet_generation(queue_item)
 
 
 @receiver(post_save, sender=EventDetail)
@@ -189,23 +189,23 @@ def _queue_event_detail_tweet(instance, created):
     from twitter.models import TweetQueue
 
     if instance.detail_type not in PRESENTATION_DETAIL_TYPES:
-        _sync_daily_reminders_for_instance(instance, created)
+        sync_daily_reminders_for_instance(instance, created)
         return
 
     if instance.status != "approved":
-        _sync_daily_reminders_for_instance(instance, created)
+        sync_daily_reminders_for_instance(instance, created)
         return
 
     if instance.event.date < timezone.localdate():
-        _sync_daily_reminders_for_instance(instance, created)
+        sync_daily_reminders_for_instance(instance, created)
         return
 
     old_status = getattr(instance, "_old_status", None)
     tweet_type = "lt" if instance.detail_type == "LT" else "special"
 
     if instance.event.date == timezone.localdate():
-        _ensure_same_day_individual_queue_skipped(instance, tweet_type)
-        _sync_daily_reminders_for_instance(instance, created)
+        ensure_same_day_individual_queue_skipped(instance, tweet_type)
+        sync_daily_reminders_for_instance(instance, created)
         return
 
     if not created and old_status == "approved":
@@ -215,7 +215,7 @@ def _queue_event_detail_tweet(instance, created):
         new_theme = instance.theme or ""
 
         if old_speaker == new_speaker and old_theme == new_theme:
-            _sync_daily_reminders_for_instance(instance, created)
+            sync_daily_reminders_for_instance(instance, created)
             return
 
         deleted, _ = TweetQueue.objects.filter(
@@ -228,7 +228,7 @@ def _queue_event_detail_tweet(instance, created):
 
     else:
         if TweetQueue.objects.filter(event_detail=instance, tweet_type=tweet_type).exists():
-            _sync_daily_reminders_for_instance(instance, created)
+            sync_daily_reminders_for_instance(instance, created)
             return
 
     queue_item = TweetQueue.objects.create(
@@ -240,16 +240,16 @@ def _queue_event_detail_tweet(instance, created):
     )
     logger.info("Queued %s tweet: %s - %s", tweet_type, instance.speaker, instance.theme)
 
-    _sync_daily_reminders_for_instance(instance, created)
+    sync_daily_reminders_for_instance(instance, created)
 
-    tweet_generation._start_tweet_generation(queue_item)
+    tweet_generation.start_tweet_generation(queue_item)
 
 
 @receiver(post_delete, sender=EventDetail)
 def sync_daily_reminder_on_event_detail_delete(sender, instance, **kwargs):
     """当日発表の削除後に daily_reminder を同期する。"""
     try:
-        if _is_active_presentation(instance.detail_type, instance.event.date):
-            _sync_daily_reminder_for_event(instance.event_id)
+        if is_active_presentation(instance.detail_type, instance.event.date):
+            sync_daily_reminder_for_event(instance.event_id)
     except Exception:
         logger.exception("Failed to sync daily reminder after EventDetail delete %s", instance.pk)

--- a/app/twitter/tests/test_generation_guard.py
+++ b/app/twitter/tests/test_generation_guard.py
@@ -35,7 +35,7 @@ class TweetGenerationThreadGuardTest(TestCase):
         from twitter.services import tweet_generation
 
         with patch.object(tweet_generation.sys, "argv", ["manage.py", "test"]):
-            tweet_generation._start_tweet_generation(queue)
+            tweet_generation.start_tweet_generation(queue)
 
         queue.refresh_from_db()
         self.assertTrue(queue.generation_token)

--- a/app/twitter/tests/test_signal_community.py
+++ b/app/twitter/tests/test_signal_community.py
@@ -33,6 +33,15 @@ class CommunityApprovalSignalTest(AutoTweetTestBase):
         mock_thread_cls.assert_called_once()
         mock_thread.start.assert_called_once()
 
+    @patch("twitter.services.tweet_generation.start_tweet_generation")
+    def test_definition_patch_reaches_signal_handler(self, mock_start):
+        """定義元の生成開始 patch が signals の呼び出しへ届く。"""
+        self.community.status = "approved"
+        self.community.save()
+
+        queue = TweetQueue.objects.get(tweet_type="new_community")
+        mock_start.assert_called_once_with(queue)
+
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_duplicate_community_queue_prevention(self, mock_thread_cls):
         """同一 community の重複キューは作成されない"""

--- a/app/twitter/tests/test_signal_event_detail.py
+++ b/app/twitter/tests/test_signal_event_detail.py
@@ -355,6 +355,27 @@ class EventDetailSignalTest(AutoTweetTestBase):
         self.assertEqual(mock_thread_cls.call_args.kwargs["args"], (reminder_queue.pk, reminder_queue.generation_token))
         mock_thread_cls.return_value.start.assert_called_once()
 
+    @patch("twitter.services.tweet_generation.start_tweet_generation")
+    def test_definition_patch_reaches_daily_reminder_sync(self, mock_start):
+        """定義元の生成開始 patch が daily_reminder の呼び出しへ届く。"""
+        today_event = Event.objects.create(
+            community=self.community,
+            date=timezone.localdate(),
+            start_time=datetime.time(22, 0),
+            duration=60,
+        )
+        EventDetail.objects.create(
+            event=today_event,
+            detail_type="LT",
+            status="approved",
+            speaker="テスト太郎",
+            theme="当日のLT",
+            start_time=datetime.time(22, 15),
+        )
+
+        reminder_queue = TweetQueue.objects.get(tweet_type="daily_reminder", event=today_event)
+        mock_start.assert_called_once_with(reminder_queue)
+
     @patch("twitter.services.tweet_generation.threading.Thread")
     def test_today_event_theme_change_regenerates_same_daily_reminder_queue(self, mock_thread_cls):
         """当日の LT 内容変更では same-day daily_reminder を同じキューIDのまま非同期再生成する"""

--- a/docs/research/issue-354-tweet-generation-test-threads.md
+++ b/docs/research/issue-354-tweet-generation-test-threads.md
@@ -3,13 +3,13 @@
 ## 概要
 
 `Community(status="approved")` や承認済み `EventDetail` の保存で `TweetQueue` が作成されると、
-`twitter.services.tweet_generation._start_tweet_generation()` が本文生成用のバックグラウンドスレッドを起動していた。
+`twitter.services.tweet_generation.start_tweet_generation()` が本文生成用のバックグラウンドスレッドを起動していた。
 SQLite テスト DB ではこの別スレッドが同じテーブルへアクセスし、`database table is locked` の
 ランダムなログを出す原因になり得る。
 
 ## 観測結果
 
-- `app/twitter/services/tweet_generation.py` の `_start_tweet_generation()` は、
+- `app/twitter/services/tweet_generation.py` の `start_tweet_generation()` は、
   `threading.Thread.start()` で非同期生成を開始する。
 - `app/website/settings/base.py` は `TESTING` または `sys.argv` の `test` で SQLite テスト DB へ切り替える。
   `TESTING` 変数自体は環境変数由来のため、保護対象の設定ファイルは変更せず、
@@ -28,7 +28,7 @@ SQLite テスト DB ではこの別スレッドが同じテーブルへアクセ
 
 ## 改善案と採用方針
 
-`_start_tweet_generation()` で `generation_token` の保存までは従来通り行い、
+`start_tweet_generation()` で `generation_token` の保存までは従来通り行い、
 global な `_should_skip_tweet_generation_thread()` により、`settings.TESTING=True` または
 `manage.py test` 実行時だけスレッド起動前に返すようにした。
 


### PR DESCRIPTION
## 概要

Issue #557 のとおり、別moduleから利用される5つのservice関数を公開名へ変更しました。互換aliasは残していません。

## 変更

- `_start_tweet_generation` → `start_tweet_generation`
- `_is_active_presentation` → `is_active_presentation`
- `_ensure_same_day_individual_queue_skipped` → `ensure_same_day_individual_queue_skipped`
- `_sync_daily_reminder_for_event` → `sync_daily_reminder_for_event`
- `_sync_daily_reminders_for_instance` → `sync_daily_reminders_for_instance`
- module-reference経由の生成開始呼出しと定義元patch境界を維持
- 公開API docstringへ実判定条件・pre_save前提を明記
- test-only/internal private関数8件は変更なし

## 検証

- 旧5名のrepo参照0
- production cross-module private import 0
- offline関連342件成功
- patch境界回帰3件成功
- Ruff全app / mypy変更3module / makemigrations / file-size / diff-check成功
- code / architecture / security review: blockerなし
- docs-sync: 旧名0、index/link乖離0

## 影響

内部Python APIのrenameのみ。URL・認証・DB schema・外部送信挙動に変更なし。

Refs #557