### PR TITLE
feat(account): 8月3日のログイン方法変更を告知する

### DIFF
--- a/app/user_account/templates/account/login.html
+++ b/app/user_account/templates/account/login.html
@@ -25,6 +25,27 @@
                     <div class="card-body">
                         {% include 'ta_hub/messages.html' %}
                         {% discord_oauth_available as discord_oauth_enabled %}
+
+                        <div class="alert alert-warning" role="alert">
+                            <div class="d-flex align-items-start">
+                                <i class="bi bi-exclamation-triangle-fill me-2 mt-1" aria-hidden="true"></i>
+                                <div>
+                                    <h5 class="alert-heading mb-2">【重要】ログイン方法変更のお知らせ</h5>
+                                    <p class="mb-2">
+                                        <strong>2026年8月3日以降、ユーザー名でのログインを廃止します。</strong>
+                                    </p>
+                                    <p class="mb-2">
+                                        今後は、<strong>メールアドレス</strong>または<strong>Discord連携</strong>でログインしてください。
+                                    </p>
+                                    <p class="mb-0">
+                                        現在ユーザー名でログインしている方は、<strong>8月3日までに</strong>、ログイン後の
+                                        <a href="{% url 'account:settings' %}" class="alert-link">アカウント設定</a>から
+                                        Discord連携またはメールアドレスの登録をお願いします。
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
                         {% if discord_oauth_enabled %}
                         <div class="text-center my-5">
                             <a href="{% provider_login_url 'discord' %}" class="btn btn-lg" style="background-color: #5865F2; color: white;">

--- a/app/user_account/tests/test_login_method_change_notice.py
+++ b/app/user_account/tests/test_login_method_change_notice.py
@@ -1,0 +1,20 @@
+"""ログイン方法変更告知の表示テスト."""
+
+from django.test import TestCase, tag
+from django.urls import reverse
+
+
+@tag("offline_external_api")
+class LoginMethodChangeNoticeTests(TestCase):
+    """ログインページに期限と必要な対応が表示されることを保証する."""
+
+    def test_login_page_shows_login_method_change_notice(self):
+        response = self.client.get(reverse("account:login"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "【重要】ログイン方法変更のお知らせ")
+        self.assertContains(response, "2026年8月3日以降、ユーザー名でのログインを廃止します。")
+        self.assertContains(response, "メールアドレス")
+        self.assertContains(response, "Discord連携")
+        self.assertContains(response, "8月3日までに")
+        self.assertContains(response, f'href="{reverse("account:settings")}"')


### PR DESCRIPTION
## 変更内容

- ログイン画面に「ログイン方法変更のお知らせ」を追加
- 2026年8月3日以降はユーザー名ログインを廃止することを明記
- 8月3日までにメールアドレス登録またはDiscord連携を行うよう案内
- アカウント設定への導線を追加
- 告知の主要文言と設定画面リンクを検証するテストを追加

## 目的

ユーザー名ログイン廃止後にログインできなくなる利用者を減らし、変更前に代替ログイン方法の登録を促すためです。

## 確認

- テンプレートと差分を目視確認済み
- テストはCIで確認予定