### PR TITLE
fix: イベント重複作成の競合を500にせずフォームエラーで扱う

### DIFF
--- a/app/event/tests/test_calendar_create.py
+++ b/app/event/tests/test_calendar_create.py
@@ -1,0 +1,80 @@
+"""カレンダーイベント登録の重複ハンドリングのテスト.
+
+Issue #568: 重複作成の競合で IntegrityError が exc_info 付き error ログになり、
+Error Reporting に incident として蓄積されていた。重複判定を unique 制約の
+IntegrityError 捕捉に一本化し、フォームエラーとして扱うことを検証する。
+"""
+from datetime import time, timedelta
+
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from event.models import Event
+from tests.factories import make_community, make_event, make_user
+
+
+class CalendarCreateDuplicateTest(TestCase):
+    def setUp(self):
+        self.user = make_user(user_name='calendar_dup_owner')
+        self.community = make_community(
+            name='重複登録テスト集会',
+            owner=self.user,
+            start_time=time(21, 0),
+        )
+        self.client = Client()
+        self.client.force_login(self.user)
+        session = self.client.session
+        session['active_community_id'] = self.community.pk
+        session.save()
+
+    def test_duplicate_datetime_shows_form_error_instead_of_500(self):
+        """同一日時のイベントが既にある場合、500 ではなくフォームエラーになる."""
+        event_date = timezone.localdate() + timedelta(days=10)
+        make_event(
+            self.community,
+            event_date=event_date,
+            start_time=time(21, 0),
+        )
+
+        response = self.client.post(
+            reverse('event:calendar_create'),
+            {
+                'start_date': event_date.isoformat(),
+                'start_time': '21:00',
+                'duration': 60,
+                'recurrence_type': 'none',
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'すでにイベントが登録されています')
+        self.assertEqual(
+            Event.objects.filter(community=self.community, date=event_date).count(),
+            1,
+        )
+
+    def test_duplicate_datetime_does_not_emit_error_log(self):
+        """重複はエラーログ（Error Reporting の incident 化対象）にしない."""
+        event_date = timezone.localdate() + timedelta(days=10)
+        make_event(
+            self.community,
+            event_date=event_date,
+            start_time=time(21, 0),
+        )
+
+        with self.assertLogs('event.views.calendar_create', level='WARNING') as logs:
+            self.client.post(
+                reverse('event:calendar_create'),
+                {
+                    'start_date': event_date.isoformat(),
+                    'start_time': '21:00',
+                    'duration': 60,
+                    'recurrence_type': 'none',
+                },
+            )
+
+        self.assertFalse(
+            [r for r in logs.records if r.levelname == 'ERROR'],
+            'IntegrityError が error ログとして記録されている',
+        )

--- a/app/event/tests/test_calendar_create.py
+++ b/app/event/tests/test_calendar_create.py
@@ -5,7 +5,9 @@ Error Reporting に incident として蓄積されていた。重複判定を un
 IntegrityError 捕捉に一本化し、フォームエラーとして扱うことを検証する。
 """
 from datetime import time, timedelta
+from unittest.mock import patch
 
+from django.db import IntegrityError
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -77,4 +79,40 @@ class CalendarCreateDuplicateTest(TestCase):
         self.assertFalse(
             [r for r in logs.records if r.levelname == 'ERROR'],
             'IntegrityError が error ログとして記録されている',
+        )
+
+    def test_race_condition_integrity_error_is_handled_as_duplicate(self):
+        """CREATE時にはじめて衝突が発覚する競合でも、500やerrorログにしない.
+
+        Issue #568 の本質は「事前チェックをすり抜けた並行作成の衝突」。
+        単一スレッドのテストでは真の競合を再現できないため、プロセス外の
+        並行性の代理として create の IntegrityError を mock で注入する
+        （内部 patch はモック境界違反だが、並行性の再現は他手段が無いため許容）。
+        """
+        event_date = timezone.localdate() + timedelta(days=10)
+
+        with patch.object(
+            Event.objects,
+            'create',
+            side_effect=IntegrityError(
+                "Duplicate entry '1-2026-08-14-21:00:00.000000' "
+                "for key 'event.event_unique_community_date_start_time'"
+            ),
+        ):
+            with self.assertLogs('event.views.calendar_create', level='WARNING') as logs:
+                response = self.client.post(
+                    reverse('event:calendar_create'),
+                    {
+                        'start_date': event_date.isoformat(),
+                        'start_time': '21:00',
+                        'duration': 60,
+                        'recurrence_type': 'none',
+                    },
+                )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'すでにイベントが登録されています')
+        self.assertFalse(
+            [r for r in logs.records if r.levelname == 'ERROR'],
+            '競合時の IntegrityError が error ログとして記録されている',
         )

--- a/app/event/views/calendar_create.py
+++ b/app/event/views/calendar_create.py
@@ -96,12 +96,16 @@ class GoogleCalendarEventCreateView(LoginRequiredMixin, FormView):
 
                 messages.success(self.request, 'イベントが正常に登録されました')
 
-            except IntegrityError:
+            except IntegrityError as e:
                 # 重複判定は事前SELECTではなくunique制約（community, date, start_time）に
                 # 一本化する。SELECT→CREATE間の競合で500 + Error Reporting誤検知になっていた
                 # （exc_info付きerrorログをError Reportingがincident化するためwarningに留める）。
+                # Eventのunique制約は現状1本のみ。別制約が増えた場合の誤分類はログの
+                # 例外文字列で事後追跡する（制約名の文字列ガードはDBバックエンドで
+                # メッセージ書式が異なり脆いため採らない）。
                 logger.warning(
-                    f'重複イベント検出: コミュニティ={community.name}, 日付={start_date}, 開始時間={start_time}')
+                    f'重複イベント検出: コミュニティ={community.name}, 日付={start_date}, '
+                    f'開始時間={start_time}, detail={e}')
                 messages.error(self.request, f'同じ日時（{start_date} {start_time}）にすでにイベントが登録されています。')
                 return self.form_invalid(form)
 

--- a/app/event/views/calendar_create.py
+++ b/app/event/views/calendar_create.py
@@ -3,6 +3,7 @@ import logging
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
+from django.db import IntegrityError, transaction
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import FormView
@@ -72,31 +73,21 @@ class GoogleCalendarEventCreateView(LoginRequiredMixin, FormView):
 
             logger.info(f'イベント登録開始: コミュニティ={community.name}, 日付={start_date}, 開始時間={start_time}')
 
-            # 同じ日時のイベントが存在するかチェック
-            existing_event = Event.objects.filter(
-                date=start_date,
-                start_time=start_time,
-                community=community
-            ).first()
-
-            if existing_event:
-                logger.warning(
-                    f'重複イベント検出: ID={existing_event.id}, コミュニティ={community.name}, 日付={start_date}, 開始時間={start_time}')
-                messages.error(self.request, f'同じ日時（{start_date} {start_time}）にすでにイベントが登録されています。')
-                return self.form_invalid(form)
-
             duration = form.cleaned_data['duration']
 
             # 新しいイベントをDBに保存
             try:
-                new_event = Event.objects.create(
-                    community=community,
-                    date=start_date,
-                    start_time=start_time,
-                    duration=duration,
-                    weekday=weekday_code(start_date),
-                    # google_calendar_event_idは同期時に設定される
-                )
+                # atomic の savepoint で包まないと、外側トランザクション内で
+                # IntegrityError を握った後のクエリが TransactionManagementError になる
+                with transaction.atomic():
+                    new_event = Event.objects.create(
+                        community=community,
+                        date=start_date,
+                        start_time=start_time,
+                        duration=duration,
+                        weekday=weekday_code(start_date),
+                        # google_calendar_event_idは同期時に設定される
+                    )
                 logger.info(f'イベントをDBに登録: ID={new_event.id}, 日付={start_date}, 開始時間={start_time}')
 
                 # イベントの作成が成功した場合、キャッシュをクリア
@@ -104,6 +95,15 @@ class GoogleCalendarEventCreateView(LoginRequiredMixin, FormView):
                 cache.delete(cache_key)
 
                 messages.success(self.request, 'イベントが正常に登録されました')
+
+            except IntegrityError:
+                # 重複判定は事前SELECTではなくunique制約（community, date, start_time）に
+                # 一本化する。SELECT→CREATE間の競合で500 + Error Reporting誤検知になっていた
+                # （exc_info付きerrorログをError Reportingがincident化するためwarningに留める）。
+                logger.warning(
+                    f'重複イベント検出: コミュニティ={community.name}, 日付={start_date}, 開始時間={start_time}')
+                messages.error(self.request, f'同じ日時（{start_date} {start_time}）にすでにイベントが登録されています。')
+                return self.form_invalid(form)
 
             except Exception as e:
                 logger.error(f'イベントのDB登録でエラー: {str(e)}', exc_info=True)


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: #568（Closes #568）
- カレンダーイベント登録で、事前重複チェック（SELECT）と CREATE の間の競合により `IntegrityError` が発生し、`exc_info` 付き error ログが Error Reporting に incident（`error_reporting_app_exception`）として蓄積されていた（2026-02-04 / 2026-08-01 の2回発生）。ユーザーには汎用エラーが表示され、重複が原因だと分からなかった

## 変更内容

- 事前SELECT による重複チェックを廃止し、unique 制約（community, date, start_time）の `IntegrityError` 捕捉に一本化（TOCTOU 競合の構造的解消）
- `transaction.atomic()` の savepoint で create を包む（外側トランザクション下で例外を握った後のクエリが `TransactionManagementError` になるのを防止）
- 重複時はフォームエラー「すでにイベントが登録されています」+ warning ログ（exc_info なし。Error Reporting の incident 化を回避）
- warning ログに例外文字列を含め、将来別の unique 制約が増えた場合の誤分類を事後追跡可能にした

## 意思決定

### 採用アプローチ
- IntegrityError 捕捉への一本化。理由: 事前チェックは競合窓が残り続ける（今回の incident の直接原因）。DB 制約が唯一の正

### 却下した代替案
- 制約名の文字列ガード（`if '制約名' not in str(e): raise`） → 却下: sqlite（テスト）と MySQL（本番）でエラーメッセージ書式が異なり脆い。unique 制約は現状1本のみで誤分類の実害がなく、ログの例外文字列で追跡可能
- 旧ログの `ID={existing_event.id}` は捕捉方式の変更で取得不能になり削除。community + 日時が unique キーそのものであり一意特定は可能（意図的な変更）

## テスト

- [x] 競合の直接検証: create 時 IntegrityError 注入 → warning + 重複メッセージ、error ログ 0 件（**旧コードで FAIL・新コードで OK を確認**。並行性の再現手段がないため mock 注入。理由コメント付き）
- [x] 実重複 POST → フォームエラー + イベント件数不変 + error ログなし
- [x] `event` アプリ全体: 548 tests OK (skipped=20)
- [x] コード + セキュリティレビュー（Opus並列）→ P1 指摘（テスト弁別性）修正済み

Closes #568

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)