### PR TITLE
fix: 重複以外のIntegrityErrorを重複扱いにしない

### DIFF
--- a/app/event/tests/test_calendar_create.py
+++ b/app/event/tests/test_calendar_create.py
@@ -81,13 +81,12 @@ class CalendarCreateDuplicateTest(TestCase):
             'IntegrityError が error ログとして記録されている',
         )
 
-    def test_race_condition_integrity_error_is_handled_as_duplicate(self):
-        """CREATE時にはじめて衝突が発覚する競合でも、500やerrorログにしない.
+    def test_non_duplicate_integrity_error_keeps_error_log(self):
+        """重複以外の整合性エラー（FK違反等）は重複扱いにせず error ログを維持する.
 
-        Issue #568 の本質は「事前チェックをすり抜けた並行作成の衝突」。
-        単一スレッドのテストでは真の競合を再現できないため、プロセス外の
-        並行性の代理として create の IntegrityError を mock で注入する
-        （内部 patch はモック境界違反だが、並行性の再現は他手段が無いため許容）。
+        重複行が存在しないのに IntegrityError になるケースの代理として
+        mock で注入する（FK違反はテストDBで直接再現しづらいため。
+        内部 patch はモック境界違反だが、他手段が無いため理由付きで許容）。
         """
         event_date = timezone.localdate() + timedelta(days=10)
 
@@ -95,8 +94,7 @@ class CalendarCreateDuplicateTest(TestCase):
             Event.objects,
             'create',
             side_effect=IntegrityError(
-                "Duplicate entry '1-2026-08-14-21:00:00.000000' "
-                "for key 'event.event_unique_community_date_start_time'"
+                'Cannot add or update a child row: a foreign key constraint fails'
             ),
         ):
             with self.assertLogs('event.views.calendar_create', level='WARNING') as logs:
@@ -111,8 +109,9 @@ class CalendarCreateDuplicateTest(TestCase):
                 )
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'すでにイベントが登録されています')
-        self.assertFalse(
+        self.assertContains(response, 'イベントの登録に失敗しました')
+        self.assertNotContains(response, 'すでにイベントが登録されています')
+        self.assertTrue(
             [r for r in logs.records if r.levelname == 'ERROR'],
-            '競合時の IntegrityError が error ログとして記録されている',
+            '重複以外の IntegrityError が error ログに残っていない（Error Reporting から消える）',
         )

--- a/app/event/views/calendar_create.py
+++ b/app/event/views/calendar_create.py
@@ -100,9 +100,15 @@ class GoogleCalendarEventCreateView(LoginRequiredMixin, FormView):
                 # 重複判定は事前SELECTではなくunique制約（community, date, start_time）に
                 # 一本化する。SELECT→CREATE間の競合で500 + Error Reporting誤検知になっていた
                 # （exc_info付きerrorログをError Reportingがincident化するためwarningに留める）。
-                # Eventのunique制約は現状1本のみ。別制約が増えた場合の誤分類はログの
-                # 例外文字列で事後追跡する（制約名の文字列ガードはDBバックエンドで
-                # メッセージ書式が異なり脆いため採らない）。
+                # 重複起因かは制約名の文字列ではなく行の実在で判別する（sqlite/MySQLで
+                # エラーメッセージ書式が異なるため）。重複以外の整合性エラー（FK違反等）は
+                # 一般エラー処理へ再送出し、error ログ（Error Reporting 対象）を維持する。
+                if not Event.objects.filter(
+                    community=community,
+                    date=start_date,
+                    start_time=start_time,
+                ).exists():
+                    raise
                 logger.warning(
                     f'重複イベント検出: コミュニティ={community.name}, 日付={start_date}, '
                     f'開始時間={start_time}, detail={e}')


### PR DESCRIPTION
## なぜこの変更が必要か

- PR #583 への Codex Review 指摘（P2）のフォローアップ。#583 は IntegrityError を無条件に重複として扱うため、FK違反等の本来調査すべき整合性エラーまで warning に格下げされ、Error Reporting から消える構造だった（Fail Loud 違反）

## 変更内容

- IntegrityError 捕捉時に重複行（community, date, start_time）の実在を確認し、存在しない場合は再送出して既存の一般エラー処理（error ログ + 汎用メッセージ）へ渡す
- 判別に制約名の文字列マッチを使わないのは、sqlite（テスト）と MySQL（本番）でエラーメッセージ書式が異なり脆いため

## テスト

- [x] 重複行なしで IntegrityError（FK違反の代理として mock 注入）→ 汎用エラー + ERROR ログ維持（修正前 FAIL・修正後 OK を確認）
- [x] 実重複 → 従来どおり重複メッセージ + warning のみ
- [x] event スイート全体 OK (skipped=20)

関連: #568（close 済み）, PR #583

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)