### PR TITLE
test: factory利用と重複テストを整理する

### DIFF
--- a/app/tests/_factory_usage_guard.py
+++ b/app/tests/_factory_usage_guard.py
@@ -126,6 +126,21 @@ class _FunctionLocalCollector(ast.NodeVisitor):
     def visit_ClassDef(self, node: ast.ClassDef):
         self.names.add(node.name)
 
+    def visit_MatchAs(self, node: ast.MatchAs):
+        if node.name:
+            self.names.add(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchStar(self, node: ast.MatchStar):
+        if node.name:
+            self.names.add(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchMapping(self, node: ast.MatchMapping):
+        if node.rest:
+            self.names.add(node.rest)
+        self.generic_visit(node)
+
     def visit_Lambda(self, node: ast.Lambda):
         return
 

--- a/app/tests/_factory_usage_guard.py
+++ b/app/tests/_factory_usage_guard.py
@@ -1,0 +1,438 @@
+"""core model fixtureの直接生成をimport解決して集計する。"""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from pathlib import Path
+from typing import Iterator, TypeAlias
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+APP_ROOT = REPOSITORY_ROOT / 'app'
+FACTORY_MODULE_PATH = Path('app/tests/factories.py')
+GENERATED_PATH_PARTS = frozenset({
+    '__pycache__',
+    '.mypy_cache',
+    '.pytest_cache',
+    '.ruff_cache',
+    'migrations',
+})
+CORE_MODEL_PATHS = {
+    ('community', 'models', 'Community'): 'Community',
+    ('event', 'models', 'Event'): 'Event',
+    ('event', 'models', 'EventDetail'): 'EventDetail',
+    ('user_account', 'models', 'CustomUser'): 'CustomUser',
+    ('django', 'contrib', 'auth', 'models', 'User'): 'User',
+}
+GET_USER_MODEL_PATH = ('django', 'contrib', 'auth', 'get_user_model')
+DIRECT_MANAGER_METHODS = frozenset({'create', 'create_user'})
+
+Symbol: TypeAlias = tuple[str, str | tuple[str, ...]] | None
+Scope: TypeAlias = tuple[str, dict[str, Symbol]]
+
+
+def _is_test_source(path: Path, repository_root: Path) -> bool:
+    relative_path = path.relative_to(repository_root)
+    if relative_path == FACTORY_MODULE_PATH:
+        return False
+    if GENERATED_PATH_PARTS.intersection(relative_path.parts):
+        return False
+    return 'tests' in relative_path.parts or path.name == 'tests.py' or path.name.startswith('test_')
+
+
+def _iter_test_sources(app_root: Path, repository_root: Path) -> Iterator[Path]:
+    """factory本体と生成物を除くrepo内Pythonテストソースを返す。"""
+    return (path for path in app_root.rglob('*.py') if _is_test_source(path, repository_root))
+
+
+def _attribute_parts(node: ast.AST) -> tuple[str, ...] | None:
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return tuple(reversed(parts))
+
+
+def _target_names(node: ast.AST) -> set[str]:
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return {name for element in node.elts for name in _target_names(element)}
+    return set()
+
+
+def _argument_names(arguments: ast.arguments) -> set[str]:
+    names = {
+        argument.arg
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        )
+    }
+    if arguments.vararg:
+        names.add(arguments.vararg.arg)
+    if arguments.kwarg:
+        names.add(arguments.kwarg.arg)
+    return names
+
+
+class _FunctionLocalCollector(ast.NodeVisitor):
+    """関数全体でローカル束縛される名前を収集する。"""
+
+    def __init__(self, node: ast.FunctionDef | ast.AsyncFunctionDef):
+        self.names = _argument_names(node.args)
+        self.global_names: set[str] = set()
+
+        for statement in node.body:
+            self.visit(statement)
+        self.names.difference_update(self.global_names)
+
+    def visit_Global(self, node: ast.Global):
+        self.global_names.update(node.names)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal):
+        self.global_names.update(node.names)
+
+    def visit_Name(self, node: ast.Name):
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.names.add(node.id)
+
+    def visit_Import(self, node: ast.Import):
+        for imported in node.names:
+            self.names.add(imported.asname or imported.name.split('.')[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        for imported in node.names:
+            if imported.name != '*':
+                self.names.add(imported.asname or imported.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        self.names.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+        self.names.add(node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef):
+        self.names.add(node.name)
+
+    def visit_Lambda(self, node: ast.Lambda):
+        return
+
+    def visit_ListComp(self, node: ast.ListComp):
+        return
+
+    def visit_SetComp(self, node: ast.SetComp):
+        return
+
+    def visit_DictComp(self, node: ast.DictComp):
+        return
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp):
+        return
+
+
+class _CoreCreateVisitor(ast.NodeVisitor):
+    """import解決済みのcore model manager callを収集する。"""
+
+    def __init__(self, model_paths: dict[tuple[str, ...], str] | None = None):
+        self.identities: list[tuple[str, str]] = []
+        self.scopes: list[Scope] = [('module', {})]
+        self.model_paths = model_paths or CORE_MODEL_PATHS
+        self.model_modules = frozenset(path[:-1] for path in self.model_paths)
+
+    def _lookup(self, name: str) -> Symbol:
+        crossed_function = False
+        for scope_kind, bindings in reversed(self.scopes):
+            if scope_kind == 'function':
+                crossed_function = True
+            if scope_kind == 'class' and crossed_function:
+                continue
+            if name in bindings:
+                return bindings[name]
+        return None
+
+    def _bind(self, name: str, symbol: Symbol):
+        self.scopes[-1][1][name] = symbol
+
+    def _resolve_qualified_path(self, node: ast.AST) -> tuple[str, ...] | None:
+        parts = _attribute_parts(node)
+        if not parts:
+            return None
+        symbol = self._lookup(parts[0])
+        if symbol is None or symbol[0] != 'module':
+            return None
+        return (*symbol[1], *parts[1:])
+
+    def _resolve_model(self, node: ast.AST) -> str | None:
+        if isinstance(node, ast.Name):
+            symbol = self._lookup(node.id)
+            if symbol is not None and symbol[0] == 'model':
+                return str(symbol[1])
+            return None
+        qualified_path = self._resolve_qualified_path(node)
+        if qualified_path is None:
+            return None
+        return self.model_paths.get(qualified_path)
+
+    def _is_get_user_model_call(self, node: ast.AST) -> bool:
+        if not isinstance(node, ast.Call):
+            return False
+        if isinstance(node.func, ast.Name):
+            symbol = self._lookup(node.func.id)
+            return symbol is not None and symbol[0] == 'get_user_model'
+        return self._resolve_qualified_path(node.func) == GET_USER_MODEL_PATH
+
+    def _assignment_symbol(self, target_name: str, value: ast.AST) -> Symbol:
+        if self._is_get_user_model_call(value):
+            model_name = target_name if target_name in {'CustomUser', 'User'} else 'User'
+            return 'model', model_name
+        resolved_model = self._resolve_model(value)
+        if resolved_model is not None:
+            return 'model', resolved_model
+        return None
+
+    def _bind_target(self, target: ast.AST, symbol: Symbol = None):
+        target_names = _target_names(target)
+        for target_name in target_names:
+            self._bind(target_name, symbol if len(target_names) == 1 else None)
+
+    def _symbol_for_path(self, path: tuple[str, ...]) -> Symbol:
+        if path in self.model_paths:
+            return 'model', self.model_paths[path]
+        if path == GET_USER_MODEL_PATH:
+            return 'get_user_model', 'get_user_model'
+        if path in self.model_modules or any(
+            model_path[:len(path)] == path for model_path in self.model_paths
+        ) or GET_USER_MODEL_PATH[:len(path)] == path:
+            return 'module', path
+        return None
+
+    def visit_Import(self, node: ast.Import):
+        for imported in node.names:
+            full_path = tuple(imported.name.split('.'))
+            if imported.asname:
+                self._bind(imported.asname, self._symbol_for_path(full_path))
+            else:
+                self._bind(full_path[0], self._symbol_for_path((full_path[0],)))
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        if node.level:
+            for imported in node.names:
+                if imported.name != '*':
+                    self._bind(imported.asname or imported.name, None)
+            return
+        module_path = tuple((node.module or '').split('.'))
+        for imported in node.names:
+            if imported.name == '*':
+                continue
+            self._bind(
+                imported.asname or imported.name,
+                self._symbol_for_path((*module_path, imported.name)),
+            )
+
+    def visit_Assign(self, node: ast.Assign):
+        self.visit(node.value)
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                self._bind(target.id, self._assignment_symbol(target.id, node.value))
+            else:
+                self._bind_target(target)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign):
+        if node.value is not None:
+            self.visit(node.value)
+        if isinstance(node.target, ast.Name) and node.value is not None:
+            self._bind(node.target.id, self._assignment_symbol(node.target.id, node.value))
+        else:
+            self._bind_target(node.target)
+
+    def visit_AugAssign(self, node: ast.AugAssign):
+        self.visit(node.value)
+        self._bind_target(node.target)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr):
+        self.visit(node.value)
+        if isinstance(node.target, ast.Name):
+            self._bind(node.target.id, self._assignment_symbol(node.target.id, node.value))
+        else:
+            self._bind_target(node.target)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef):
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+        if node.returns is not None:
+            self.visit(node.returns)
+        self._bind(node.name, None)
+
+        local_names = _FunctionLocalCollector(node).names
+        self.scopes.append(('function', dict.fromkeys(local_names)))
+        for statement in node.body:
+            self.visit(statement)
+        self.scopes.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+        self._visit_function(node)
+
+    def visit_Lambda(self, node: ast.Lambda):
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+        self.scopes.append(('function', dict.fromkeys(_argument_names(node.args))))
+        self.visit(node.body)
+        self.scopes.pop()
+
+    def visit_ClassDef(self, node: ast.ClassDef):
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+        self._bind(node.name, None)
+
+        self.scopes.append(('class', {}))
+        for statement in node.body:
+            self.visit(statement)
+        self.scopes.pop()
+
+    def visit_For(self, node: ast.For | ast.AsyncFor):
+        self.visit(node.iter)
+        self._bind_target(node.target)
+        for statement in (*node.body, *node.orelse):
+            self.visit(statement)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor):
+        self.visit_For(node)
+
+    def visit_With(self, node: ast.With | ast.AsyncWith):
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self._bind_target(item.optional_vars)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith):
+        self.visit_With(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler):
+        if node.type is not None:
+            self.visit(node.type)
+        if node.name:
+            self._bind(node.name, None)
+        for statement in node.body:
+            self.visit(statement)
+
+    def _visit_comprehension(
+        self,
+        generators: list[ast.comprehension],
+        result_nodes: tuple[ast.AST, ...],
+    ):
+        first_generator, *remaining_generators = generators
+        self.visit(first_generator.iter)
+        self.scopes.append(('function', {}))
+        self._bind_target(first_generator.target)
+        for condition in first_generator.ifs:
+            self.visit(condition)
+
+        for generator in remaining_generators:
+            self.visit(generator.iter)
+            self._bind_target(generator.target)
+            for condition in generator.ifs:
+                self.visit(condition)
+        for result_node in result_nodes:
+            self.visit(result_node)
+        self.scopes.pop()
+
+    def visit_ListComp(self, node: ast.ListComp):
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_SetComp(self, node: ast.SetComp):
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_DictComp(self, node: ast.DictComp):
+        self._visit_comprehension(node.generators, (node.key, node.value))
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp):
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_Call(self, node: ast.Call):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in DIRECT_MANAGER_METHODS:
+            manager = node.func.value
+            if isinstance(manager, ast.Attribute) and manager.attr == 'objects':
+                model_name = self._resolve_model(manager.value)
+                if model_name is not None:
+                    self.identities.append((model_name, node.func.attr))
+        self.generic_visit(node)
+
+
+def find_direct_core_creates(
+    tree: ast.AST,
+    model_paths: dict[tuple[str, ...], str] | None = None,
+) -> list[tuple[str, str]]:
+    """ASTからimport解決できるcore model直接生成を返す。"""
+    visitor = _CoreCreateVisitor(model_paths)
+    visitor.visit(tree)
+    return visitor.identities
+
+
+def _module_path(path: Path, app_root: Path) -> tuple[str, ...]:
+    relative_path = path.relative_to(app_root).with_suffix('')
+    parts = relative_path.parts
+    return parts[:-1] if parts[-1] == '__init__' else parts
+
+
+def _discover_project_model_paths(
+    app_root: Path,
+    repository_root: Path,
+) -> dict[tuple[str, ...], str]:
+    """プロジェクト内moduleが再公開するcore model aliasを解決する。"""
+    parsed_modules = {
+        _module_path(path, app_root): ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for path in app_root.rglob('*.py')
+        if not GENERATED_PATH_PARTS.intersection(path.relative_to(repository_root).parts)
+    }
+    model_paths = dict(CORE_MODEL_PATHS)
+
+    changed = True
+    while changed:
+        changed = False
+        for module_path, tree in parsed_modules.items():
+            visitor = _CoreCreateVisitor(model_paths)
+            visitor.visit(tree)
+            for exported_name, symbol in visitor.scopes[0][1].items():
+                if symbol is None or symbol[0] != 'model':
+                    continue
+                exported_path = (*module_path, exported_name)
+                model_name = str(symbol[1])
+                if model_paths.get(exported_path) == model_name:
+                    continue
+                model_paths[exported_path] = model_name
+                changed = True
+    return model_paths
+
+
+def count_direct_core_creates(
+    repository_root: Path = REPOSITORY_ROOT,
+    app_root: Path = APP_ROOT,
+) -> Counter[str]:
+    """repo内テストのcore model直接生成をモデル別に集計する。"""
+    counts: Counter[str] = Counter()
+    model_paths = _discover_project_model_paths(app_root, repository_root)
+    for path in _iter_test_sources(app_root, repository_root):
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for model_name, _manager_method in find_direct_core_creates(tree, model_paths):
+            counts[model_name] += 1
+    return counts

--- a/app/tests/_factory_usage_guard.py
+++ b/app/tests/_factory_usage_guard.py
@@ -1,4 +1,8 @@
-"""core model fixtureの直接生成をimport解決して集計する。"""
+"""各test fileの明示importからcore model直接生成を集計する。
+
+canonical modelのdirect/aliased ImportFrom、module import、相対import、
+get_user_model aliasを解決する。プロジェクト内moduleからのre-exportは対象外。
+"""
 
 from __future__ import annotations
 
@@ -25,6 +29,7 @@ CORE_MODEL_PATHS = {
     ('user_account', 'models', 'CustomUser'): 'CustomUser',
     ('django', 'contrib', 'auth', 'models', 'User'): 'User',
 }
+CORE_MODEL_MODULES = frozenset(path[:-1] for path in CORE_MODEL_PATHS)
 GET_USER_MODEL_PATH = ('django', 'contrib', 'auth', 'get_user_model')
 DIRECT_MANAGER_METHODS = frozenset({'create', 'create_user'})
 
@@ -32,8 +37,8 @@ Symbol: TypeAlias = tuple[str, str | tuple[str, ...]] | None
 Scope: TypeAlias = tuple[str, dict[str, Symbol]]
 
 
-def _is_test_source(path: Path, repository_root: Path) -> bool:
-    relative_path = path.relative_to(repository_root)
+def _is_test_source(path: Path) -> bool:
+    relative_path = path.relative_to(REPOSITORY_ROOT)
     if relative_path == FACTORY_MODULE_PATH:
         return False
     if GENERATED_PATH_PARTS.intersection(relative_path.parts):
@@ -41,9 +46,9 @@ def _is_test_source(path: Path, repository_root: Path) -> bool:
     return 'tests' in relative_path.parts or path.name == 'tests.py' or path.name.startswith('test_')
 
 
-def _iter_test_sources(app_root: Path, repository_root: Path) -> Iterator[Path]:
+def _iter_test_sources() -> Iterator[Path]:
     """factory本体と生成物を除くrepo内Pythonテストソースを返す。"""
-    return (path for path in app_root.rglob('*.py') if _is_test_source(path, repository_root))
+    return (path for path in APP_ROOT.rglob('*.py') if _is_test_source(path))
 
 
 def _attribute_parts(node: ast.AST) -> tuple[str, ...] | None:
@@ -140,11 +145,10 @@ class _FunctionLocalCollector(ast.NodeVisitor):
 class _CoreCreateVisitor(ast.NodeVisitor):
     """import解決済みのcore model manager callを収集する。"""
 
-    def __init__(self, model_paths: dict[tuple[str, ...], str] | None = None):
+    def __init__(self, package_path: tuple[str, ...] = ()):
         self.identities: list[tuple[str, str]] = []
         self.scopes: list[Scope] = [('module', {})]
-        self.model_paths = model_paths or CORE_MODEL_PATHS
-        self.model_modules = frozenset(path[:-1] for path in self.model_paths)
+        self.package_path = package_path
 
     def _lookup(self, name: str) -> Symbol:
         crossed_function = False
@@ -178,7 +182,7 @@ class _CoreCreateVisitor(ast.NodeVisitor):
         qualified_path = self._resolve_qualified_path(node)
         if qualified_path is None:
             return None
-        return self.model_paths.get(qualified_path)
+        return CORE_MODEL_PATHS.get(qualified_path)
 
     def _is_get_user_model_call(self, node: ast.AST) -> bool:
         if not isinstance(node, ast.Call):
@@ -203,15 +207,30 @@ class _CoreCreateVisitor(ast.NodeVisitor):
             self._bind(target_name, symbol if len(target_names) == 1 else None)
 
     def _symbol_for_path(self, path: tuple[str, ...]) -> Symbol:
-        if path in self.model_paths:
-            return 'model', self.model_paths[path]
+        if path in CORE_MODEL_PATHS:
+            return 'model', CORE_MODEL_PATHS[path]
         if path == GET_USER_MODEL_PATH:
             return 'get_user_model', 'get_user_model'
-        if path in self.model_modules or any(
-            model_path[:len(path)] == path for model_path in self.model_paths
+        if path in CORE_MODEL_MODULES or any(
+            model_path[:len(path)] == path for model_path in CORE_MODEL_PATHS
         ) or GET_USER_MODEL_PATH[:len(path)] == path:
             return 'module', path
         return None
+
+    def _import_from_module_path(self, node: ast.ImportFrom) -> tuple[str, ...] | None:
+        module_parts = tuple((node.module or '').split('.')) if node.module else ()
+        if not node.level:
+            return module_parts
+
+        levels_up = node.level - 1
+        if levels_up > len(self.package_path):
+            return None
+        base_path = (
+            self.package_path[:len(self.package_path) - levels_up]
+            if levels_up
+            else self.package_path
+        )
+        return (*base_path, *module_parts)
 
     def visit_Import(self, node: ast.Import):
         for imported in node.names:
@@ -222,12 +241,12 @@ class _CoreCreateVisitor(ast.NodeVisitor):
                 self._bind(full_path[0], self._symbol_for_path((full_path[0],)))
 
     def visit_ImportFrom(self, node: ast.ImportFrom):
-        if node.level:
+        module_path = self._import_from_module_path(node)
+        if module_path is None:
             for imported in node.names:
                 if imported.name != '*':
                     self._bind(imported.asname or imported.name, None)
             return
-        module_path = tuple((node.module or '').split('.'))
         for imported in node.names:
             if imported.name == '*':
                 continue
@@ -380,59 +399,27 @@ class _CoreCreateVisitor(ast.NodeVisitor):
 
 def find_direct_core_creates(
     tree: ast.AST,
-    model_paths: dict[tuple[str, ...], str] | None = None,
+    package_path: tuple[str, ...] = (),
 ) -> list[tuple[str, str]]:
-    """ASTからimport解決できるcore model直接生成を返す。"""
-    visitor = _CoreCreateVisitor(model_paths)
+    """ASTから明示importで解決できるcore model直接生成を返す。"""
+    visitor = _CoreCreateVisitor(package_path)
     visitor.visit(tree)
     return visitor.identities
 
 
-def _module_path(path: Path, app_root: Path) -> tuple[str, ...]:
-    relative_path = path.relative_to(app_root).with_suffix('')
-    parts = relative_path.parts
-    return parts[:-1] if parts[-1] == '__init__' else parts
+def _package_path(path: Path) -> tuple[str, ...]:
+    relative_path = path.relative_to(APP_ROOT).with_suffix('')
+    return relative_path.parts[:-1]
 
 
-def _discover_project_model_paths(
-    app_root: Path,
-    repository_root: Path,
-) -> dict[tuple[str, ...], str]:
-    """プロジェクト内moduleが再公開するcore model aliasを解決する。"""
-    parsed_modules = {
-        _module_path(path, app_root): ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
-        for path in app_root.rglob('*.py')
-        if not GENERATED_PATH_PARTS.intersection(path.relative_to(repository_root).parts)
-    }
-    model_paths = dict(CORE_MODEL_PATHS)
-
-    changed = True
-    while changed:
-        changed = False
-        for module_path, tree in parsed_modules.items():
-            visitor = _CoreCreateVisitor(model_paths)
-            visitor.visit(tree)
-            for exported_name, symbol in visitor.scopes[0][1].items():
-                if symbol is None or symbol[0] != 'model':
-                    continue
-                exported_path = (*module_path, exported_name)
-                model_name = str(symbol[1])
-                if model_paths.get(exported_path) == model_name:
-                    continue
-                model_paths[exported_path] = model_name
-                changed = True
-    return model_paths
-
-
-def count_direct_core_creates(
-    repository_root: Path = REPOSITORY_ROOT,
-    app_root: Path = APP_ROOT,
-) -> Counter[str]:
-    """repo内テストのcore model直接生成をモデル別に集計する。"""
+def count_direct_core_creates() -> Counter[str]:
+    """各test fileの明示importからcore model直接生成を集計する。"""
     counts: Counter[str] = Counter()
-    model_paths = _discover_project_model_paths(app_root, repository_root)
-    for path in _iter_test_sources(app_root, repository_root):
+    for path in _iter_test_sources():
         tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
-        for model_name, _manager_method in find_direct_core_creates(tree, model_paths):
+        for model_name, _manager_method in find_direct_core_creates(
+            tree,
+            package_path=_package_path(path),
+        ):
             counts[model_name] += 1
     return counts

--- a/app/tests/test_factory_usage.py
+++ b/app/tests/test_factory_usage.py
@@ -1,33 +1,14 @@
 """共有factoryへ移行中のcore model直接生成件数をratchetする。"""
 
-from __future__ import annotations
-
 import ast
-from collections import Counter
-from pathlib import Path
-from typing import Iterator, TypeAlias
 from unittest import TestCase
 
+from tests._factory_usage_guard import (
+    count_direct_core_creates,
+    find_direct_core_creates,
+)
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-APP_ROOT = REPOSITORY_ROOT / 'app'
-FACTORY_MODULE_PATH = Path('app/tests/factories.py')
-GENERATED_PATH_PARTS = frozenset({
-    '__pycache__',
-    '.mypy_cache',
-    '.pytest_cache',
-    '.ruff_cache',
-    'migrations',
-})
-CORE_MODEL_PATHS = {
-    ('community', 'models', 'Community'): 'Community',
-    ('event', 'models', 'Event'): 'Event',
-    ('event', 'models', 'EventDetail'): 'EventDetail',
-    ('user_account', 'models', 'CustomUser'): 'CustomUser',
-    ('django', 'contrib', 'auth', 'models', 'User'): 'User',
-}
-GET_USER_MODEL_PATH = ('django', 'contrib', 'auth', 'get_user_model')
-DIRECT_MANAGER_METHODS = frozenset({'create', 'create_user'})
+
 MAX_DIRECT_CREATES_BY_MODEL = {
     'Community': 258,
     'CustomUser': 119,
@@ -36,362 +17,6 @@ MAX_DIRECT_CREATES_BY_MODEL = {
     'User': 107,
 }
 MAX_DIRECT_CORE_CREATES = 801
-
-Symbol: TypeAlias = tuple[str, str | tuple[str, ...]] | None
-Scope: TypeAlias = tuple[str, dict[str, Symbol]]
-
-
-def _is_test_source(path: Path) -> bool:
-    relative_path = path.relative_to(REPOSITORY_ROOT)
-    if relative_path == FACTORY_MODULE_PATH:
-        return False
-    if GENERATED_PATH_PARTS.intersection(relative_path.parts):
-        return False
-    return 'tests' in relative_path.parts or path.name == 'tests.py' or path.name.startswith('test_')
-
-
-def _iter_test_sources() -> Iterator[Path]:
-    """factory本体と生成物を除くrepo内Pythonテストソースを返す。"""
-    return (path for path in APP_ROOT.rglob('*.py') if _is_test_source(path))
-
-
-def _attribute_parts(node: ast.AST) -> tuple[str, ...] | None:
-    parts: list[str] = []
-    current = node
-    while isinstance(current, ast.Attribute):
-        parts.append(current.attr)
-        current = current.value
-    if not isinstance(current, ast.Name):
-        return None
-    parts.append(current.id)
-    return tuple(reversed(parts))
-
-
-def _target_names(node: ast.AST) -> set[str]:
-    if isinstance(node, ast.Name):
-        return {node.id}
-    if isinstance(node, (ast.List, ast.Tuple)):
-        return {name for element in node.elts for name in _target_names(element)}
-    return set()
-
-
-class _FunctionLocalCollector(ast.NodeVisitor):
-    """関数全体でローカル束縛される名前を収集する。"""
-
-    def __init__(self, node: ast.FunctionDef | ast.AsyncFunctionDef):
-        self.names = {
-            argument.arg
-            for argument in (
-                *node.args.posonlyargs,
-                *node.args.args,
-                *node.args.kwonlyargs,
-            )
-        }
-        if node.args.vararg:
-            self.names.add(node.args.vararg.arg)
-        if node.args.kwarg:
-            self.names.add(node.args.kwarg.arg)
-        self.global_names: set[str] = set()
-
-        for statement in node.body:
-            self.visit(statement)
-        self.names.difference_update(self.global_names)
-
-    def visit_Global(self, node: ast.Global):
-        self.global_names.update(node.names)
-
-    def visit_Nonlocal(self, node: ast.Nonlocal):
-        self.global_names.update(node.names)
-
-    def visit_Name(self, node: ast.Name):
-        if isinstance(node.ctx, (ast.Store, ast.Del)):
-            self.names.add(node.id)
-
-    def visit_Import(self, node: ast.Import):
-        for imported in node.names:
-            self.names.add(imported.asname or imported.name.split('.')[0])
-
-    def visit_ImportFrom(self, node: ast.ImportFrom):
-        for imported in node.names:
-            if imported.name != '*':
-                self.names.add(imported.asname or imported.name)
-
-    def visit_FunctionDef(self, node: ast.FunctionDef):
-        self.names.add(node.name)
-
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
-        self.names.add(node.name)
-
-    def visit_ClassDef(self, node: ast.ClassDef):
-        self.names.add(node.name)
-
-    def visit_Lambda(self, node: ast.Lambda):
-        return
-
-    def visit_ListComp(self, node: ast.ListComp):
-        return
-
-    def visit_SetComp(self, node: ast.SetComp):
-        return
-
-    def visit_DictComp(self, node: ast.DictComp):
-        return
-
-    def visit_GeneratorExp(self, node: ast.GeneratorExp):
-        return
-
-
-class _CoreCreateVisitor(ast.NodeVisitor):
-    """import解決済みのcore model manager callを収集する。"""
-
-    def __init__(self, model_paths: dict[tuple[str, ...], str] | None = None):
-        self.identities: list[tuple[str, str]] = []
-        self.scopes: list[Scope] = [('module', {})]
-        self.model_paths = model_paths or CORE_MODEL_PATHS
-        self.model_modules = frozenset(path[:-1] for path in self.model_paths)
-
-    def _lookup(self, name: str) -> Symbol:
-        crossed_function = False
-        for scope_kind, bindings in reversed(self.scopes):
-            if scope_kind == 'function':
-                crossed_function = True
-            if scope_kind == 'class' and crossed_function:
-                continue
-            if name in bindings:
-                return bindings[name]
-        return None
-
-    def _bind(self, name: str, symbol: Symbol):
-        self.scopes[-1][1][name] = symbol
-
-    def _resolve_qualified_path(self, node: ast.AST) -> tuple[str, ...] | None:
-        parts = _attribute_parts(node)
-        if not parts:
-            return None
-        symbol = self._lookup(parts[0])
-        if symbol is None or symbol[0] != 'module':
-            return None
-        return (*symbol[1], *parts[1:])
-
-    def _resolve_model(self, node: ast.AST) -> str | None:
-        if isinstance(node, ast.Name):
-            symbol = self._lookup(node.id)
-            if symbol is not None and symbol[0] == 'model':
-                return str(symbol[1])
-            return None
-        qualified_path = self._resolve_qualified_path(node)
-        if qualified_path is None:
-            return None
-        return self.model_paths.get(qualified_path)
-
-    def _is_get_user_model_call(self, node: ast.AST) -> bool:
-        if not isinstance(node, ast.Call):
-            return False
-        if isinstance(node.func, ast.Name):
-            symbol = self._lookup(node.func.id)
-            return symbol is not None and symbol[0] == 'get_user_model'
-        return self._resolve_qualified_path(node.func) == GET_USER_MODEL_PATH
-
-    def _assignment_symbol(self, target_name: str, value: ast.AST) -> Symbol:
-        if self._is_get_user_model_call(value):
-            model_name = target_name if target_name in {'CustomUser', 'User'} else 'User'
-            return 'model', model_name
-        resolved_model = self._resolve_model(value)
-        if resolved_model is not None:
-            return 'model', resolved_model
-        return None
-
-    def _bind_target(self, target: ast.AST, symbol: Symbol = None):
-        target_names = _target_names(target)
-        for target_name in target_names:
-            self._bind(target_name, symbol if len(target_names) == 1 else None)
-
-    def _symbol_for_path(self, path: tuple[str, ...]) -> Symbol:
-        if path in self.model_paths:
-            return 'model', self.model_paths[path]
-        if path == GET_USER_MODEL_PATH:
-            return 'get_user_model', 'get_user_model'
-        if path in self.model_modules or any(
-            model_path[:len(path)] == path for model_path in self.model_paths
-        ) or GET_USER_MODEL_PATH[:len(path)] == path:
-            return 'module', path
-        return None
-
-    def visit_Import(self, node: ast.Import):
-        for imported in node.names:
-            full_path = tuple(imported.name.split('.'))
-            if imported.asname:
-                self._bind(imported.asname, self._symbol_for_path(full_path))
-            else:
-                root_path = (full_path[0],)
-                self._bind(full_path[0], self._symbol_for_path(root_path))
-
-    def visit_ImportFrom(self, node: ast.ImportFrom):
-        if node.level:
-            for imported in node.names:
-                if imported.name != '*':
-                    self._bind(imported.asname or imported.name, None)
-            return
-        module_path = tuple((node.module or '').split('.'))
-        for imported in node.names:
-            if imported.name == '*':
-                continue
-            self._bind(
-                imported.asname or imported.name,
-                self._symbol_for_path((*module_path, imported.name)),
-            )
-
-    def visit_Assign(self, node: ast.Assign):
-        self.visit(node.value)
-        for target in node.targets:
-            if isinstance(target, ast.Name):
-                self._bind(target.id, self._assignment_symbol(target.id, node.value))
-            else:
-                self._bind_target(target)
-
-    def visit_AnnAssign(self, node: ast.AnnAssign):
-        if node.value is not None:
-            self.visit(node.value)
-        if isinstance(node.target, ast.Name) and node.value is not None:
-            self._bind(node.target.id, self._assignment_symbol(node.target.id, node.value))
-        else:
-            self._bind_target(node.target)
-
-    def visit_AugAssign(self, node: ast.AugAssign):
-        self.visit(node.value)
-        self._bind_target(node.target)
-
-    def visit_NamedExpr(self, node: ast.NamedExpr):
-        self.visit(node.value)
-        if isinstance(node.target, ast.Name):
-            self._bind(node.target.id, self._assignment_symbol(node.target.id, node.value))
-        else:
-            self._bind_target(node.target)
-
-    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef):
-        for decorator in node.decorator_list:
-            self.visit(decorator)
-        for default in (*node.args.defaults, *node.args.kw_defaults):
-            if default is not None:
-                self.visit(default)
-        if node.returns is not None:
-            self.visit(node.returns)
-        self._bind(node.name, None)
-
-        local_names = _FunctionLocalCollector(node).names
-        self.scopes.append(('function', dict.fromkeys(local_names)))
-        for statement in node.body:
-            self.visit(statement)
-        self.scopes.pop()
-
-    def visit_FunctionDef(self, node: ast.FunctionDef):
-        self._visit_function(node)
-
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
-        self._visit_function(node)
-
-    def visit_ClassDef(self, node: ast.ClassDef):
-        for decorator in node.decorator_list:
-            self.visit(decorator)
-        for base in node.bases:
-            self.visit(base)
-        for keyword in node.keywords:
-            self.visit(keyword.value)
-        self._bind(node.name, None)
-
-        self.scopes.append(('class', {}))
-        for statement in node.body:
-            self.visit(statement)
-        self.scopes.pop()
-
-    def visit_For(self, node: ast.For | ast.AsyncFor):
-        self.visit(node.iter)
-        self._bind_target(node.target)
-        for statement in (*node.body, *node.orelse):
-            self.visit(statement)
-
-    def visit_AsyncFor(self, node: ast.AsyncFor):
-        self.visit_For(node)
-
-    def visit_With(self, node: ast.With | ast.AsyncWith):
-        for item in node.items:
-            self.visit(item.context_expr)
-            if item.optional_vars is not None:
-                self._bind_target(item.optional_vars)
-        for statement in node.body:
-            self.visit(statement)
-
-    def visit_AsyncWith(self, node: ast.AsyncWith):
-        self.visit_With(node)
-
-    def visit_ExceptHandler(self, node: ast.ExceptHandler):
-        if node.type is not None:
-            self.visit(node.type)
-        if node.name:
-            self._bind(node.name, None)
-        for statement in node.body:
-            self.visit(statement)
-
-    def visit_Call(self, node: ast.Call):
-        if isinstance(node.func, ast.Attribute) and node.func.attr in DIRECT_MANAGER_METHODS:
-            manager = node.func.value
-            if isinstance(manager, ast.Attribute) and manager.attr == 'objects':
-                model_name = self._resolve_model(manager.value)
-                if model_name is not None:
-                    self.identities.append((model_name, node.func.attr))
-        self.generic_visit(node)
-
-
-def _find_direct_core_creates(
-    tree: ast.AST,
-    model_paths: dict[tuple[str, ...], str] | None = None,
-) -> list[tuple[str, str]]:
-    visitor = _CoreCreateVisitor(model_paths)
-    visitor.visit(tree)
-    return visitor.identities
-
-
-def _module_path(path: Path) -> tuple[str, ...]:
-    relative_path = path.relative_to(APP_ROOT).with_suffix('')
-    parts = relative_path.parts
-    return parts[:-1] if parts[-1] == '__init__' else parts
-
-
-def _discover_project_model_paths() -> dict[tuple[str, ...], str]:
-    """プロジェクト内moduleが再公開するcore model aliasを解決する。"""
-    parsed_modules = {
-        _module_path(path): ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
-        for path in APP_ROOT.rglob('*.py')
-        if not GENERATED_PATH_PARTS.intersection(path.relative_to(REPOSITORY_ROOT).parts)
-    }
-    model_paths = dict(CORE_MODEL_PATHS)
-
-    changed = True
-    while changed:
-        changed = False
-        for module_path, tree in parsed_modules.items():
-            visitor = _CoreCreateVisitor(model_paths)
-            visitor.visit(tree)
-            for exported_name, symbol in visitor.scopes[0][1].items():
-                if symbol is None or symbol[0] != 'model':
-                    continue
-                exported_path = (*module_path, exported_name)
-                model_name = str(symbol[1])
-                if model_paths.get(exported_path) == model_name:
-                    continue
-                model_paths[exported_path] = model_name
-                changed = True
-    return model_paths
-
-
-def _count_direct_core_creates() -> Counter[str]:
-    counts: Counter[str] = Counter()
-    model_paths = _discover_project_model_paths()
-    for path in _iter_test_sources():
-        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
-        for model_name, _manager_method in _find_direct_core_creates(tree, model_paths):
-            counts[model_name] += 1
-    return counts
 
 
 class FactoryUsageRatchetTest(TestCase):
@@ -431,7 +56,7 @@ def use_unimported_local_model():
 CommunityFactory.create(name='ignored')
 CommunityFactory.objects.create(name='ignored')
 """
-        identities = _find_direct_core_creates(ast.parse(source))
+        identities = find_direct_core_creates(ast.parse(source))
 
         self.assertCountEqual(
             identities,
@@ -445,9 +70,37 @@ CommunityFactory.objects.create(name='ignored')
             ],
         )
 
+    def test_lambda_and_comprehension_targets_shadow_module_model(self):
+        """内包表記とlambdaのローカル束縛をcore modelとして数えない。"""
+        source = """
+from community.models import Community
+
+values = []
+(lambda Community: Community.objects.create(name='ignored'))(object())
+[Community.objects.create(name='ignored') for Community in values]
+{Community.objects.create(name='ignored') for Community in values}
+{Community: Community.objects.create(name='ignored') for Community in values}
+(Community.objects.create(name='ignored') for Community in values)
+
+[value for value in Community.objects.create(name='outer-iter-counted')]
+Community.objects.create(name='global-counted')
+
+Community = object()
+Community.objects.create(name='module-shadow-ignored')
+"""
+        identities = find_direct_core_creates(ast.parse(source))
+
+        self.assertEqual(
+            identities,
+            [
+                ('Community', 'create'),
+                ('Community', 'create'),
+            ],
+        )
+
     def test_direct_core_model_fixture_debt_does_not_increase(self):
         """共有factory外の直接生成は今回のpost値以下に保つ。"""
-        counts = _count_direct_core_creates()
+        counts = count_direct_core_creates()
 
         for model_name, maximum in MAX_DIRECT_CREATES_BY_MODEL.items():
             with self.subTest(model=model_name):

--- a/app/tests/test_factory_usage.py
+++ b/app/tests/test_factory_usage.py
@@ -1,0 +1,113 @@
+"""共有factoryへ移行中のcore model直接生成件数をratchetする。"""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from pathlib import Path
+from typing import Iterator
+from unittest import TestCase
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+APP_ROOT = REPOSITORY_ROOT / 'app'
+FACTORY_MODULE_PATH = Path('app/tests/factories.py')
+GENERATED_PATH_PARTS = frozenset({
+    '__pycache__',
+    '.mypy_cache',
+    '.pytest_cache',
+    '.ruff_cache',
+    'migrations',
+})
+CORE_MODEL_NAMES = frozenset({
+    'Community',
+    'CustomUser',
+    'Event',
+    'EventDetail',
+    'User',
+})
+DIRECT_MANAGER_METHODS = frozenset({'create', 'create_user'})
+MAX_DIRECT_CREATES_BY_MODEL = {
+    'Community': 258,
+    'CustomUser': 119,
+    'Event': 160,
+    'EventDetail': 157,
+    'User': 107,
+}
+MAX_DIRECT_CORE_CREATES = 801
+
+
+def _is_test_source(path: Path) -> bool:
+    relative_path = path.relative_to(REPOSITORY_ROOT)
+    if relative_path == FACTORY_MODULE_PATH:
+        return False
+    if GENERATED_PATH_PARTS.intersection(relative_path.parts):
+        return False
+    return 'tests' in relative_path.parts or path.name == 'tests.py' or path.name.startswith('test_')
+
+
+def _iter_test_sources() -> Iterator[Path]:
+    """factory本体と生成物を除くrepo内Pythonテストソースを返す。"""
+    return (path for path in APP_ROOT.rglob('*.py') if _is_test_source(path))
+
+
+def _direct_core_create_identity(node: ast.AST) -> tuple[str, str] | None:
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+        return None
+    if node.func.attr not in DIRECT_MANAGER_METHODS:
+        return None
+
+    manager = node.func.value
+    if not isinstance(manager, ast.Attribute) or manager.attr != 'objects':
+        return None
+    if not isinstance(manager.value, ast.Name) or manager.value.id not in CORE_MODEL_NAMES:
+        return None
+    return manager.value.id, node.func.attr
+
+
+def _count_direct_core_creates() -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for path in _iter_test_sources():
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for node in ast.walk(tree):
+            identity = _direct_core_create_identity(node)
+            if identity is not None:
+                counts[identity[0]] += 1
+    return counts
+
+
+class FactoryUsageRatchetTest(TestCase):
+    """core model fixtureの直接生成負債が増えないことを検証する。"""
+
+    def test_ast_matcher_identifies_only_core_model_manager_calls(self):
+        """モデル名とmanager APIの両方が一致するcallだけを数える。"""
+        source = """
+Community.objects.create(name='counted')
+User.objects.create_user(user_name='counted')
+OtherModel.objects.create(name='ignored')
+CommunityFactory.create(name='ignored')
+"""
+        identities = [
+            identity
+            for node in ast.walk(ast.parse(source))
+            if (identity := _direct_core_create_identity(node)) is not None
+        ]
+
+        self.assertCountEqual(identities, [('Community', 'create'), ('User', 'create_user')])
+
+    def test_direct_core_model_fixture_debt_does_not_increase(self):
+        """共有factory外の直接生成は今回のpost値以下に保つ。"""
+        counts = _count_direct_core_creates()
+
+        for model_name, maximum in MAX_DIRECT_CREATES_BY_MODEL.items():
+            with self.subTest(model=model_name):
+                self.assertLessEqual(
+                    counts[model_name],
+                    maximum,
+                    f'{model_name}.objects direct create debt increased: {counts[model_name]} > {maximum}',
+                )
+        self.assertLessEqual(
+            counts.total(),
+            MAX_DIRECT_CORE_CREATES,
+            f'repo test direct core create debt increased: {counts.total()} > {MAX_DIRECT_CORE_CREATES}',
+        )

--- a/app/tests/test_factory_usage.py
+++ b/app/tests/test_factory_usage.py
@@ -113,6 +113,43 @@ Community.objects.create(name='module-shadow-ignored')
             ],
         )
 
+    def test_match_pattern_captures_shadow_module_models(self):
+        """match patternの全capture形式をローカル束縛として扱う。"""
+        source = """
+from community.models import Community
+from event.models import Event, EventDetail
+from user_account.models import CustomUser
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+def match_as_capture(value):
+    match value:
+        case str() as Community:
+            Community.objects.create(name='ignored')
+
+def match_star_capture(value):
+    match value:
+        case [*Event]:
+            Event.objects.create(name='ignored')
+
+def match_mapping_captures(value):
+    match value:
+        case {'speaker': CustomUser, **EventDetail}:
+            CustomUser.objects.create_user(user_name='ignored')
+            EventDetail.objects.create(name='ignored')
+
+def nested_pattern_capture(value):
+    match value:
+        case {'nested': [str() as User]}:
+            User.objects.create_user(user_name='ignored')
+
+Community.objects.create(name='global-counted')
+"""
+        identities = find_direct_core_creates(ast.parse(source))
+
+        self.assertEqual(identities, [('Community', 'create')])
+
     def test_direct_core_model_fixture_snapshot_matches_exactly(self):
         """共有factory外の直接生成件数が意図したsnapshotと完全一致する。"""
         counts = count_direct_core_creates()

--- a/app/tests/test_factory_usage.py
+++ b/app/tests/test_factory_usage.py
@@ -9,21 +9,20 @@ from tests._factory_usage_guard import (
 )
 
 
-MAX_DIRECT_CREATES_BY_MODEL = {
+EXPECTED_DIRECT_CREATES_BY_MODEL = {
     'Community': 258,
     'CustomUser': 119,
     'Event': 160,
     'EventDetail': 157,
     'User': 107,
 }
-MAX_DIRECT_CORE_CREATES = 801
 
 
 class FactoryUsageRatchetTest(TestCase):
     """core model fixtureの直接生成負債が増えないことを検証する。"""
 
-    def test_ast_matcher_identifies_only_core_model_manager_calls(self):
-        """import解決できるcore model manager callだけを数える。"""
+    def test_explicit_import_matcher_ignores_unrelated_and_reexported_models(self):
+        """明示的なcanonical importだけを解決しre-exportは数えない。"""
         source = """
 from community.models import Community
 from event.models import Event as CalendarEvent
@@ -32,6 +31,7 @@ import event.models as event_models
 import community.models
 from django.contrib.auth import get_user_model as resolve_user_model
 from unrelated.models import Community as UnrelatedCommunity
+from twitter.tests._auto_tweet_test_base import CustomUser as ReexportedUser
 
 Account = resolve_user_model()
 
@@ -43,6 +43,7 @@ community.models.Community.objects.create(name='counted')
 Account.objects.create_user(user_name='counted')
 
 UnrelatedCommunity.objects.create(name='ignored')
+ReexportedUser.objects.create_user(user_name='ignored')
 
 def use_local_shadow():
     Community = object()
@@ -69,6 +70,20 @@ CommunityFactory.objects.create(name='ignored')
                 ('User', 'create_user'),
             ],
         )
+
+    def test_relative_import_resolves_canonical_model_from_file_package(self):
+        """file packageを基準にcanonical modelsの相対importを解決する。"""
+        source = """
+from ..models import Community as RelativeCommunity
+
+RelativeCommunity.objects.create(name='counted')
+"""
+        identities = find_direct_core_creates(
+            ast.parse(source),
+            package_path=('community', 'tests'),
+        )
+
+        self.assertEqual(identities, [('Community', 'create')])
 
     def test_lambda_and_comprehension_targets_shadow_module_model(self):
         """内包表記とlambdaのローカル束縛をcore modelとして数えない。"""
@@ -98,19 +113,25 @@ Community.objects.create(name='module-shadow-ignored')
             ],
         )
 
-    def test_direct_core_model_fixture_debt_does_not_increase(self):
-        """共有factory外の直接生成は今回のpost値以下に保つ。"""
+    def test_direct_core_model_fixture_snapshot_matches_exactly(self):
+        """共有factory外の直接生成件数が意図したsnapshotと完全一致する。"""
         counts = count_direct_core_creates()
+        expected_total = sum(EXPECTED_DIRECT_CREATES_BY_MODEL.values())
+        snapshot_guidance = (
+            'Direct fixture snapshot changed. Both increases and reductions require '
+            'intentional fixture review and EXPECTED_DIRECT_CREATES_BY_MODEL update.'
+        )
 
-        for model_name, maximum in MAX_DIRECT_CREATES_BY_MODEL.items():
+        self.assertEqual(set(counts), set(EXPECTED_DIRECT_CREATES_BY_MODEL), snapshot_guidance)
+        for model_name, expected in EXPECTED_DIRECT_CREATES_BY_MODEL.items():
             with self.subTest(model=model_name):
-                self.assertLessEqual(
+                self.assertEqual(
                     counts[model_name],
-                    maximum,
-                    f'{model_name}.objects direct create debt increased: {counts[model_name]} > {maximum}',
+                    expected,
+                    f'{model_name}: expected {expected}, observed {counts[model_name]}. {snapshot_guidance}',
                 )
-        self.assertLessEqual(
+        self.assertEqual(
             counts.total(),
-            MAX_DIRECT_CORE_CREATES,
-            f'repo test direct core create debt increased: {counts.total()} > {MAX_DIRECT_CORE_CREATES}',
+            expected_total,
+            f'total: expected {expected_total}, observed {counts.total()}. {snapshot_guidance}',
         )

--- a/app/tests/test_factory_usage.py
+++ b/app/tests/test_factory_usage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ast
 from collections import Counter
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, TypeAlias
 from unittest import TestCase
 
 
@@ -19,13 +19,14 @@ GENERATED_PATH_PARTS = frozenset({
     '.ruff_cache',
     'migrations',
 })
-CORE_MODEL_NAMES = frozenset({
-    'Community',
-    'CustomUser',
-    'Event',
-    'EventDetail',
-    'User',
-})
+CORE_MODEL_PATHS = {
+    ('community', 'models', 'Community'): 'Community',
+    ('event', 'models', 'Event'): 'Event',
+    ('event', 'models', 'EventDetail'): 'EventDetail',
+    ('user_account', 'models', 'CustomUser'): 'CustomUser',
+    ('django', 'contrib', 'auth', 'models', 'User'): 'User',
+}
+GET_USER_MODEL_PATH = ('django', 'contrib', 'auth', 'get_user_model')
 DIRECT_MANAGER_METHODS = frozenset({'create', 'create_user'})
 MAX_DIRECT_CREATES_BY_MODEL = {
     'Community': 258,
@@ -35,6 +36,9 @@ MAX_DIRECT_CREATES_BY_MODEL = {
     'User': 107,
 }
 MAX_DIRECT_CORE_CREATES = 801
+
+Symbol: TypeAlias = tuple[str, str | tuple[str, ...]] | None
+Scope: TypeAlias = tuple[str, dict[str, Symbol]]
 
 
 def _is_test_source(path: Path) -> bool:
@@ -51,28 +55,342 @@ def _iter_test_sources() -> Iterator[Path]:
     return (path for path in APP_ROOT.rglob('*.py') if _is_test_source(path))
 
 
-def _direct_core_create_identity(node: ast.AST) -> tuple[str, str] | None:
-    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+def _attribute_parts(node: ast.AST) -> tuple[str, ...] | None:
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
         return None
-    if node.func.attr not in DIRECT_MANAGER_METHODS:
+    parts.append(current.id)
+    return tuple(reversed(parts))
+
+
+def _target_names(node: ast.AST) -> set[str]:
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return {name for element in node.elts for name in _target_names(element)}
+    return set()
+
+
+class _FunctionLocalCollector(ast.NodeVisitor):
+    """関数全体でローカル束縛される名前を収集する。"""
+
+    def __init__(self, node: ast.FunctionDef | ast.AsyncFunctionDef):
+        self.names = {
+            argument.arg
+            for argument in (
+                *node.args.posonlyargs,
+                *node.args.args,
+                *node.args.kwonlyargs,
+            )
+        }
+        if node.args.vararg:
+            self.names.add(node.args.vararg.arg)
+        if node.args.kwarg:
+            self.names.add(node.args.kwarg.arg)
+        self.global_names: set[str] = set()
+
+        for statement in node.body:
+            self.visit(statement)
+        self.names.difference_update(self.global_names)
+
+    def visit_Global(self, node: ast.Global):
+        self.global_names.update(node.names)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal):
+        self.global_names.update(node.names)
+
+    def visit_Name(self, node: ast.Name):
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.names.add(node.id)
+
+    def visit_Import(self, node: ast.Import):
+        for imported in node.names:
+            self.names.add(imported.asname or imported.name.split('.')[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        for imported in node.names:
+            if imported.name != '*':
+                self.names.add(imported.asname or imported.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        self.names.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+        self.names.add(node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef):
+        self.names.add(node.name)
+
+    def visit_Lambda(self, node: ast.Lambda):
+        return
+
+    def visit_ListComp(self, node: ast.ListComp):
+        return
+
+    def visit_SetComp(self, node: ast.SetComp):
+        return
+
+    def visit_DictComp(self, node: ast.DictComp):
+        return
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp):
+        return
+
+
+class _CoreCreateVisitor(ast.NodeVisitor):
+    """import解決済みのcore model manager callを収集する。"""
+
+    def __init__(self, model_paths: dict[tuple[str, ...], str] | None = None):
+        self.identities: list[tuple[str, str]] = []
+        self.scopes: list[Scope] = [('module', {})]
+        self.model_paths = model_paths or CORE_MODEL_PATHS
+        self.model_modules = frozenset(path[:-1] for path in self.model_paths)
+
+    def _lookup(self, name: str) -> Symbol:
+        crossed_function = False
+        for scope_kind, bindings in reversed(self.scopes):
+            if scope_kind == 'function':
+                crossed_function = True
+            if scope_kind == 'class' and crossed_function:
+                continue
+            if name in bindings:
+                return bindings[name]
         return None
 
-    manager = node.func.value
-    if not isinstance(manager, ast.Attribute) or manager.attr != 'objects':
+    def _bind(self, name: str, symbol: Symbol):
+        self.scopes[-1][1][name] = symbol
+
+    def _resolve_qualified_path(self, node: ast.AST) -> tuple[str, ...] | None:
+        parts = _attribute_parts(node)
+        if not parts:
+            return None
+        symbol = self._lookup(parts[0])
+        if symbol is None or symbol[0] != 'module':
+            return None
+        return (*symbol[1], *parts[1:])
+
+    def _resolve_model(self, node: ast.AST) -> str | None:
+        if isinstance(node, ast.Name):
+            symbol = self._lookup(node.id)
+            if symbol is not None and symbol[0] == 'model':
+                return str(symbol[1])
+            return None
+        qualified_path = self._resolve_qualified_path(node)
+        if qualified_path is None:
+            return None
+        return self.model_paths.get(qualified_path)
+
+    def _is_get_user_model_call(self, node: ast.AST) -> bool:
+        if not isinstance(node, ast.Call):
+            return False
+        if isinstance(node.func, ast.Name):
+            symbol = self._lookup(node.func.id)
+            return symbol is not None and symbol[0] == 'get_user_model'
+        return self._resolve_qualified_path(node.func) == GET_USER_MODEL_PATH
+
+    def _assignment_symbol(self, target_name: str, value: ast.AST) -> Symbol:
+        if self._is_get_user_model_call(value):
+            model_name = target_name if target_name in {'CustomUser', 'User'} else 'User'
+            return 'model', model_name
+        resolved_model = self._resolve_model(value)
+        if resolved_model is not None:
+            return 'model', resolved_model
         return None
-    if not isinstance(manager.value, ast.Name) or manager.value.id not in CORE_MODEL_NAMES:
+
+    def _bind_target(self, target: ast.AST, symbol: Symbol = None):
+        target_names = _target_names(target)
+        for target_name in target_names:
+            self._bind(target_name, symbol if len(target_names) == 1 else None)
+
+    def _symbol_for_path(self, path: tuple[str, ...]) -> Symbol:
+        if path in self.model_paths:
+            return 'model', self.model_paths[path]
+        if path == GET_USER_MODEL_PATH:
+            return 'get_user_model', 'get_user_model'
+        if path in self.model_modules or any(
+            model_path[:len(path)] == path for model_path in self.model_paths
+        ) or GET_USER_MODEL_PATH[:len(path)] == path:
+            return 'module', path
         return None
-    return manager.value.id, node.func.attr
+
+    def visit_Import(self, node: ast.Import):
+        for imported in node.names:
+            full_path = tuple(imported.name.split('.'))
+            if imported.asname:
+                self._bind(imported.asname, self._symbol_for_path(full_path))
+            else:
+                root_path = (full_path[0],)
+                self._bind(full_path[0], self._symbol_for_path(root_path))
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        if node.level:
+            for imported in node.names:
+                if imported.name != '*':
+                    self._bind(imported.asname or imported.name, None)
+            return
+        module_path = tuple((node.module or '').split('.'))
+        for imported in node.names:
+            if imported.name == '*':
+                continue
+            self._bind(
+                imported.asname or imported.name,
+                self._symbol_for_path((*module_path, imported.name)),
+            )
+
+    def visit_Assign(self, node: ast.Assign):
+        self.visit(node.value)
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                self._bind(target.id, self._assignment_symbol(target.id, node.value))
+            else:
+                self._bind_target(target)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign):
+        if node.value is not None:
+            self.visit(node.value)
+        if isinstance(node.target, ast.Name) and node.value is not None:
+            self._bind(node.target.id, self._assignment_symbol(node.target.id, node.value))
+        else:
+            self._bind_target(node.target)
+
+    def visit_AugAssign(self, node: ast.AugAssign):
+        self.visit(node.value)
+        self._bind_target(node.target)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr):
+        self.visit(node.value)
+        if isinstance(node.target, ast.Name):
+            self._bind(node.target.id, self._assignment_symbol(node.target.id, node.value))
+        else:
+            self._bind_target(node.target)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef):
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+        if node.returns is not None:
+            self.visit(node.returns)
+        self._bind(node.name, None)
+
+        local_names = _FunctionLocalCollector(node).names
+        self.scopes.append(('function', dict.fromkeys(local_names)))
+        for statement in node.body:
+            self.visit(statement)
+        self.scopes.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+        self._visit_function(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef):
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+        self._bind(node.name, None)
+
+        self.scopes.append(('class', {}))
+        for statement in node.body:
+            self.visit(statement)
+        self.scopes.pop()
+
+    def visit_For(self, node: ast.For | ast.AsyncFor):
+        self.visit(node.iter)
+        self._bind_target(node.target)
+        for statement in (*node.body, *node.orelse):
+            self.visit(statement)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor):
+        self.visit_For(node)
+
+    def visit_With(self, node: ast.With | ast.AsyncWith):
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self._bind_target(item.optional_vars)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith):
+        self.visit_With(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler):
+        if node.type is not None:
+            self.visit(node.type)
+        if node.name:
+            self._bind(node.name, None)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_Call(self, node: ast.Call):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in DIRECT_MANAGER_METHODS:
+            manager = node.func.value
+            if isinstance(manager, ast.Attribute) and manager.attr == 'objects':
+                model_name = self._resolve_model(manager.value)
+                if model_name is not None:
+                    self.identities.append((model_name, node.func.attr))
+        self.generic_visit(node)
+
+
+def _find_direct_core_creates(
+    tree: ast.AST,
+    model_paths: dict[tuple[str, ...], str] | None = None,
+) -> list[tuple[str, str]]:
+    visitor = _CoreCreateVisitor(model_paths)
+    visitor.visit(tree)
+    return visitor.identities
+
+
+def _module_path(path: Path) -> tuple[str, ...]:
+    relative_path = path.relative_to(APP_ROOT).with_suffix('')
+    parts = relative_path.parts
+    return parts[:-1] if parts[-1] == '__init__' else parts
+
+
+def _discover_project_model_paths() -> dict[tuple[str, ...], str]:
+    """プロジェクト内moduleが再公開するcore model aliasを解決する。"""
+    parsed_modules = {
+        _module_path(path): ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for path in APP_ROOT.rglob('*.py')
+        if not GENERATED_PATH_PARTS.intersection(path.relative_to(REPOSITORY_ROOT).parts)
+    }
+    model_paths = dict(CORE_MODEL_PATHS)
+
+    changed = True
+    while changed:
+        changed = False
+        for module_path, tree in parsed_modules.items():
+            visitor = _CoreCreateVisitor(model_paths)
+            visitor.visit(tree)
+            for exported_name, symbol in visitor.scopes[0][1].items():
+                if symbol is None or symbol[0] != 'model':
+                    continue
+                exported_path = (*module_path, exported_name)
+                model_name = str(symbol[1])
+                if model_paths.get(exported_path) == model_name:
+                    continue
+                model_paths[exported_path] = model_name
+                changed = True
+    return model_paths
 
 
 def _count_direct_core_creates() -> Counter[str]:
     counts: Counter[str] = Counter()
+    model_paths = _discover_project_model_paths()
     for path in _iter_test_sources():
         tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
-        for node in ast.walk(tree):
-            identity = _direct_core_create_identity(node)
-            if identity is not None:
-                counts[identity[0]] += 1
+        for model_name, _manager_method in _find_direct_core_creates(tree, model_paths):
+            counts[model_name] += 1
     return counts
 
 
@@ -80,20 +398,52 @@ class FactoryUsageRatchetTest(TestCase):
     """core model fixtureの直接生成負債が増えないことを検証する。"""
 
     def test_ast_matcher_identifies_only_core_model_manager_calls(self):
-        """モデル名とmanager APIの両方が一致するcallだけを数える。"""
+        """import解決できるcore model manager callだけを数える。"""
         source = """
-Community.objects.create(name='counted')
-User.objects.create_user(user_name='counted')
-OtherModel.objects.create(name='ignored')
-CommunityFactory.create(name='ignored')
-"""
-        identities = [
-            identity
-            for node in ast.walk(ast.parse(source))
-            if (identity := _direct_core_create_identity(node)) is not None
-        ]
+from community.models import Community
+from event.models import Event as CalendarEvent
+from user_account.models import CustomUser as AccountUser
+import event.models as event_models
+import community.models
+from django.contrib.auth import get_user_model as resolve_user_model
+from unrelated.models import Community as UnrelatedCommunity
 
-        self.assertCountEqual(identities, [('Community', 'create'), ('User', 'create_user')])
+Account = resolve_user_model()
+
+Community.objects.create(name='counted')
+CalendarEvent.objects.create(name='counted')
+AccountUser.objects.create_user(user_name='counted')
+event_models.EventDetail.objects.create(name='counted')
+community.models.Community.objects.create(name='counted')
+Account.objects.create_user(user_name='counted')
+
+UnrelatedCommunity.objects.create(name='ignored')
+
+def use_local_shadow():
+    Community = object()
+    Community.objects.create(name='ignored')
+
+def use_unimported_local_model():
+    class EventDetail:
+        pass
+    EventDetail.objects.create(name='ignored')
+
+CommunityFactory.create(name='ignored')
+CommunityFactory.objects.create(name='ignored')
+"""
+        identities = _find_direct_core_creates(ast.parse(source))
+
+        self.assertCountEqual(
+            identities,
+            [
+                ('Community', 'create'),
+                ('Event', 'create'),
+                ('CustomUser', 'create_user'),
+                ('EventDetail', 'create'),
+                ('Community', 'create'),
+                ('User', 'create_user'),
+            ],
+        )
 
     def test_direct_core_model_fixture_debt_does_not_increase(self):
         """共有factory外の直接生成は今回のpost値以下に保つ。"""

--- a/app/twitter/tests/_auto_tweet_test_base.py
+++ b/app/twitter/tests/_auto_tweet_test_base.py
@@ -1,16 +1,11 @@
 """自動投稿テストで共有するセットアップを提供する。"""
 
 import datetime
-from unittest.mock import patch
 
-from django.contrib.auth import get_user_model
 from django.test import Client, TestCase, tag
 from django.utils import timezone
 
-from community.models import Community, CommunityMember
-from event.models import Event
-
-CustomUser = get_user_model()
+from tests.factories import make_community, make_event, make_user
 
 
 @tag('offline_external_api')
@@ -19,14 +14,15 @@ class AutoTweetTestBase(TestCase):
 
     def setUp(self):
         self.client = Client()
-        self.owner = CustomUser.objects.create_user(
+        self.owner = make_user(
             user_name="auto_tweet_owner",
             email="auto_tweet_owner@example.com",
             password="testpassword",
         )
         # status=pending で作成 (承認前)
-        self.community = Community.objects.create(
+        self.community = make_community(
             name="Auto Tweet Community",
+            owner=self.owner,
             start_time=datetime.time(22, 0),
             duration=60,
             weekdays=["Mon", "Thu"],
@@ -37,16 +33,13 @@ class AutoTweetTestBase(TestCase):
             status="pending",
             twitter_hashtag="TestMeetup",
         )
-        CommunityMember.objects.create(
-            community=self.community,
-            user=self.owner,
-            role=CommunityMember.Role.OWNER,
-        )
-        self.event = Event.objects.create(
-            community=self.community,
-            date=datetime.date(2099, 5, 1),
+        self.event = make_event(
+            self.community,
+            event_date=datetime.date(2099, 5, 1),
             start_time=datetime.time(22, 0),
             duration=60,
+            weekday="",
+            accepts_lt_application=True,
         )
 
     def due_scheduled_at(self):
@@ -64,22 +57,23 @@ class TweetGeneratorTestBase(TestCase):
     """告知文生成テストで共有するセットアップを提供する。"""
 
     def setUp(self):
-        with patch("twitter.services.tweet_generation.threading.Thread"):
-            self.community = Community.objects.create(
-                name="Generator Test Community",
-                start_time=datetime.time(22, 0),
-                duration=60,
-                weekdays=["Mon"],
-                frequency="毎週",
-                organizers="Test",
-                description="テスト用集会",
-                platform="All",
-                status="approved",
-                twitter_hashtag="GenTest",
-            )
-        self.event = Event.objects.create(
-            community=self.community,
-            date=datetime.date(2026, 5, 1),
+        self.community = make_community(
+            name="Generator Test Community",
             start_time=datetime.time(22, 0),
             duration=60,
+            weekdays=["Mon"],
+            frequency="毎週",
+            organizers="Test",
+            description="テスト用集会",
+            platform="All",
+            status="approved",
+            twitter_hashtag="GenTest",
+        )
+        self.event = make_event(
+            self.community,
+            event_date=datetime.date(2026, 5, 1),
+            start_time=datetime.time(22, 0),
+            duration=60,
+            weekday="",
+            accepts_lt_application=True,
         )

--- a/app/twitter/tests/test_generator_community.py
+++ b/app/twitter/tests/test_generator_community.py
@@ -11,9 +11,8 @@ from twitter.tests._auto_tweet_test_base import TweetGeneratorTestBase
 class TweetGeneratorCommunityTest(TweetGeneratorTestBase):
     """新規集会の告知文生成を検証する。"""
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_new_community_tweet(self, mock_llm, _mock_thread):
+    def test_generate_new_community_tweet(self, mock_llm):
         """新規集会の告知文が生成��れる"""
         mock_llm.return_value = "新しい集会がはじまります！"
 

--- a/app/twitter/tests/test_generator_event.py
+++ b/app/twitter/tests/test_generator_event.py
@@ -6,23 +6,22 @@ from unittest.mock import patch
 from django.test import tag
 from django.utils import timezone
 
-from event.models import Event, EventDetail
+from tests.factories import make_event, make_event_detail, make_user
 from twitter.models import TweetQueue
 
-from twitter.tests._auto_tweet_test_base import CustomUser, TweetGeneratorTestBase
+from twitter.tests._auto_tweet_test_base import TweetGeneratorTestBase
 
 @tag('offline_external_api')
 class TweetGeneratorEventTest(TweetGeneratorTestBase):
     """発表と当日リマインドの告知文生成を検証する。"""
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_lt_tweet(self, mock_llm, _mock_thread):
+    def test_generate_lt_tweet(self, mock_llm):
         """LT 告知文が生成される"""
         mock_llm.return_value = "LT告知テスト"
 
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト太郎",
@@ -44,19 +43,18 @@ class TweetGeneratorEventTest(TweetGeneratorTestBase):
         self.assertIn("告知ポスト", user_prompt)
         self.assertNotIn("告知ツイート", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_lt_tweet_includes_applicant_x_account(self, mock_llm, _mock_thread):
+    def test_generate_lt_tweet_includes_applicant_x_account(self, mock_llm):
         """LT 告知のプロンプトに申請者の X アカウントを含める"""
         mock_llm.return_value = "LT告知テスト"
-        applicant = CustomUser.objects.create_user(
+        applicant = make_user(
             user_name="lt_speaker",
             email="lt_speaker@example.com",
             password="testpassword",
             x_account="speaker_vr",
         )
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト太郎",
@@ -72,13 +70,12 @@ class TweetGeneratorEventTest(TweetGeneratorTestBase):
         self.assertIn("発表者: テスト太郎さん（@speaker_vr）", user_prompt)
         self.assertIn("発表者（「テスト太郎さん（@speaker_vr）」をそのまま記載）", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_lt_tweet_uses_name_only_without_applicant_x_account(self, mock_llm, _mock_thread):
+    def test_generate_lt_tweet_uses_name_only_without_applicant_x_account(self, mock_llm):
         """申請者や X アカウントがない LT 告知は従来どおり名前だけを使う"""
         mock_llm.return_value = "LT告知テスト"
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト太郎",
@@ -93,19 +90,18 @@ class TweetGeneratorEventTest(TweetGeneratorTestBase):
         self.assertIn("発表者: テスト太郎さん", user_prompt)
         self.assertNotIn("@", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_lt_generator_fallback_includes_applicant_x_account(self, mock_llm, _mock_thread):
+    def test_lt_generator_fallback_includes_applicant_x_account(self, mock_llm):
         """LLM 生成失敗時の LT fallback に申請者の X アカウントを含める"""
         mock_llm.return_value = "\n".join(["長い本文"] * 20)
-        applicant = CustomUser.objects.create_user(
+        applicant = make_user(
             user_name="fallback_speaker",
             email="fallback_speaker@example.com",
             password="testpassword",
             x_account="fallback_vr",
         )
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト太郎",
@@ -126,9 +122,8 @@ class TweetGeneratorEventTest(TweetGeneratorTestBase):
 
         self.assertIn("テスト太郎さん（@fallback_vr）", result)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_lt_generator_fallback_fits_long_theme_under_weighted_limit(self, mock_llm, _mock_thread):
+    def test_lt_generator_fallback_fits_long_theme_under_weighted_limit(self, mock_llm):
         """LLM が長い本文を返し続けても LT 告知を決定的に280以内へ収める"""
         mock_llm.return_value = (
             "5/16(土) 22:00~ 「計算と自然」集会\n\n"
@@ -144,8 +139,8 @@ class TweetGeneratorEventTest(TweetGeneratorTestBase):
         self.event.date = datetime.date(2026, 5, 16)
         self.event.start_time = datetime.time(22, 0)
         self.event.save(update_fields=["date", "start_time"])
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="nconc",
@@ -167,14 +162,13 @@ class TweetGeneratorEventTest(TweetGeneratorTestBase):
         self.assertLessEqual(count_tweet_length(result), 280)
         self.assertNotIn("自律型エージェントの実装", result)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_special_event_tweet(self, mock_llm, _mock_thread):
+    def test_generate_special_event_tweet(self, mock_llm):
         """特別回告知文が生成される"""
         mock_llm.return_value = "特別回告知テスト"
 
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="SPECIAL",
             status="approved",
             speaker="ゲスト講師",
@@ -195,20 +189,21 @@ class TweetGeneratorEventTest(TweetGeneratorTestBase):
         self.assertIn("告知ポスト", user_prompt)
         self.assertNotIn("告知ツイート", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_daily_reminder_tweet(self, mock_llm, _mock_thread):
+    def test_generate_daily_reminder_tweet(self, mock_llm):
         """当日リマインド生成時に開催情報と発表情報をプロンプトへ含める"""
         mock_llm.return_value = "今日開催のリマインド"
 
-        today_event = Event.objects.create(
-            community=self.community,
-            date=timezone.localdate(),
+        today_event = make_event(
+            self.community,
+            event_date=timezone.localdate(),
             start_time=datetime.time(20, 0),
             duration=60,
+            weekday="",
+            accepts_lt_application=True,
         )
-        EventDetail.objects.create(
-            event=today_event,
+        make_event_detail(
+            today_event,
             detail_type="LT",
             status="approved",
             speaker="リマインド太郎",
@@ -230,25 +225,26 @@ class TweetGeneratorEventTest(TweetGeneratorTestBase):
         self.assertIn("リマインダーポスト", user_prompt)
         self.assertNotIn("リマインダーツイート", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_daily_reminder_tweet_includes_applicant_x_account(self, mock_llm, _mock_thread):
+    def test_generate_daily_reminder_tweet_includes_applicant_x_account(self, mock_llm):
         """当日リマインドの発表一覧に申請者の X アカウントを含める"""
         mock_llm.return_value = "今日開催のリマインド"
-        applicant = CustomUser.objects.create_user(
+        applicant = make_user(
             user_name="reminder_speaker",
             email="reminder_speaker@example.com",
             password="testpassword",
             x_account="reminder_vr",
         )
-        today_event = Event.objects.create(
-            community=self.community,
-            date=timezone.localdate(),
+        today_event = make_event(
+            self.community,
+            event_date=timezone.localdate(),
             start_time=datetime.time(20, 0),
             duration=60,
+            weekday="",
+            accepts_lt_application=True,
         )
-        EventDetail.objects.create(
-            event=today_event,
+        make_event_detail(
+            today_event,
             detail_type="LT",
             status="approved",
             speaker="リマインド太郎",
@@ -263,17 +259,18 @@ class TweetGeneratorEventTest(TweetGeneratorTestBase):
         _, user_prompt = mock_llm.call_args[0]
         self.assertIn("- 発表: リマインド太郎さん（@reminder_vr）「今日の見どころ」", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
-    def test_generate_daily_reminder_tweet_returns_none_without_approved_details(self, _mock_thread):
+    def test_generate_daily_reminder_tweet_returns_none_without_approved_details(self):
         """approved な LT/SPECIAL がない場合は daily reminder を生成しない"""
-        today_event = Event.objects.create(
-            community=self.community,
-            date=timezone.localdate(),
+        today_event = make_event(
+            self.community,
+            event_date=timezone.localdate(),
             start_time=datetime.time(20, 0),
             duration=60,
+            weekday="",
+            accepts_lt_application=True,
         )
-        EventDetail.objects.create(
-            event=today_event,
+        make_event_detail(
+            today_event,
             detail_type="BLOG",
             status="approved",
             speaker="ブロガー",

--- a/app/twitter/tests/test_generator_prompt.py
+++ b/app/twitter/tests/test_generator_prompt.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from django.test import tag
 
-from event.models import EventDetail
+from tests.factories import make_event_detail
 
 from twitter.tests._auto_tweet_test_base import TweetGeneratorTestBase
 
@@ -48,14 +48,13 @@ class TweetGeneratorPromptTest(TweetGeneratorTestBase):
 
         self.assertIsNone(result)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_sanitize_strips_newlines_in_prompt(self, mock_llm, _mock_thread):
+    def test_sanitize_strips_newlines_in_prompt(self, mock_llm):
         """ユーザー入力の改行・制御文字がサニタイズされてプロンプトに渡される"""
         mock_llm.return_value = "サニタイズテスト"
 
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト\n太郎\r\n",

--- a/app/twitter/tests/test_generator_slide_share.py
+++ b/app/twitter/tests/test_generator_slide_share.py
@@ -5,23 +5,22 @@ from unittest.mock import patch
 
 from django.test import tag
 
-from event.models import EventDetail
+from tests.factories import make_event_detail, make_user
 from twitter.models import TweetQueue
 
-from twitter.tests._auto_tweet_test_base import CustomUser, TweetGeneratorTestBase
+from twitter.tests._auto_tweet_test_base import TweetGeneratorTestBase
 
 @tag('offline_external_api')
 class TweetGeneratorSlideShareTest(TweetGeneratorTestBase):
     """資料共有の告知文生成を検証する。"""
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_slide_share_tweet_with_slide(self, mock_llm, _mock_thread):
+    def test_generate_slide_share_tweet_with_slide(self, mock_llm):
         """スライド共有ツイートが生成される（slide_url のみ）"""
         mock_llm.return_value = "スライド公開しました！"
 
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト太郎",
@@ -47,14 +46,13 @@ class TweetGeneratorSlideShareTest(TweetGeneratorTestBase):
         self.assertIn("スライド", user_prompt)
         self.assertNotIn("動画", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_slide_share_tweet_with_youtube(self, mock_llm, _mock_thread):
+    def test_generate_slide_share_tweet_with_youtube(self, mock_llm):
         """スライド共有ツイートが生成される（youtube_url のみ）"""
         mock_llm.return_value = "動画公開しました！"
 
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト太郎",
@@ -77,14 +75,13 @@ class TweetGeneratorSlideShareTest(TweetGeneratorTestBase):
         self.assertIn("動画", user_prompt)
         self.assertNotIn("スライド", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_slide_share_tweet_with_both(self, mock_llm, _mock_thread):
+    def test_generate_slide_share_tweet_with_both(self, mock_llm):
         """スライド共有ツイートが生成される（slide_url + youtube_url 両方）"""
         mock_llm.return_value = "スライドと動画公開！"
 
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト太郎",
@@ -106,19 +103,18 @@ class TweetGeneratorSlideShareTest(TweetGeneratorTestBase):
         self.assertNotIn("ツイート", user_prompt)
         self.assertIn("スライド・動画", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_slide_share_tweet_includes_applicant_x_account(self, mock_llm, _mock_thread):
+    def test_generate_slide_share_tweet_includes_applicant_x_account(self, mock_llm):
         """スライド共有告知のプロンプトに申請者の X アカウントを含める"""
         mock_llm.return_value = "スライド公開テスト"
-        applicant = CustomUser.objects.create_user(
+        applicant = make_user(
             user_name="slide_speaker",
             email="slide_speaker@example.com",
             password="testpassword",
             x_account="speaker_vr",
         )
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト太郎",
@@ -135,13 +131,12 @@ class TweetGeneratorSlideShareTest(TweetGeneratorTestBase):
         self.assertIn("発表者: テスト太郎さん（@speaker_vr）", user_prompt)
         self.assertIn("発表者（「テスト太郎さん（@speaker_vr）」をそのまま記載）", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_generate_slide_share_tweet_uses_name_only_without_applicant_x_account(self, mock_llm, _mock_thread):
+    def test_generate_slide_share_tweet_uses_name_only_without_applicant_x_account(self, mock_llm):
         """申請者や X アカウントがないスライド告知は従来どおり名前だけを使う"""
         mock_llm.return_value = "スライド公開テスト"
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト太郎",
@@ -157,19 +152,18 @@ class TweetGeneratorSlideShareTest(TweetGeneratorTestBase):
         self.assertIn("発表者: テスト太郎さん", user_prompt)
         self.assertNotIn("@", user_prompt)
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
     @patch("twitter.tweet_generator._call_llm")
-    def test_slide_share_generator_fallback_includes_applicant_x_account(self, mock_llm, _mock_thread):
+    def test_slide_share_generator_fallback_includes_applicant_x_account(self, mock_llm):
         """LLM 生成失敗時のスライド共有 fallback に申請者の X アカウントを含める"""
         mock_llm.return_value = "\n".join(["長い本文"] * 20)
-        applicant = CustomUser.objects.create_user(
+        applicant = make_user(
             user_name="slide_fallback_speaker",
             email="slide_fallback_speaker@example.com",
             password="testpassword",
             x_account="fallback_vr",
         )
-        detail = EventDetail.objects.create(
-            event=self.event,
+        detail = make_event_detail(
+            self.event,
             detail_type="LT",
             status="approved",
             speaker="テスト太郎",

--- a/app/twitter/tests/test_scheduled_dispatch.py
+++ b/app/twitter/tests/test_scheduled_dispatch.py
@@ -214,11 +214,8 @@ class PostScheduledTweetsViewTest(AutoTweetTestBase):
         self.assertEqual(queue.generated_text, "")
         mock_post.assert_not_called()
 
-    @patch("twitter.services.tweet_generation.threading.Thread")
-    def test_post_scheduled_tweets_ignores_non_approved_or_non_lt_details(self, mock_thread_cls):
+    def test_post_scheduled_tweets_ignores_non_approved_or_non_lt_details(self):
         """approved な LT/SPECIAL がなくてもスケジューラは新規キューを作らない"""
-        mock_thread_cls.return_value = MagicMock()
-
         pending_event = Event.objects.create(
             community=self.community,
             date=timezone.localdate(),
@@ -259,11 +256,8 @@ class PostScheduledTweetsViewTest(AutoTweetTestBase):
         self.assertFalse(TweetQueue.objects.filter(tweet_type="daily_reminder").exists())
 
     @patch("twitter.views.post_tweet")
-    @patch("twitter.services.tweet_generation.threading.Thread")
-    def test_post_scheduled_tweets_does_not_create_missing_daily_reminder(self, mock_thread_cls, mock_post):
+    def test_post_scheduled_tweets_does_not_create_missing_daily_reminder(self, mock_post):
         """daily_reminder が未作成ならスケジューラは補完作成しない"""
-        mock_thread_cls.return_value = MagicMock()
-
         today_event = Event.objects.create(
             community=self.community,
             date=timezone.localdate(),

--- a/app/twitter/tests/test_x_api.py
+++ b/app/twitter/tests/test_x_api.py
@@ -164,8 +164,13 @@ class UploadMediaErrorHandlingTest(TestCase):
         mock_post_response.raise_for_status.side_effect = requests.HTTPError(response=mock_post_response)
         mock_post.return_value = mock_post_response
 
-        result = upload_media("https://data.vrc-ta-hub.com/x.png")
+        with self.assertLogs("twitter.x_api", level="ERROR") as log_context:
+            result = upload_media("https://data.vrc-ta-hub.com/x.png")
+
         self.assertIsNone(result)
+        combined_logs = "\n".join(log_context.output)
+        self.assertIn("401", combined_logs)
+        self.assertIn('"code":89', combined_logs)
 
     @patch.dict("os.environ", {
         "X_API_KEY": "",
@@ -232,6 +237,7 @@ class PostTweetSuccessPathTest(TestCase):
         result = post_tweet("hello")
         self.assertTrue(result["ok"])
         self.assertEqual(result["data"]["id"], "999")
+        self.assertIsNotNone(mock_post.call_args.kwargs["auth"])
 
     @patch.dict("os.environ", VALID_CREDS_ENV, clear=False)
     @patch("twitter.x_api.validate_tweet_text", return_value=[])
@@ -397,7 +403,12 @@ class PostTweetErrorHandlingTest(TestCase):
         http_error = requests.HTTPError(response=err_response)
         mock_post.side_effect = http_error
 
-        result = post_tweet("hello")
+        with self.assertLogs("twitter.x_api", level="ERROR") as log_context:
+            result = post_tweet("hello")
+
         self.assertFalse(result["ok"])
         self.assertEqual(result["status_code"], 429)
         self.assertIn("Rate limit", result["error_body"])
+        combined_logs = "\n".join(log_context.output)
+        self.assertIn("429", combined_logs)
+        self.assertIn("Rate limit", combined_logs)

--- a/app/twitter/tests/test_x_api_functions.py
+++ b/app/twitter/tests/test_x_api_functions.py
@@ -1,12 +1,14 @@
-"""X API投稿と画像アップロードのテスト。"""
+"""X API正本テストにない認証・SSRF・サイズ境界のテスト。"""
 
 from unittest.mock import MagicMock, patch
+
+import requests
 from django.test import TestCase, tag
 
 
 @tag('offline_external_api')
 class PostTweetFunctionTest(TestCase):
-    """X API 投稿関数の単体テスト（OAuth 1.0a）"""
+    """投稿前の認証・重み付き文字数検証を補完する。"""
 
     OAUTH1_ENV = {
         "X_API_KEY": "test-api-key",
@@ -16,97 +18,8 @@ class PostTweetFunctionTest(TestCase):
         "X_API_ALLOW_TEST_CALLS": "1",
     }
 
-    @patch("twitter.x_api.requests.post")
-    def test_post_tweet_success(self, mock_post):
-        """正常にツイートが投稿される"""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "data": {"id": "12345", "text": "テストツイート"},
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
-
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import post_tweet
-            result = post_tweet("テストツイート")
-
-        self.assertTrue(result["ok"])
-        self.assertEqual(result["data"]["id"], "12345")
-
-        # OAuth1 認証が使われていることを確認
-        call_kwargs = mock_post.call_args
-        self.assertIsNotNone(call_kwargs.kwargs.get("auth"))
-
-    @patch("twitter.x_api.requests.post")
-    def test_post_tweet_with_media_ids(self, mock_post):
-        """media_ids 付きでツイートが投稿される"""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "data": {"id": "12345", "text": "画像付き"},
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
-
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import post_tweet
-            result = post_tweet("画像付き", media_ids=["media_111"])
-
-        self.assertTrue(result["ok"])
-        # payload に media フィールドが含まれている
-        call_kwargs = mock_post.call_args
-        payload = call_kwargs.kwargs.get("json")
-        self.assertEqual(payload["media"], {"media_ids": ["media_111"]})
-
-    def test_post_tweet_no_credentials(self):
-        """環境変数が未設定の場合は ok=False を返す"""
-        with patch.dict("os.environ", {
-            "X_API_KEY": "",
-            "X_API_SECRET": "",
-            "X_ACCESS_TOKEN": "",
-            "X_ACCESS_TOKEN_SECRET": "",
-        }):
-            from twitter.x_api import post_tweet
-            result = post_tweet("テスト")
-        self.assertFalse(result["ok"])
-        self.assertIsNone(result["data"])
-
-    @patch("twitter.x_api.requests.post")
-    def test_post_tweet_api_error(self, mock_post):
-        """API エラー時は ok=False を返す"""
-        import requests
-
-        mock_post.side_effect = requests.RequestException("API Error")
-
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import post_tweet
-            result = post_tweet("テスト")
-        self.assertFalse(result["ok"])
-
-    @patch("twitter.x_api.requests.post")
-    def test_post_tweet_api_error_with_response(self, mock_post):
-        """API エラー時にレスポンスがある場合は status_code/error_body を返す"""
-        import requests
-
-        mock_response = MagicMock()
-        mock_response.status_code = 403
-        mock_response.text = '{"detail": "You are not permitted to perform this action."}'
-        error = requests.RequestException("Forbidden")
-        error.response = mock_response
-        mock_post.side_effect = error
-
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import post_tweet
-            with self.assertLogs("twitter.x_api", level="ERROR") as log_ctx:
-                result = post_tweet("テスト")
-        self.assertFalse(result["ok"])
-        self.assertEqual(result["status_code"], 403)
-        self.assertIn("not permitted", result["error_body"])
-        combined = "\n".join(log_ctx.output)
-        self.assertIn("403", combined)
-        self.assertIn("not permitted", combined)
-
     def test_post_tweet_missing_partial_credentials(self):
-        """一部の認証情報だけ設定されている場合は ok=False を返す"""
+        """一部の認証情報だけ設定されている場合は ok=False を返す。"""
         with patch.dict("os.environ", {
             "X_API_KEY": "key",
             "X_API_SECRET": "secret",
@@ -114,14 +27,17 @@ class PostTweetFunctionTest(TestCase):
             "X_ACCESS_TOKEN_SECRET": "",
         }):
             from twitter.x_api import post_tweet
+
             result = post_tweet("テスト")
+
         self.assertFalse(result["ok"])
 
     @patch("twitter.x_api.requests.post")
     def test_post_tweet_rejects_weighted_length_before_api_call(self, mock_post):
-        """Python の len が280以内でも重み付き超過なら X API を呼ばない"""
+        """重み付き文字数が超過する投稿は X API を呼ばない。"""
         with patch.dict("os.environ", self.OAUTH1_ENV):
             from twitter.x_api import post_tweet
+
             result = post_tweet("あ" * 141)
 
         self.assertFalse(result["ok"])
@@ -131,7 +47,7 @@ class PostTweetFunctionTest(TestCase):
 
 @tag('offline_external_api')
 class UploadMediaFunctionTest(TestCase):
-    """upload_media 関数のテスト"""
+    """正本テストと重複しない画像アップロード境界を補完する。"""
 
     OAUTH1_ENV = {
         "X_API_KEY": "test-api-key",
@@ -142,8 +58,9 @@ class UploadMediaFunctionTest(TestCase):
     }
     ALLOWED_IMAGE_URL = "https://data.vrc-ta-hub.com/community/1/poster.webp"
 
-    def _make_stream_response(self, data=None, content_type="image/webp"):
-        """stream=True のレスポンスモックを生成するヘルパー"""
+    @staticmethod
+    def _make_stream_response(data=None, content_type="image/webp"):
+        """stream=True のレスポンスモックを返す。"""
         if data is None:
             data = b"RIFF\x04\x00\x00\x00WEBP"
         mock_response = MagicMock()
@@ -154,165 +71,62 @@ class UploadMediaFunctionTest(TestCase):
 
     @patch("twitter.x_api.requests.post")
     @patch("twitter.x_api.requests.get")
-    def test_upload_media_success(self, mock_get, mock_post):
-        """正常に画像がアップロードされる"""
-        mock_get.return_value = self._make_stream_response()
-
-        # メディアアップロードのモック
-        mock_upload_response = MagicMock()
-        mock_upload_response.json.return_value = {"media_id_string": "media_12345"}
-        mock_upload_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_upload_response
-
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import upload_media
-            result = upload_media(self.ALLOWED_IMAGE_URL)
-
-        self.assertEqual(result, "media_12345")
-
-    @patch("twitter.x_api.requests.get")
-    def test_upload_media_download_failure(self, mock_get):
-        """画像ダウンロード失敗時は None を返す"""
-        import requests
-
-        mock_get.side_effect = requests.RequestException("Download failed")
-
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import upload_media
-            result = upload_media(self.ALLOWED_IMAGE_URL)
-
-        self.assertIsNone(result)
-
-    def test_upload_media_no_credentials(self):
-        """認証情報がない場合は None を返す"""
-        with patch.dict("os.environ", {
-            "X_API_KEY": "",
-            "X_API_SECRET": "",
-            "X_ACCESS_TOKEN": "",
-            "X_ACCESS_TOKEN_SECRET": "",
-        }):
-            from twitter.x_api import upload_media
-            result = upload_media(self.ALLOWED_IMAGE_URL)
-        self.assertIsNone(result)
-
-    @patch("twitter.x_api.requests.post")
-    @patch("twitter.x_api.requests.get")
     def test_upload_media_upload_failure(self, mock_get, mock_post):
-        """X API へのアップロード失敗時は None を返す"""
-        import requests
-
+        """レスポンスを伴わないアップロード失敗は None を返す。"""
         mock_get.return_value = self._make_stream_response(content_type="image/png")
         mock_post.side_effect = requests.RequestException("Upload failed")
 
         with patch.dict("os.environ", self.OAUTH1_ENV):
             from twitter.x_api import upload_media
+
             result = upload_media(self.ALLOWED_IMAGE_URL)
 
         self.assertIsNone(result)
 
-    @patch("twitter.x_api.requests.post")
-    @patch("twitter.x_api.requests.get")
-    def test_upload_media_upload_failure_with_response(self, mock_get, mock_post):
-        """X API アップロード失敗時にレスポンスがある場合はステータスとボディをログ出力する"""
-        import requests
-
-        mock_get.return_value = self._make_stream_response(content_type="image/png")
-        mock_response = MagicMock()
-        mock_response.status_code = 403
-        mock_response.text = '{"errors": [{"message": "media type not allowed"}]}'
-        error = requests.RequestException("Forbidden")
-        error.response = mock_response
-        mock_post.side_effect = error
-
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import upload_media
-            with self.assertLogs("twitter.x_api", level="ERROR") as log_ctx:
-                result = upload_media(self.ALLOWED_IMAGE_URL)
-
-        self.assertIsNone(result)
-        combined = "\n".join(log_ctx.output)
-        self.assertIn("403", combined)
-        self.assertIn("media type not allowed", combined)
-
-    # --- SSRF防止テスト ---
-    def test_upload_media_blocks_untrusted_domain(self):
-        """許可リストにないドメインからの画像ダウンロードを拒否する"""
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import upload_media
-            result = upload_media("https://evil.example.com/malicious.png")
-        self.assertIsNone(result)
-
     def test_upload_media_blocks_localhost(self):
-        """localhost からの画像ダウンロードを拒否する"""
+        """localhost からの画像ダウンロードを拒否する。"""
         with patch.dict("os.environ", self.OAUTH1_ENV):
             from twitter.x_api import upload_media
+
             result = upload_media("http://localhost:8080/internal-api")
+
         self.assertIsNone(result)
 
     def test_upload_media_blocks_internal_ip(self):
-        """内部IPアドレスからの画像ダウンロードを拒否する"""
+        """内部IPアドレスからの画像ダウンロードを拒否する。"""
         with patch.dict("os.environ", self.OAUTH1_ENV):
             from twitter.x_api import upload_media
+
             result = upload_media("http://169.254.169.254/latest/meta-data/")
+
         self.assertIsNone(result)
-
-    @patch("twitter.x_api.requests.post")
-    @patch("twitter.x_api.requests.get")
-    def test_upload_media_allows_trusted_domain(self, mock_get, mock_post):
-        """許可ドメインからのダウンロードは成功する"""
-        mock_get.return_value = self._make_stream_response()
-
-        mock_upload_response = MagicMock()
-        mock_upload_response.json.return_value = {"media_id_string": "media_ok"}
-        mock_upload_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_upload_response
-
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import upload_media
-            result = upload_media("https://data.vrc-ta-hub.com/poster.webp")
-
-        self.assertEqual(result, "media_ok")
 
     @patch("twitter.x_api.requests.post")
     @patch("twitter.x_api.requests.get")
     def test_upload_media_allows_cf_transform_url(self, mock_get, mock_post):
-        """CF Image Resizing URL も許可ドメインとして通過する"""
+        """CF Image Resizing URL も許可ドメインとして通過する。"""
         mock_get.return_value = self._make_stream_response()
         mock_upload_response = MagicMock()
         mock_upload_response.json.return_value = {"media_id_string": "media_cf"}
         mock_upload_response.raise_for_status = MagicMock()
         mock_post.return_value = mock_upload_response
-
         cf_url = (
             "https://data.vrc-ta-hub.com/cdn-cgi/image/"
             "width=960,quality=80,format=auto/community/1/poster.webp"
         )
+
         with patch.dict("os.environ", self.OAUTH1_ENV):
             from twitter.x_api import upload_media
+
             result = upload_media(cf_url)
 
         self.assertEqual(result, "media_cf")
 
-    # --- サイズ制限テスト ---
-    @patch("twitter.x_api.requests.get")
-    def test_upload_media_rejects_oversized_image(self, mock_get):
-        """5MB超の画像は拒否される"""
-        # 6MB のチャンクを返すモック
-        oversized_data = b"x" * (6 * 1024 * 1024)
-        mock_get.return_value = self._make_stream_response(data=oversized_data)
-
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import upload_media
-            result = upload_media(self.ALLOWED_IMAGE_URL)
-
-        self.assertIsNone(result)
-
     @patch("twitter.x_api.requests.get")
     def test_upload_media_rejects_oversized_chunked_image(self, mock_get):
-        """複数チャンクで合計5MB超の場合も拒否される"""
-        chunk_size = 1024 * 1024  # 1MB per chunk
-        chunks = [b"x" * chunk_size for _ in range(6)]  # 6MB total
-
+        """複数チャンクの合計が5MBを超える画像を拒否する。"""
+        chunk_size = 1024 * 1024
+        chunks = [b"x" * chunk_size for _ in range(6)]
         mock_response = MagicMock()
         mock_response.headers = {"Content-Type": "image/png"}
         mock_response.raise_for_status = MagicMock()
@@ -321,24 +135,7 @@ class UploadMediaFunctionTest(TestCase):
 
         with patch.dict("os.environ", self.OAUTH1_ENV):
             from twitter.x_api import upload_media
+
             result = upload_media(self.ALLOWED_IMAGE_URL)
 
         self.assertIsNone(result)
-
-    @patch("twitter.x_api.requests.post")
-    @patch("twitter.x_api.requests.get")
-    def test_upload_media_accepts_exactly_5mb(self, mock_get, mock_post):
-        """ちょうど5MBの画像は受け入れられる"""
-        exactly_5mb = b"\x89PNG\r\n\x1a\n" + b"x" * (5 * 1024 * 1024 - 8)
-        mock_get.return_value = self._make_stream_response(data=exactly_5mb)
-
-        mock_upload_response = MagicMock()
-        mock_upload_response.json.return_value = {"media_id_string": "media_5mb"}
-        mock_upload_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_upload_response
-
-        with patch.dict("os.environ", self.OAUTH1_ENV):
-            from twitter.x_api import upload_media
-            result = upload_media(self.ALLOWED_IMAGE_URL)
-
-        self.assertEqual(result, "media_5mb")

--- a/app/vket/tests/_vket_test_bases.py
+++ b/app/vket/tests/_vket_test_bases.py
@@ -2,45 +2,38 @@
 
 from datetime import timedelta
 
-from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.test import Client, TestCase
 from django.utils import timezone
 
-from community.models import Community, CommunityMember
-from event.models import Event
+from community.models import CommunityMember
+from tests.factories import make_community, make_event, make_user
 from vket.models import (
     VketCollaboration,
     VketParticipation,
 )
 
-
-User = get_user_model()
-
-
 class VketApplyFlowBase(TestCase):
     def setUp(self):
         self.client = Client()
-        self.owner = User.objects.create_user(
+        self.owner = make_user(
             user_name='owner_user',
             email='owner@example.com',
             password='testpass123',
         )
-        self.other_user = User.objects.create_user(
+        self.other_user = make_user(
             user_name='other_user',
             email='other@example.com',
             password='testpass123',
         )
 
-        self.community = Community.objects.create(
+        self.community = make_community(
             name='個人開発集会',
+            owner=self.owner,
             status='approved',
             frequency='毎週',
-        )
-        CommunityMember.objects.create(
-            community=self.community,
-            user=self.owner,
-            role=CommunityMember.Role.OWNER,
+            weekdays=[],
+            organizers='',
         )
         CommunityMember.objects.create(
             community=self.community,
@@ -60,11 +53,13 @@ class VketApplyFlowBase(TestCase):
         )
 
         # 日付選択肢の元になるイベントを作成
-        Event.objects.create(
-            community=self.community,
-            date=today,
+        make_event(
+            self.community,
+            event_date=today,
             start_time='22:00',
             duration=60,
+            weekday='',
+            accepts_lt_application=True,
         )
 
     def _set_active_community(self):
@@ -95,26 +90,32 @@ class VketManageViewsBase(TestCase):
     def setUp(self):
         self.client = Client()
         cache.clear()
-        self.superuser = User.objects.create_superuser(
+        self.superuser = make_user(
             user_name='admin_user',
             email='admin@example.com',
             password='adminpass123',
+            is_staff=True,
+            is_superuser=True,
         )
-        self.normal_user = User.objects.create_user(
+        self.normal_user = make_user(
             user_name='normal_user',
             email='normal@example.com',
             password='testpass123',
         )
 
-        self.community1 = Community.objects.create(
+        self.community1 = make_community(
             name='集会A',
             status='approved',
             frequency='毎週',
+            weekdays=[],
+            organizers='',
         )
-        self.community2 = Community.objects.create(
+        self.community2 = make_community(
             name='集会B',
             status='approved',
             frequency='毎週',
+            weekdays=[],
+            organizers='',
         )
 
         today = timezone.localdate()
@@ -129,19 +130,21 @@ class VketManageViewsBase(TestCase):
         )
 
         # 公開済みイベント（published_event）を使う
-        self.event1 = Event.objects.create(
-            community=self.community1,
-            date=today,
+        self.event1 = make_event(
+            self.community1,
+            event_date=today,
             start_time='21:00',
             duration=60,
             weekday='Tue',
+            accepts_lt_application=True,
         )
-        self.event2 = Event.objects.create(
-            community=self.community2,
-            date=today,
+        self.event2 = make_event(
+            self.community2,
+            event_date=today,
             start_time='21:30',
             duration=60,
             weekday='Tue',
+            accepts_lt_application=True,
         )
 
         self.participation1 = VketParticipation.objects.create(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -216,6 +216,14 @@ User / Community / Event / EventDetail を `setUp` で毎回手書きする重�
 | `make_event(...)` | Event。`event_date` 未指定で `today + 7 days`（未来イベント） |
 | `make_event_detail(...)` | EventDetail。`start_time` 未指定で親 event の `start_time` を引き継ぐ |
 
+### 直接生成件数の ratchet
+
+共有 factory 外の直接生成は、Community 258件、CustomUser 119件、Event 160件、
+EventDetail 157件、User 107件（合計801件）を exact snapshot として固定する。
+増加・減少のどちらでも意図を確認し、移行内容に合わせて snapshot を更新する。
+集計対象は canonical model の明示 import（直接・alias・module・相対 import と
+`get_user_model`）に限り、プロジェクト内 module からの re-export は対象外とする。
+
 ### 使用例
 
 ```python


### PR DESCRIPTION
## 概要

Issue #539 の最終waveとして、共通factoryへの移行、過剰なThread patchの撤去、X API重複テストの統合、直接生成件数のratchetを追加します。

## 変更

- core fixtureの直接生成を 839件 → 801件に削減
- `@patch` を 411件 → 378件に削減（signal/thread経路に必要なpatchは維持）
- X APIの重複テスト13件を削除し、OAuth・SSRF・5MB境界・HTTP error/logの固有assertは正本側へ維持
- 5モデルの直接生成件数をモデル別exact snapshotで固定
- canonical明示importのみを集計し、project re-exportは非対応とする契約をテスト・docsへ記載

## 検証

- 全offline: 2,013 passed / 4 skipped
- ratchet: 5 passed
- ruff: passed
- mypy: passed
- file-size-guard: helper 440行 / test 174行（閾値内）
- git diff --check: passed
- code/security/architecture review: blocker 0

Refs #539