### PR TITLE
docs(vket): 発表見出しをイベント詳細へのリンクに変更

### DIFF
--- a/docs/giga-week-2026-summer/draft-article.md
+++ b/docs/giga-week-2026-summer/draft-article.md
@@ -8,85 +8,67 @@
 
 ## 7月11日（土）20:00 - セキュリティ集会
 
-### VRChatにおけるリッピング対策の現実
+### [VRChatにおけるリッピング対策の現実](/event/detail/790/)
 
 登壇者: soisinaさん
 
-[イベント詳細](/event/detail/790/)
-
 https://youtu.be/DfkgPwoiJMk
 
-### AI駆動バグハント入門
+### [AI駆動バグハント入門](/event/detail/789/)
 
 登壇者: kumama_nuiさん
-
-[イベント詳細](/event/detail/789/)
 
 https://youtu.be/GKF7kAxCc6o
 
 ## 7月11日（土）21:00 - VRC通信工学集会
 
-### VRChatを支える通信技術　〜なぜリアルタイム通信できるのか〜
+### [VRChatを支える通信技術　〜なぜリアルタイム通信できるのか〜](/event/detail/774/)
 
 登壇者: Yudofu_185さん
-
-[イベント詳細](/event/detail/774/)
 
 https://youtu.be/imawrD-X1mI
 
 ## 7月11日（土）23:00 - バックエンド集会
 
-### WebRTCこねこねしたい
+### [WebRTCこねこねしたい](/event/detail/825/)
 
 登壇者: かるだんさん
-
-[イベント詳細](/event/detail/825/)
 
 https://youtu.be/ZQ9SMavU3hk
 
 ## 7月12日（日）21:00 - ITエンジニア キャリア相談・雑談集会
 
-### 会社選びと企業文化
+### [会社選びと企業文化](/event/detail/791/)
 
 登壇者: KAGU3さん
-
-[イベント詳細](/event/detail/791/)
 
 https://youtu.be/56RLcCT3xFg
 
 ## 7月13日（月）22:00 - VR酔い訓練集会
 
-### VR酔い
+### [VR酔い](/event/detail/792/)
 
 登壇者: 法月ロイさん
-
-[イベント詳細](/event/detail/792/)
 
 https://youtu.be/FHw2O3_fRf0
 
 ## 7月14日（火）21:00 - CS集会
 
-### 秋葉原に行けなくても大丈夫、秋月の通販でZ80を作ろう
+### [秋葉原に行けなくても大丈夫、秋月の通販でZ80を作ろう](/event/detail/793/)
 
 登壇者: 夜鍋ヨナさん
 
-[イベント詳細](/event/detail/793/)
-
 https://youtu.be/wsWcBboqce0
 
-### 令和に取り残されたPC-9800と機械語プログラミング
+### [令和に取り残されたPC-9800と機械語プログラミング](/event/detail/794/)
 
 登壇者: KusaReMKNさん
 
-[イベント詳細](/event/detail/794/)
-
 https://youtu.be/WLLYs9Sod8g
 
-### 定数除数整数除算の高速化
+### [定数除数整数除算の高速化](/event/detail/795/)
 
 登壇者: Mizarさん
-
-[イベント詳細](/event/detail/795/)
 
 https://youtu.be/810mI62iPRM
 
@@ -94,329 +76,255 @@ https://youtu.be/810mI62iPRM
 
 https://www.youtube.com/watch?v=Vp1-lFuq0NM
 
-### 四元数による姿勢制御と被覆空間
+### [四元数による姿勢制御と被覆空間](/event/detail/682/)
 
 登壇者: Metachick-2021さん
 
-[イベント詳細](/event/detail/682/)
-
-### ジンバルロックの裏にある数学
+### [ジンバルロックの裏にある数学](/event/detail/683/)
 
 登壇者: eda.beansさん
 
-[イベント詳細](/event/detail/683/)
-
 ## 7月16日（木）21:00 - 組み込みエンジニア集会
 
-### RaspberryPi Picoの表現力の拡張～アナログコンピュータとの出会い～
+### [RaspberryPi Picoの表現力の拡張～アナログコンピュータとの出会い～](/event/detail/786/)
 
 登壇者: すぎうりさん
 
-[イベント詳細](/event/detail/786/)
-
 https://youtu.be/zV6PhhC9SZ8
 
-### 3Dスキャンを使ってロボットを動かしてみた話
+### [3Dスキャンを使ってロボットを動かしてみた話](/event/detail/777/)
 
 登壇者: sezaki_aoiさん
-
-[イベント詳細](/event/detail/777/)
 
 https://youtu.be/g2YFrbzrMOs
 
 ## 7月16日（木）22:00 - 個人開発集会
 
-### 次の覇権を取れる言語!? Gleamのすすめ
+### [次の覇権を取れる言語!? Gleamのすすめ](/event/detail/826/)
 
 登壇者: neverClearさん
-
-[イベント詳細](/event/detail/826/)
 
 https://youtu.be/QDF23i7C324
 
 ## 7月17日（金）22:00 - VRC微分音集会
 
-### 徹底解剖！31平均律
+### [徹底解剖！31平均律](/event/detail/759/)
 
 登壇者: MisohitoNakaiさん、らいある_Liarlさん、渡月 太陽さん、takunnmaさん
-
-[イベント詳細](/event/detail/759/)
 
 https://youtu.be/i_7B3k94hYE
 
 ## 7月18日（土）22:00 - ITインフラ集会
 
-### マルチインスタンスライブを支えるインフラ設計 1000人超規模のイベント開催を見据えたインフラを考える
+### [マルチインスタンスライブを支えるインフラ設計 1000人超規模のイベント開催を見据えたインフラを考える](/event/detail/779/)
 
 登壇者: やっさんさん
-
-[イベント詳細](/event/detail/779/)
 
 https://youtu.be/6m6kh-y-DuM
 
 ## 7月18日（土）22:30 - 「計算と自然」集会
 
-### LLM呼び出しの自動化のためのペトリネットワークフローとプライバシーレベルを考慮した知識共有の枠組み
+### [LLM呼び出しの自動化のためのペトリネットワークフローとプライバシーレベルを考慮した知識共有の枠組み](/event/detail/787/)
 
 登壇者: nconcさん
-
-[イベント詳細](/event/detail/787/)
 
 https://youtu.be/SwwZMjURrq4
 
 ## 7月19日（日）21:00 - VR核融合コミュニティ Virtual Fusion Nexus
 
-### 核融合エネルギーはどこから生まれ、どこへ向かうのか
+### [核融合エネルギーはどこから生まれ、どこへ向かうのか](/event/detail/783/)
 
 登壇者: トリカさん
 
-[イベント詳細](/event/detail/783/)
-
 https://youtu.be/A5VuMiigGQU
 
-### 日本の核融合原型炉の研究開発計画 - 2030年代の早期発電実証を目指して-
+### [日本の核融合原型炉の研究開発計画 - 2030年代の早期発電実証を目指して-](/event/detail/784/)
 
 登壇者: Hakoyanさん
 
-[イベント詳細](/event/detail/784/)
-
 https://youtu.be/b8qzyJq8Pqk
 
-### 核融合装置の遠隔保守と各国のR&D
+### [核融合装置の遠隔保守と各国のR&D](/event/detail/785/)
 
 登壇者: IWMTTさん
-
-[イベント詳細](/event/detail/785/)
 
 https://youtu.be/EP-C517PHq8
 
 ## 7月19日（日）22:00 - VRC脳波技術集会
 
-### ふじゅ～システムを作った話
+### [ふじゅ～システムを作った話](/event/detail/716/)
 
 登壇者: Spis（スピス）さん
-
-[イベント詳細](/event/detail/716/)
 
 https://youtu.be/t2HkStzm8sE
 
 ## 7月20日（月）22:00 - 化学のおはなし会
 
-### 「ニトロ」はなぜ爆発するのか
+### [「ニトロ」はなぜ爆発するのか](/event/detail/798/)
 
 登壇者: ねろねさん
-
-[イベント詳細](/event/detail/798/)
 
 https://youtu.be/sQlwlT8_8V0
 
 ## 7月20日（月）22:30 - SW_Arch ソフトウェアアーキテクチャ集会
 
-### アーキテクチャ雑談議
+### [アーキテクチャ雑談議](/event/detail/799/)
 
 登壇者: ありあなさん、somnicatさん
-
-[イベント詳細](/event/detail/799/)
 
 https://youtu.be/vL_vHaGFXeo
 
 ## 7月21日（火）21:00 - C# Tokyo VRもくもく会
 
-### ローカルで動くAIの今後の姿を試してみる MXCでOpenClaw保護・Aion Instructの用途
+### [ローカルで動くAIの今後の姿を試してみる MXCでOpenClaw保護・Aion Instructの用途](/event/detail/800/)
 
 登壇者: suusanex（須藤）さん
 
-[イベント詳細](/event/detail/800/)
-
 https://youtu.be/x9_QFHbgICE
 
-### C# Tokyo コミュニティ YouTube チャンネルを支える技術
+### [C# Tokyo コミュニティ YouTube チャンネルを支える技術](/event/detail/801/)
 
 登壇者: mishizakiさん
-
-[イベント詳細](/event/detail/801/)
 
 https://youtu.be/UHuvT2m7LiE
 
 ## 7月21日（火）22:00 - VRChat.rb
 
-### VRChat.rbの野望
+### [VRChat.rbの野望](/event/detail/802/)
 
 登壇者: いとじゅんさん
 
-[イベント詳細](/event/detail/802/)
-
 https://youtu.be/7loH512r5Ig
 
-### Rubyは高級な電卓
+### [Rubyは高級な電卓](/event/detail/829/)
 
 登壇者: skytomoさん
 
-[イベント詳細](/event/detail/829/)
-
 https://youtu.be/SWTVRiZUiRo
 
-### RubyでDiscordBotつくってみた
+### [RubyでDiscordBotつくってみた](/event/detail/803/)
 
 登壇者: 慕狼ゆにさん
 
-[イベント詳細](/event/detail/803/)
-
 https://youtu.be/Wnkpna_NCtk
 
-### 非Rubyエンジニア、Rubyistの集いに潜入
+### [非Rubyエンジニア、Rubyistの集いに潜入](/event/detail/806/)
 
 登壇者: KAGU3さん
 
-[イベント詳細](/event/detail/806/)
-
 https://youtu.be/I3AMlZzm2_M
 
-### assets:precompileを眺める w/ propshaft
+### [assets:precompileを眺める w/ propshaft](/event/detail/805/)
 
 登壇者: 北亜 - Hokuaさん
 
-[イベント詳細](/event/detail/805/)
-
 https://youtu.be/U-HASeHJHDI
 
-### Rubyのマニアックな機能を10個紹介するよ
+### [Rubyのマニアックな機能を10個紹介するよ](/event/detail/831/)
 
 登壇者: Kirika_K2さん
 
-[イベント詳細](/event/detail/831/)
-
 https://youtu.be/bfmONjhe5EA
 
-### （Fizz)BuzzるRockstarになろう
+### [（Fizz)BuzzるRockstarになろう](/event/detail/830/)
 
 登壇者: kanatanoyuuyakeさん
 
-[イベント詳細](/event/detail/830/)
-
 https://youtu.be/Kwhw7qHwFYQ
 
-### Rubyの演算子風メソッド図鑑
+### [Rubyの演算子風メソッド図鑑](/event/detail/824/)
 
 登壇者: すぎうりさん
 
-[イベント詳細](/event/detail/824/)
-
 https://youtu.be/OGgdZtG39KQ
 
-### Ruby初学者が関西Ruby会議を振り返る
+### [Ruby初学者が関西Ruby会議を振り返る](/event/detail/804/)
 
 登壇者: isoshigiさん
-
-[イベント詳細](/event/detail/804/)
 
 https://youtu.be/ERm_CdDnTSE
 
-### 今川焼、大判焼き、御座候、その他多様な名称があることで知られる食品の名称を適切に取り扱うためのgem imagawayaki util
+### [今川焼、大判焼き、御座候、その他多様な名称があることで知られる食品の名称を適切に取り扱うためのgem imagawayaki util](/event/detail/823/)
 
 登壇者: isoshigiさん
 
-[イベント詳細](/event/detail/823/)
-
 https://youtu.be/-Rqbgw2EdEk
 
-### Ridgepoleの紹介
+### [Ridgepoleの紹介](/event/detail/832/)
 
 登壇者: ito845さん
-
-[イベント詳細](/event/detail/832/)
 
 https://youtu.be/iOFBLIfNqx0
 
 ## 7月22日（水）21:30 - VRC競プロ部(ABC感想会)
 
-### 競プロって何？
+### [競プロって何？](/event/detail/807/)
 
 登壇者: cleanttedさん
 
-[イベント詳細](/event/detail/807/)
-
 https://youtu.be/7TZJ6UARbnM
 
-### 包除原理の数え方
+### [包除原理の数え方](/event/detail/808/)
 
 登壇者: Mizar_みざーさん
 
-[イベント詳細](/event/detail/808/)
-
 https://youtu.be/tBFTP2XT75Q
 
-### FPSで殴る二項係数の畳み込み
+### [FPSで殴る二項係数の畳み込み](/event/detail/809/)
 
 登壇者: seekworser／ぷせうどさん
 
-[イベント詳細](/event/detail/809/)
-
 https://youtu.be/Vdl17fCUsaM
 
-### スマホで始める競技プログラミング (Android 編)
+### [スマホで始める競技プログラミング (Android 編)](/event/detail/810/)
 
 登壇者: りすりす（里水理姿）さん
 
-[イベント詳細](/event/detail/810/)
-
 https://youtu.be/-_KOc31wVtA
 
-### 日常を競プロで爆発させよう～初心者でも作問はできる～
+### [日常を競プロで爆発させよう～初心者でも作問はできる～](/event/detail/811/)
 
 登壇者: あめんばー／りふぉげんさん
-
-[イベント詳細](/event/detail/811/)
 
 https://youtu.be/YoeSzeKSn84
 
 ## 7月23日（木）21:00 - データサイエンティスト集会
 
-### データからみる ぶいちゃ民の習性 -DS集会の活動ふりかえり-
+### [データからみる ぶいちゃ民の習性 -DS集会の活動ふりかえり-](/event/detail/812/)
 
 登壇者: いそひまさん
-
-[イベント詳細](/event/detail/812/)
 
 https://youtu.be/EfoFmMVd6oQ
 
 ## 7月24日（金）21:00 - VRC海洋学研究会
 
-### 海の学問－海洋学－とは？
+### [海の学問－海洋学－とは？](/event/detail/813/)
 
 登壇者: Cramerさん
-
-[イベント詳細](/event/detail/813/)
 
 https://youtu.be/UaoI97x1rgs
 
 ## 7月24日（金）22:00 - 仮想学生集会
 
-### 仮想学生集会って、何？
+### [仮想学生集会って、何？](/event/detail/814/)
 
 登壇者: てりやき定食さん
-
-[イベント詳細](/event/detail/814/)
 
 https://youtu.be/5CW4LqaRkmY
 
 ## 7月25日（土）21:00 - マネジメント集会
 
-### 同人ノベルゲーム作ってみた！Extends ～企画から販売までを動かす『面白そう駆動開発』～
+### [同人ノベルゲーム作ってみた！Extends ～企画から販売までを動かす『面白そう駆動開発』～](/event/detail/815/)
 
 登壇者: wakazu9nさん
-
-[イベント詳細](/event/detail/815/)
 
 https://youtu.be/VWJCk4A46-w
 
 ## 7月27日（月）21:30 - ML集会
 
-### vrcpilot: VRChatにAIアバターを生み出すツール
+### [vrcpilot: VRChatにAIアバターを生み出すツール](/event/detail/796/)
 
 登壇者: GesonAnkoさん
-
-[イベント詳細](/event/detail/796/)
 
 https://youtu.be/w-eQyvRPbZM
 


### PR DESCRIPTION
## なぜこの変更が必要か

公開したVket 2026 Summerアーカイブ記事で、イベント詳細への内部リンクが汎用アンカーテキスト「イベント詳細」46個になっており、SEO上のアンカーテキスト価値がなかった。発表タイトル自体をリンクにすることで、リンク先（イベント詳細ページ）の内容をアンカーテキストが説明する形に改善する（ユーザー指示）。

## 変更内容

- 発表見出し（H3）46件を `### [発表タイトル](/event/detail/N/)` 形式に変更
- 汎用アンカーテキスト「イベント詳細」の行を削除

## 意思決定

### 採用アプローチ
- 見出し自体のリンク化を採用。理由: 発表タイトルがそのままアンカーテキストになり、追加の視覚要素なしでSEOと回遊性を両立できる

### 却下した代替案
- 「イベント詳細」行のアンカーテキストだけ発表タイトルに置換 → 却下: 同じテキストが見出しと連続して重複し冗長

## テスト

- [x] 正規表現一括変換で46件全件を変換（変換数をassertで確認）
- [x] `convert_markdown`で h3内リンク46件・iframe 45件・h3 46件を確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)