### PR TITLE
feat: 発表申請ボタンを未ログインユーザーにも表示する

### DIFF
--- a/app/community/templates/community/detail.html
+++ b/app/community/templates/community/detail.html
@@ -190,7 +190,7 @@
                         </section>
 
                         <!-- 発表申請 -->
-                        {% if request.user.is_authenticated and community.status == 'approved' and community.accepts_lt_application %}
+                        {% if community.status == 'approved' and community.accepts_lt_application %}
                         <section class="mb-4">
                             <h2 class="fs-5 fw-bold mb-3">
                                 <i class="bi bi-mic me-2"></i>発表を申し込む
@@ -200,6 +200,9 @@
                                class="btn btn-success">
                                 <i class="bi bi-plus-circle me-2"></i>発表を申し込む
                             </a>
+                            {% if not request.user.is_authenticated %}
+                                <p class="text-muted small mt-2 mb-0">申請にはログインが必要です（ログイン画面に移動します）</p>
+                            {% endif %}
                         </section>
                         {% endif %}
 

--- a/app/community/tests/test_views.py
+++ b/app/community/tests/test_views.py
@@ -2,7 +2,9 @@ import shutil
 import tempfile
 from datetime import date, timedelta, time
 from pathlib import Path
+from urllib.parse import quote
 
+from django.conf import settings
 from django.http import QueryDict
 from django.db import connection
 from django.test import TestCase, Client, RequestFactory, override_settings
@@ -533,6 +535,8 @@ class CommunityDetailViewBlogSpecialSectionTest(TestCase):
 class CommunityDetailViewLtApplicationSectionTest(TestCase):
     """CommunityDetailViewのLT申請セクション表示テスト"""
 
+    LOGIN_NOTICE = '申請にはログインが必要です'
+
     def setUp(self):
         self.client = Client()
 
@@ -558,25 +562,37 @@ class CommunityDetailViewLtApplicationSectionTest(TestCase):
             role=CommunityMember.Role.OWNER
         )
 
+        self.detail_url = reverse(
+            'community:detail', kwargs={'pk': self.community.pk}
+        )
+        self.apply_url = reverse(
+            'event:lt_application_create',
+            kwargs={'community_pk': self.community.pk},
+        )
+
     def test_lt_section_shown_when_authenticated_and_approved_and_accepts_lt(self):
         """ログイン済み・承認済み・LT受付ONの場合、LT申請セクションが表示される"""
         self.client.login(username='テストユーザー', password='testpass123')
-        response = self.client.get(
-            reverse('community:detail', kwargs={'pk': self.community.pk})
-        )
+        response = self.client.get(self.detail_url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '発表を申し込む')
-        self.assertContains(response, '発表を申し込む')
+        self.assertContains(response, self.apply_url)
 
-    def test_lt_section_not_shown_when_not_authenticated(self):
-        """未ログインの場合、LT申請セクションは表示されない"""
-        response = self.client.get(
-            reverse('community:detail', kwargs={'pk': self.community.pk})
-        )
+    def test_login_notice_not_shown_when_authenticated(self):
+        """ログイン済みの場合、ログインが必要な旨の補足文は表示されない"""
+        self.client.login(username='テストユーザー', password='testpass123')
+        response = self.client.get(self.detail_url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, '発表を申し込む')
+        self.assertNotContains(response, self.LOGIN_NOTICE)
+
+    def test_lt_section_shown_when_not_authenticated(self):
+        """未ログインでも申請導線と補足文が表示される（Issue #569）"""
+        response = self.client.get(self.detail_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.apply_url)
+        self.assertContains(response, self.LOGIN_NOTICE)
 
     def test_lt_section_not_shown_when_not_approved(self):
         """未承認集会の場合、詳細ページ自体が閲覧できない（superuserのみ閲覧可）"""
@@ -584,25 +600,28 @@ class CommunityDetailViewLtApplicationSectionTest(TestCase):
         self.community.save()
 
         self.client.login(username='テストユーザー', password='testpass123')
-        response = self.client.get(
-            reverse('community:detail', kwargs={'pk': self.community.pk})
-        )
+        response = self.client.get(self.detail_url)
 
         self.assertEqual(response.status_code, 404)
-        self.assertNotContains(response, '発表を申し込む', status_code=404)
 
     def test_lt_section_not_shown_when_accepts_lt_is_false(self):
-        """LT受付OFFの場合、LT申請セクションは表示されない"""
+        """LT受付OFFの場合、未ログインでもLT申請セクションは表示されない"""
         self.community.accepts_lt_application = False
         self.community.save()
 
-        self.client.login(username='テストユーザー', password='testpass123')
-        response = self.client.get(
-            reverse('community:detail', kwargs={'pk': self.community.pk})
-        )
+        response = self.client.get(self.detail_url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, '発表を申し込む')
+        self.assertNotContains(response, self.apply_url)
+        self.assertNotContains(response, self.LOGIN_NOTICE)
+
+    def test_anonymous_apply_redirects_to_login_with_next(self):
+        """未ログインで申請ページへアクセスするとnext付きでログインへ誘導される"""
+        response = self.client.get(self.apply_url)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(settings.LOGIN_URL, response.url)
+        self.assertIn(f'next={quote(self.apply_url)}', response.url)
 
 
 class CommunityDetailArchiveNoticeTest(TestCase):


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: #569（Closes #569）
- 集会詳細ページの「発表を申し込む」セクションが未ログイン訪問者に表示されず、発表申請の導線が見えないため機会損失になっていた（ユーザーからの改善要望）

## 変更内容

- `community/detail.html` の表示条件から `request.user.is_authenticated` を削除（`status == 'approved'` と `accepts_lt_application` は維持）
- 未ログイン時のみ「申請にはログインが必要です（ログイン画面に移動します）」の補足文をボタン直下に表示
- 申請フォーム（`LTApplicationCreateView`）は `LoginRequiredMixin` のまま。未ログインクリックは `?next=` 付きでログイン画面へ、ログイン後に申請フォームへ直行

## 意思決定

### 採用アプローチ
- テンプレート条件の変更のみで実現。理由: ビュー側の認証ゲート（`LoginRequiredMixin`）が既にログイン誘導 + `next` 復帰を備えており、コード追加が最小で済む（KISS）

### 却下した代替案
- 未ログイン用の専用ランディング → 却下: YAGNI。ログイン画面への直行で十分

## テスト

- [x] 未ログイン + 承認済み + 受付中 → ボタンと補足文が表示（修正前に失敗することを確認済み）
- [x] ログイン済み → 補足文は非表示
- [x] `accepts_lt_application=False` → 未ログインでもセクション非表示
- [x] 未ログインで申請URLへGET → ログインへ302 + `next` に元URL
- [x] `community.tests` 322件 OK / `event.tests.test_lt_application` 52件 OK
- [x] セキュリティレビュー実測: オープンリダイレクト（悪性 `next` 4パターン拒否）・CSRF 403・未承認集会404

## Screenshot

| Before（本番・未ログイン） | After（ローカル・未ログイン） |
|--------|-------|
| ![Before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/4925b12c57f0-before-prod-569.avif) | ![After](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/e2d50c211783-after-local-569.avif) |

Closes #569

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)