### PR TITLE
fix: Vketロックの対象をコラボ本体イベントに限定する

### DIFF
--- a/app/api_v1/tests/test_event_detail_api.py
+++ b/app/api_v1/tests/test_event_detail_api.py
@@ -128,6 +128,7 @@ class EventDetailAPITest(TestCase):
             collaboration=collaboration,
             community=self.community1,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
+            published_event=self.locked_event,
         )
         
         self.client = APIClient()

--- a/app/api_v1/tests/test_event_detail_api.py
+++ b/app/api_v1/tests/test_event_detail_api.py
@@ -7,6 +7,7 @@ from datetime import date, time
 from user_account.models import CustomUser, APIKey
 from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
+from tests.factories import make_event
 from vket.models import VketCollaboration, VketParticipation
 
 
@@ -355,6 +356,50 @@ class EventDetailAPITest(TestCase):
         self.assertEqual(self.event_detail1.event_id, self.event1.id)
         self.assertEqual(self.event_detail1.start_time, time(20, 0))
         self.assertEqual(self.event_detail1.duration, 30)
+
+    def test_update_event_detail_cannot_move_out_of_locked_event(self):
+        """ロック中イベントの詳細を兄弟イベントへ移す抜け道（移動→削除）を防ぐ."""
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.raw_api_key1}')
+
+        url = reverse('event-detail-api-detail', kwargs={'pk': self.locked_event_detail.id})
+
+        response = self.client.patch(url, {'event': self.event1.id}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('event', response.data)
+        self.locked_event_detail.refresh_from_db()
+        self.assertEqual(self.locked_event_detail.event_id, self.locked_event.id)
+
+    def test_update_event_detail_allows_move_when_not_locked(self):
+        """ロックされていない詳細のイベント移動は従来どおり許可する."""
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.raw_api_key1}')
+        unlocked_event = make_event(
+            self.community1,
+            event_date=date(2024, 12, 27),
+            start_time=time(20, 0),
+            duration=120,
+            weekday='fri',
+        )
+
+        url = reverse('event-detail-api-detail', kwargs={'pk': self.event_detail1.id})
+
+        response = self.client.patch(url, {'event': unlocked_event.id}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.event_detail1.refresh_from_db()
+        self.assertEqual(self.event_detail1.event_id, unlocked_event.id)
+
+    def test_superuser_can_move_locked_event_detail(self):
+        """superuser はロック中でも詳細のイベント移動ができる."""
+        self.client.force_authenticate(user=self.superuser)
+
+        url = reverse('event-detail-api-detail', kwargs={'pk': self.locked_event_detail.id})
+
+        response = self.client.patch(url, {'event': self.event1.id}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.locked_event_detail.refresh_from_db()
+        self.assertEqual(self.locked_event_detail.event_id, self.event1.id)
 
     def test_superuser_can_update_locked_event_detail_datetime(self):
         """superuser は Vket 期間中でも日時変更できる."""

--- a/app/api_v1/views.py
+++ b/app/api_v1/views.py
@@ -279,14 +279,18 @@ class EventDetailAPIViewSet(DatabaseReconnectListMixin, viewsets.ModelViewSet):
     def perform_update(self, serializer):
         instance = serializer.instance
         target_event = serializer.validated_data.get('event', instance.event)
+        errors = {}
+        # ロック中イベントからの持ち出しを禁止する。移動を許すと「未ロックの兄弟
+        # イベントへ移してから削除」でロックを迂回できてしまう。
+        if target_event != instance.event and is_event_datetime_locked(instance.event, self.request.user):
+            errors['event'] = [EVENT_DETAIL_DATETIME_LOCK_MESSAGE]
         if is_event_datetime_locked(target_event, self.request.user):
-            errors = {}
             if has_event_detail_start_time_changed(instance, serializer.validated_data.get('start_time')):
                 errors['start_time'] = [EVENT_DETAIL_DATETIME_LOCK_MESSAGE]
             if has_event_detail_duration_changed(instance, serializer.validated_data.get('duration')):
                 errors['duration'] = [EVENT_DETAIL_DATETIME_LOCK_MESSAGE]
-            if errors:
-                raise ValidationError(errors)
+        if errors:
+            raise ValidationError(errors)
         serializer.save()
 
     def destroy(self, request, *args, **kwargs):

--- a/app/event/datetime_lock.py
+++ b/app/event/datetime_lock.py
@@ -1,6 +1,7 @@
 from datetime import datetime, time
 
 from vket.models import VketParticipation
+from vket.services import collab_event_match
 
 
 EVENT_DETAIL_DATETIME_LOCK_MESSAGE = "Vketコラボ期間中のため運営のみ変更できます。"
@@ -16,7 +17,7 @@ def is_event_datetime_locked(event, user) -> bool:
     return VketParticipation.objects.filter(
         # コラボ本体のイベントだけをロックする。同じ集会の通常イベントまで
         # 巻き込むとコラボ無関係の定例回まで編集不能になる（Issue #571）。
-        published_event_id=event.pk,
+        collab_event_match(event),
         community_id=event.community_id,
         lifecycle=VketParticipation.Lifecycle.ACTIVE,
         collaboration__period_start__lte=event.date,

--- a/app/event/datetime_lock.py
+++ b/app/event/datetime_lock.py
@@ -10,10 +10,13 @@ def is_event_datetime_locked(event, user) -> bool:
     if getattr(user, "is_superuser", False):
         return False
 
-    if not event.community_id or not event.date:
+    if not event.pk or not event.community_id or not event.date:
         return False
 
     return VketParticipation.objects.filter(
+        # コラボ本体のイベントだけをロックする。同じ集会の通常イベントまで
+        # 巻き込むとコラボ無関係の定例回まで編集不能になる（Issue #571）。
+        published_event_id=event.pk,
         community_id=event.community_id,
         lifecycle=VketParticipation.Lifecycle.ACTIVE,
         collaboration__period_start__lte=event.date,

--- a/app/event/tests/test_datetime_lock.py
+++ b/app/event/tests/test_datetime_lock.py
@@ -1,0 +1,86 @@
+"""is_event_datetime_locked のユニットテスト。
+
+ロック対象はコラボ本体イベント（VketParticipation.published_event）のみで、
+同じ集会の通常イベントは期間内でもロックしない（Issue #571）。
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from event.datetime_lock import is_event_datetime_locked
+from tests.factories import make_community, make_event, make_user
+from vket.models import VketCollaboration, VketParticipation
+
+
+class IsEventDatetimeLockedTests(TestCase):
+    def setUp(self):
+        self.owner = make_user(
+            user_name='lock_owner',
+            email='lock_owner@example.com',
+        )
+        self.community = make_community(name='ロック判定集会', owner=self.owner)
+        today = timezone.localdate()
+        self.collaboration = VketCollaboration.objects.create(
+            slug='datetime-lock-test',
+            name='Vket Datetime Lock Test',
+            period_start=today,
+            period_end=today + timedelta(days=7),
+            registration_deadline=today,
+            lt_deadline=today + timedelta(days=3),
+        )
+        self.collab_event = make_event(
+            self.community, event_date=today + timedelta(days=1),
+        )
+        self.regular_event = make_event(
+            self.community, event_date=today + timedelta(days=2),
+        )
+
+    def _create_participation(self, published_event=None, **kwargs):
+        kwargs.setdefault('lifecycle', VketParticipation.Lifecycle.ACTIVE)
+        return VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            published_event=published_event,
+            **kwargs,
+        )
+
+    def test_collab_event_in_period_is_locked(self):
+        """コラボ本体イベントは期間内ならロックされる"""
+        self._create_participation(published_event=self.collab_event)
+
+        self.assertTrue(is_event_datetime_locked(self.collab_event, self.owner))
+
+    def test_regular_event_of_participating_community_is_not_locked(self):
+        """コラボ参加集会でも、コラボ本体でない通常イベントはロックされない"""
+        self._create_participation(published_event=self.collab_event)
+
+        self.assertFalse(is_event_datetime_locked(self.regular_event, self.owner))
+
+    def test_participation_without_published_event_is_not_locked(self):
+        """published_event 未設定の参加だけならロックされない"""
+        self._create_participation(published_event=None)
+
+        self.assertFalse(is_event_datetime_locked(self.collab_event, self.owner))
+
+    def test_declined_participation_is_not_locked(self):
+        """不参加の場合はロックされない"""
+        self._create_participation(
+            published_event=self.collab_event,
+            lifecycle=VketParticipation.Lifecycle.DECLINED,
+        )
+
+        self.assertFalse(is_event_datetime_locked(self.collab_event, self.owner))
+
+    def test_superuser_is_not_locked(self):
+        """superuser はロック対象外"""
+        superuser = make_user(
+            user_name='lock_admin',
+            email='lock_admin@example.com',
+            is_staff=True,
+            is_superuser=True,
+        )
+        self._create_participation(published_event=self.collab_event)
+
+        self.assertFalse(is_event_datetime_locked(self.collab_event, superuser))

--- a/app/event/tests/test_datetime_lock.py
+++ b/app/event/tests/test_datetime_lock.py
@@ -59,8 +59,39 @@ class IsEventDatetimeLockedTests(TestCase):
         self.assertFalse(is_event_datetime_locked(self.regular_event, self.owner))
 
     def test_participation_without_published_event_is_not_locked(self):
-        """published_event 未設定の参加だけならロックされない"""
+        """published_event 未設定 + confirmed 日時も未設定ならロックされない"""
         self._create_participation(published_event=None)
+
+        self.assertFalse(is_event_datetime_locked(self.collab_event, self.owner))
+
+    def test_confirmed_schedule_match_is_locked_without_published_event(self):
+        """published_event 未設定でも confirmed 日時が一致すれば本体としてロックされる"""
+        self._create_participation(
+            published_event=None,
+            confirmed_date=self.collab_event.date,
+            confirmed_start_time=self.collab_event.start_time,
+            confirmed_duration=self.collab_event.duration,
+        )
+
+        self.assertTrue(is_event_datetime_locked(self.collab_event, self.owner))
+
+    def test_confirmed_schedule_mismatch_is_not_locked(self):
+        """confirmed 日時が一致しない同一集会イベントはロックされない"""
+        self._create_participation(
+            published_event=None,
+            confirmed_date=self.collab_event.date,
+            confirmed_start_time=self.collab_event.start_time,
+            confirmed_duration=self.collab_event.duration,
+        )
+
+        self.assertFalse(is_event_datetime_locked(self.regular_event, self.owner))
+
+    def test_unconfirmed_participation_is_not_locked(self):
+        """スケジュール未確定（confirmed_date なし）の参加ではロックされない"""
+        self._create_participation(
+            published_event=None,
+            confirmed_start_time=self.collab_event.start_time,
+        )
 
         self.assertFalse(is_event_datetime_locked(self.collab_event, self.owner))
 

--- a/app/event/tests/test_event_date_update.py
+++ b/app/event/tests/test_event_date_update.py
@@ -500,6 +500,24 @@ class EventDateUpdateViewTests(TestCase):
         self.event.refresh_from_db()
         self.assertEqual(self.event.date, self.original_date)
 
+    def test_vket_lock_blocks_move_onto_confirmed_date(self):
+        """期間外のイベントを confirmed_date（期間内）へ動かす操作もブロックする"""
+        confirmed_date = self.original_date + timedelta(days=3)
+        self._create_vket_period(
+            confirmed_date,
+            confirmed_date + timedelta(days=1),
+            use_confirmed_match=True,
+            confirmed_date=confirmed_date,
+        )
+        self.client.force_login(self.owner)
+
+        response = self._post_date(confirmed_date)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '運営のみ')
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.date, self.original_date)
+
     def test_superuser_can_bypass_vket_lock(self):
         new_date = self.original_date + timedelta(days=3)
         self._create_vket_period(new_date, new_date + timedelta(days=1))
@@ -511,11 +529,14 @@ class EventDateUpdateViewTests(TestCase):
         self.event.refresh_from_db()
         self.assertEqual(self.event.date, new_date)
 
-    def _create_vket_period(self, period_start, period_end, *, use_confirmed_match=False):
+    def _create_vket_period(
+        self, period_start, period_end, *, use_confirmed_match=False, confirmed_date=None,
+    ):
         """コラボ期間と本体イベントの紐づけを作る。
 
         use_confirmed_match=True は本番同様に published_event 未設定で、
-        confirmed 日時一致のフォールバック経路を通す。
+        confirmed 日時一致のフォールバック経路を通す。confirmed_date を渡すと
+        イベントの現在日と異なる確定日（未移動状態）を再現できる。
         """
         collaboration = VketCollaboration.objects.create(
             slug=f'event-date-lock-{period_start.isoformat()}',
@@ -527,7 +548,7 @@ class EventDateUpdateViewTests(TestCase):
         )
         link = (
             {
-                'confirmed_date': self.event.date,
+                'confirmed_date': confirmed_date or self.event.date,
                 'confirmed_start_time': self.event.start_time,
                 'confirmed_duration': self.event.duration,
             }

--- a/app/event/tests/test_event_date_update.py
+++ b/app/event/tests/test_event_date_update.py
@@ -467,6 +467,39 @@ class EventDateUpdateViewTests(TestCase):
         self.event.refresh_from_db()
         self.assertEqual(self.event.date, self.original_date)
 
+    def test_vket_lock_checks_old_date_with_confirmed_match(self):
+        """published_event 未設定でも、変更前日付が期間内ならブロックする"""
+        self._create_vket_period(
+            self.original_date,
+            self.original_date + timedelta(days=1),
+            use_confirmed_match=True,
+        )
+        self.client.force_login(self.owner)
+
+        response = self._post_date(self.original_date + timedelta(days=3))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '運営のみ')
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.date, self.original_date)
+
+    def test_vket_lock_checks_new_date_with_confirmed_match(self):
+        """published_event 未設定でも、移動先日付が期間内ならブロックする"""
+        new_date = self.original_date + timedelta(days=3)
+        self._create_vket_period(
+            new_date,
+            new_date + timedelta(days=1),
+            use_confirmed_match=True,
+        )
+        self.client.force_login(self.owner)
+
+        response = self._post_date(new_date)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '運営のみ')
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.date, self.original_date)
+
     def test_superuser_can_bypass_vket_lock(self):
         new_date = self.original_date + timedelta(days=3)
         self._create_vket_period(new_date, new_date + timedelta(days=1))
@@ -478,7 +511,12 @@ class EventDateUpdateViewTests(TestCase):
         self.event.refresh_from_db()
         self.assertEqual(self.event.date, new_date)
 
-    def _create_vket_period(self, period_start, period_end):
+    def _create_vket_period(self, period_start, period_end, *, use_confirmed_match=False):
+        """コラボ期間と本体イベントの紐づけを作る。
+
+        use_confirmed_match=True は本番同様に published_event 未設定で、
+        confirmed 日時一致のフォールバック経路を通す。
+        """
         collaboration = VketCollaboration.objects.create(
             slug=f'event-date-lock-{period_start.isoformat()}',
             name='Vket日付変更ロック',
@@ -487,11 +525,20 @@ class EventDateUpdateViewTests(TestCase):
             registration_deadline=period_start,
             lt_deadline=period_end,
         )
+        link = (
+            {
+                'confirmed_date': self.event.date,
+                'confirmed_start_time': self.event.start_time,
+                'confirmed_duration': self.event.duration,
+            }
+            if use_confirmed_match
+            else {'published_event': self.event}
+        )
         return VketParticipation.objects.create(
             collaboration=collaboration,
             community=self.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
-            published_event=self.event,
+            **link,
         )
 
     def _make_recurring_master(self):

--- a/app/event/tests/test_event_date_update.py
+++ b/app/event/tests/test_event_date_update.py
@@ -491,6 +491,7 @@ class EventDateUpdateViewTests(TestCase):
             collaboration=collaboration,
             community=self.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
+            published_event=self.event,
         )
 
     def _make_recurring_master(self):

--- a/app/event/tests/test_event_delete_view.py
+++ b/app/event/tests/test_event_delete_view.py
@@ -286,6 +286,7 @@ class EventDeleteViewPermissionTest(TestCase):
             collaboration=collaboration,
             community=self.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
+            published_event=child,
         )
         self.client.login(username='Owner User', password='ownerpass123')
 
@@ -348,6 +349,7 @@ class EventDeleteViewPermissionTest(TestCase):
             collaboration=collaboration,
             community=self.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
+            published_event=locked_child,
         )
         self.client.login(username='Owner User', password='ownerpass123')
 

--- a/app/event/tests/test_event_detail_form.py
+++ b/app/event/tests/test_event_detail_form.py
@@ -92,6 +92,7 @@ class EventDetailFormCleanTest(TestCase):
             collaboration=self.vket_collaboration,
             community=self.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
+            published_event=self.locked_event,
         )
 
     def _create_request(self):

--- a/app/event/tests/test_event_detail_permissions.py
+++ b/app/event/tests/test_event_detail_permissions.py
@@ -116,6 +116,7 @@ class EventDetailPermissionTests(TestCase):
             collaboration=collaboration,
             community=self.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
+            published_event=self.locked_event,
         )
 
     def test_non_member_cannot_access_event_detail_create_view(self):

--- a/app/event/tests/test_event_my_list_view.py
+++ b/app/event/tests/test_event_my_list_view.py
@@ -762,6 +762,7 @@ class EventMyListEditButtonTest(TestCase):
             collaboration=collab,
             community=self.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
+            published_event=event,
         )
         self.client.force_login(self.owner)
         response = self.client.get(reverse('event:my_list'))

--- a/app/event/tests/test_event_update_view.py
+++ b/app/event/tests/test_event_update_view.py
@@ -208,6 +208,7 @@ class EventUpdateViewVketLockTest(EventUpdateViewBaseMixin, TestCase):
             collaboration=self.collaboration,
             community=self.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
+            published_event=self.event,
         )
 
     def test_owner_blocked_during_vket_lock(self):

--- a/app/vket/services.py
+++ b/app/vket/services.py
@@ -16,11 +16,12 @@ class VketPublicationSyncResult:
 
 
 def get_vket_lock_info(event, *, date=None) -> tuple[bool, str]:
-    """Vketコラボ期間中のイベントかどうかを判定し、ロックメッセージを返す。
+    """Vketコラボ本体のイベントかどうかを判定し、ロックメッセージを返す。
 
-    イベントの所属Communityがアクティブな VketParticipation を持ち、
+    そのイベント自身がアクティブな VketParticipation の公開先（published_event）で、
     かつイベント日がそのコラボの開催期間内（period_start〜period_end）であれば
-    ロック中と判定する。1クエリで判定とメッセージ取得を行う。
+    ロック中と判定する。同じ集会の通常イベントは期間内でもロックしない。
+    1クエリで判定とメッセージ取得を行う。
 
     Args:
         event: Event インスタンス
@@ -32,8 +33,13 @@ def get_vket_lock_info(event, *, date=None) -> tuple[bool, str]:
     # ロック判定に不要な列まで読むと、列追加直後の古いDBスキーマで 500 になりうるため、
     # メッセージ生成に必要な情報だけを取得する（欠損カラム参照による 500 回避）。
     target_date = date or event.date
+    if not event.pk:
+        return False, ""
     participation = (
         VketParticipation.objects.filter(
+            # コラボ本体のイベントだけをロックする。同じ集会の通常イベントまで
+            # 巻き込むとコラボ無関係の定例回まで編集不能になる（Issue #571）。
+            published_event_id=event.pk,
             community=event.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
             collaboration__period_start__lte=target_date,

--- a/app/vket/services.py
+++ b/app/vket/services.py
@@ -17,17 +17,27 @@ class VketPublicationSyncResult:
     changed_index_data: bool
 
 
-def collab_event_match(event) -> Q:
+def collab_event_match(event, *, date=None) -> Q:
     """イベントがコラボ本体かを判定する VketParticipation 向け条件を返す。
 
     published_event 一致が本来の判定だが、本番では publication sync が未実施で
     published_event が全件未設定のため、それだけではロックが一切効かない。
     フォールバックとして confirmed 日時一致も本体とみなす（この一致規則は
     _resolve_publication_event が既存 Event を本体として拾う規則と同じ）。
+
+    Args:
+        event: Event インスタンス
+        date: 追加で本体とみなす日付。移動先日付を渡すと「期間内へ移動して本体になる」
+            操作もロック対象にできる（イベントの現在日との OR で判定する）。
     """
+    if not event.pk:
+        # pk が None だと published_event_id=None が IS NULL に化けて誤判定するため、
+        # 未保存イベントは常に不一致（空集合）にする。
+        return Q(pk__in=[])
+    candidate_dates = {event.date, date} - {None}
     return Q(published_event_id=event.pk) | Q(
         published_event__isnull=True,
-        confirmed_date=event.date,
+        confirmed_date__in=candidate_dates,
         confirmed_start_time=event.start_time,
     )
 
@@ -49,14 +59,16 @@ def get_vket_lock_info(event, *, date=None) -> tuple[bool, str]:
     Returns:
         (ロック中か, メッセージ) のタプル。ロックされていない場合は (False, "")
     """
+    if not event.pk:
+        return False, ""
     # ロック判定に不要な列まで読むと、列追加直後の古いDBスキーマで 500 になりうるため、
     # メッセージ生成に必要な情報だけを取得する（欠損カラム参照による 500 回避）。
     target_date = date or event.date
-    if not event.pk:
-        return False, ""
     participation = (
         VketParticipation.objects.filter(
-            collab_event_match(event),
+            # 移動先日付が confirmed_date と一致する場合も本体扱いにして、
+            # 期間外の Event を confirmed_date へ動かす操作を素通りさせない。
+            collab_event_match(event, date=target_date),
             community=event.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
             collaboration__period_start__lte=target_date,

--- a/app/vket/services.py
+++ b/app/vket/services.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+from django.db.models import Q
+
 from community.constants import weekday_code
 from event.models import Event, EventDetail
 from vket.models import VketParticipation, VketPresentation
@@ -15,13 +17,30 @@ class VketPublicationSyncResult:
     changed_index_data: bool
 
 
+def collab_event_match(event) -> Q:
+    """イベントがコラボ本体かを判定する VketParticipation 向け条件を返す。
+
+    published_event 一致が本来の判定だが、本番では publication sync が未実施で
+    published_event が全件未設定のため、それだけではロックが一切効かない。
+    フォールバックとして confirmed 日時一致も本体とみなす（この一致規則は
+    _resolve_publication_event が既存 Event を本体として拾う規則と同じ）。
+    """
+    return Q(published_event_id=event.pk) | Q(
+        published_event__isnull=True,
+        confirmed_date=event.date,
+        confirmed_start_time=event.start_time,
+    )
+
+
 def get_vket_lock_info(event, *, date=None) -> tuple[bool, str]:
     """Vketコラボ本体のイベントかどうかを判定し、ロックメッセージを返す。
 
-    そのイベント自身がアクティブな VketParticipation の公開先（published_event）で、
-    かつイベント日がそのコラボの開催期間内（period_start〜period_end）であれば
+    そのイベント自身がアクティブな VketParticipation のコラボ本体で、
+    かつ判定対象日がそのコラボの開催期間内（period_start〜period_end）であれば
     ロック中と判定する。同じ集会の通常イベントは期間内でもロックしない。
     1クエリで判定とメッセージ取得を行う。
+
+    本体判定は published_event 一致、または confirmed 日時一致（下記フォールバック）。
 
     Args:
         event: Event インスタンス
@@ -37,9 +56,7 @@ def get_vket_lock_info(event, *, date=None) -> tuple[bool, str]:
         return False, ""
     participation = (
         VketParticipation.objects.filter(
-            # コラボ本体のイベントだけをロックする。同じ集会の通常イベントまで
-            # 巻き込むとコラボ無関係の定例回まで編集不能になる（Issue #571）。
-            published_event_id=event.pk,
+            collab_event_match(event),
             community=event.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
             collaboration__period_start__lte=target_date,

--- a/app/vket/tests/test_schedule_lock.py
+++ b/app/vket/tests/test_schedule_lock.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 
 from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
+from tests.factories import make_event
 from vket.models import VketCollaboration, VketParticipation
 from vket.services import get_vket_lock_info, is_event_locked_by_vket, get_vket_lock_message
 
@@ -127,35 +128,48 @@ class VketScheduleLockServiceTests(TestCase):
             duration=60,
         )
 
+    def _create_participation(self, published_event=None, **kwargs):
+        kwargs.setdefault('lifecycle', VketParticipation.Lifecycle.ACTIVE)
+        return VketParticipation.objects.create(
+            collaboration=self.collaboration,
+            community=self.community,
+            published_event=published_event,
+            **kwargs,
+        )
+
     def test_no_participation_not_locked(self):
         """参加していないCommunityのイベントはロックされない"""
         self.assertFalse(is_event_locked_by_vket(self.event_in_period))
 
     def test_active_participation_in_period_locked(self):
-        """アクティブな参加があり期間内のイベントはロックされる"""
-        VketParticipation.objects.create(
-            collaboration=self.collaboration,
-            community=self.community,
-            lifecycle=VketParticipation.Lifecycle.ACTIVE,
-        )
+        """コラボ本体イベント（published_event）は期間内ならロックされる"""
+        self._create_participation(published_event=self.event_in_period)
         self.assertTrue(is_event_locked_by_vket(self.event_in_period))
 
-    def test_active_participation_outside_period_not_locked(self):
-        """アクティブな参加があっても期間外のイベントはロックされない"""
-        VketParticipation.objects.create(
-            collaboration=self.collaboration,
-            community=self.community,
-            lifecycle=VketParticipation.Lifecycle.ACTIVE,
+    def test_regular_event_of_participating_community_not_locked(self):
+        """コラボ参加集会でも、コラボ本体でない通常イベントはロックされない"""
+        collab_event = make_event(
+            self.community,
+            event_date=self.event_in_period.date,
+            start_time='23:00',
         )
+        self._create_participation(published_event=collab_event)
+
+        self.assertFalse(is_event_locked_by_vket(self.event_in_period))
+
+    def test_participation_without_published_event_not_locked(self):
+        """published_event 未設定の参加だけならロックされない"""
+        self._create_participation(published_event=None)
+        self.assertFalse(is_event_locked_by_vket(self.event_in_period))
+
+    def test_active_participation_outside_period_not_locked(self):
+        """コラボ本体イベントでも期間外ならロックされない"""
+        self._create_participation(published_event=self.event_outside_period)
         self.assertFalse(is_event_locked_by_vket(self.event_outside_period))
 
     def test_lock_info_can_evaluate_proposed_date(self):
         """保存前の移動先日付もキーワード引数で判定できる"""
-        VketParticipation.objects.create(
-            collaboration=self.collaboration,
-            community=self.community,
-            lifecycle=VketParticipation.Lifecycle.ACTIVE,
-        )
+        self._create_participation(published_event=self.event_outside_period)
 
         locked, message = get_vket_lock_info(
             self.event_outside_period,
@@ -167,31 +181,22 @@ class VketScheduleLockServiceTests(TestCase):
 
     def test_declined_participation_not_locked(self):
         """不参加の場合はロックされない"""
-        VketParticipation.objects.create(
-            collaboration=self.collaboration,
-            community=self.community,
+        self._create_participation(
+            published_event=self.event_in_period,
             lifecycle=VketParticipation.Lifecycle.DECLINED,
         )
         self.assertFalse(is_event_locked_by_vket(self.event_in_period))
 
     def test_lock_message_contains_collab_name(self):
         """ロックメッセージにコラボ名が含まれる"""
-        VketParticipation.objects.create(
-            collaboration=self.collaboration,
-            community=self.community,
-            lifecycle=VketParticipation.Lifecycle.ACTIVE,
-        )
+        self._create_participation(published_event=self.event_in_period)
         msg = get_vket_lock_message(self.event_in_period)
         self.assertIn('Vket Lock Test', msg)
         self.assertIn('運営のみ', msg)
 
     def test_get_vket_lock_info_does_not_select_stage_registered_at(self):
         """ロック判定は不要列をSELECTせず、列追加直後の古いDBでも動ける"""
-        VketParticipation.objects.create(
-            collaboration=self.collaboration,
-            community=self.community,
-            lifecycle=VketParticipation.Lifecycle.ACTIVE,
-        )
+        self._create_participation(published_event=self.event_in_period)
 
         with CaptureQueriesContext(connection) as queries:
             locked, msg = get_vket_lock_info(self.event_in_period)
@@ -247,6 +252,7 @@ class VketScheduleLockViewTests(TestCase):
             collaboration=self.collaboration,
             community=self.community,
             lifecycle=VketParticipation.Lifecycle.ACTIVE,
+            published_event=self.event,
         )
         self.detail = EventDetail.objects.create(
             event=self.event,

--- a/app/vket/tests/test_schedule_lock.py
+++ b/app/vket/tests/test_schedule_lock.py
@@ -158,8 +158,41 @@ class VketScheduleLockServiceTests(TestCase):
         self.assertFalse(is_event_locked_by_vket(self.event_in_period))
 
     def test_participation_without_published_event_not_locked(self):
-        """published_event 未設定の参加だけならロックされない"""
+        """published_event 未設定 + confirmed 日時も未設定ならロックされない"""
         self._create_participation(published_event=None)
+        self.assertFalse(is_event_locked_by_vket(self.event_in_period))
+
+    def test_confirmed_schedule_match_locked_without_published_event(self):
+        """published_event 未設定でも confirmed 日時が一致すれば本体としてロックされる"""
+        self._create_participation(
+            published_event=None,
+            confirmed_date=self.event_in_period.date,
+            confirmed_start_time=self.event_in_period.start_time,
+            confirmed_duration=self.event_in_period.duration,
+        )
+        self.assertTrue(is_event_locked_by_vket(self.event_in_period))
+
+    def test_confirmed_schedule_mismatch_not_locked(self):
+        """同じ日でも開始時刻が違う通常イベントはロックされない"""
+        other_time_event = make_event(
+            self.community,
+            event_date=self.event_in_period.date,
+            start_time='23:30',
+        )
+        self._create_participation(
+            published_event=None,
+            confirmed_date=self.event_in_period.date,
+            confirmed_start_time=self.event_in_period.start_time,
+            confirmed_duration=self.event_in_period.duration,
+        )
+        self.assertFalse(is_event_locked_by_vket(other_time_event))
+
+    def test_unconfirmed_participation_not_locked(self):
+        """スケジュール未確定（confirmed_date なし）の参加ではロックされない"""
+        self._create_participation(
+            published_event=None,
+            confirmed_start_time=self.event_in_period.start_time,
+        )
         self.assertFalse(is_event_locked_by_vket(self.event_in_period))
 
     def test_active_participation_outside_period_not_locked(self):

--- a/app/vket/tests/test_schedule_lock.py
+++ b/app/vket/tests/test_schedule_lock.py
@@ -14,7 +14,12 @@ from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
 from tests.factories import make_event
 from vket.models import VketCollaboration, VketParticipation
-from vket.services import get_vket_lock_info, is_event_locked_by_vket, get_vket_lock_message
+from vket.services import (
+    collab_event_match,
+    get_vket_lock_info,
+    is_event_locked_by_vket,
+    get_vket_lock_message,
+)
 
 User = get_user_model()
 
@@ -186,6 +191,19 @@ class VketScheduleLockServiceTests(TestCase):
             confirmed_duration=self.event_in_period.duration,
         )
         self.assertFalse(is_event_locked_by_vket(other_time_event))
+
+    def test_unsaved_event_never_matches(self):
+        """未保存イベント（pk なし）は本体条件に一致しない"""
+        self._create_participation(published_event=None)
+        unsaved = Event(
+            community=self.community,
+            date=self.event_in_period.date,
+            start_time=self.event_in_period.start_time,
+        )
+
+        matched = VketParticipation.objects.filter(collab_event_match(unsaved)).exists()
+
+        self.assertFalse(matched)
 
     def test_unconfirmed_participation_not_locked(self):
         """スケジュール未確定（confirmed_date なし）の参加ではロックされない"""


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: #571（Closes #571）
- Vketコラボ期間中、コラボ参加集会の**通常イベント**（コラボと無関係の定例回）まで日時変更・EventDetail削除・API更新がロックされ、主催者が自分のイベントを管理できなかった

## 変更内容

- ロック判定2関数（`get_vket_lock_info` / `is_event_datetime_locked`）の対象を「コラボ本体イベント」に限定
- 本体判定は共有の `collab_event_match(event, date=None) -> Q` に集約: `published_event` 一致、または（published_event 未設定時のフォールバック）confirmed 日時一致
- API の「EventDetail をロック中イベントから別イベントへ移す→削除」迂回を `perform_update` の移動元判定で遮断（セキュリティレビュー指摘）
- 「期間外の Event を confirmed_date へ移動して素通り」する経路も移動先日付の本体判定で遮断（コードレビュー指摘）
- 再発防止テスト計21本追加（修正前に失敗することを確認済み）

## 意思決定

### 採用アプローチ
- confirmed 日時一致フォールバックを追加。理由: 本番DB調査で ACTIVE な VketParticipation 26件すべてが `published_event` 未設定（publication sync 未実行）と判明し、published_event のみの判定では本番でロックが一切効かなくなるため。一致規則は `_resolve_publication_event` の既存 Event 探索と同一で設計整合
- 移動先日付の本体判定は「置換」ではなく「現在日との OR」（`confirmed_date__in`）。置換だと現在日基準の本体判定が消え、本体イベント自体の移動が素通りするため

### 却下した代替案
- publication sync を本番で実行して published_event を埋める → 本 PR では却下: データ操作を伴う運用判断のため Issue #581 に分離
- `VketPresentation.published_event_detail` 紐づきでの EventDetail 単位ロック → 却下: 本番で0件のため現状は機能しない。#581 の運用整備後に検討可能

### 既知の制限（Issue #581 で追跡）
- 運営が本体イベントの日時を直接変更して confirmed_* を更新し忘れると、フォールバック判定が外れロックが解除される（fail-open）。恒久対応は運用判断が必要なため #581 に分離

## テスト

- [x] 修正前に失敗する再発防止テストで各修正を確認（3ラウンド計11本の失敗確認）
- [x] `manage.py test`（全体）: Ran 2068, OK (skipped=23)
- [x] 生成SQLの形状確認（1クエリ維持・OR/AND 結合・NULL 比較）
- [x] コード + セキュリティレビュー（Opus並列）→ 指摘4点修正済み、運用課題は #581 化

Closes #571

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)