### PR TITLE
feat: 集会登録フォームに審査基準の表示と同意チェックを追加する

### DIFF
--- a/app/community/forms.py
+++ b/app/community/forms.py
@@ -149,6 +149,15 @@ class CommunityUpdateForm(VrcGroupUrlMixin, forms.ModelForm):
 class CommunityCreateForm(VrcGroupUrlMixin, forms.ModelForm):
     """集会新規登録用フォーム."""
 
+    guidelines_agreed = forms.BooleanField(
+        label='掲載・審査基準とガイドラインを確認し、遵守することに同意します。',
+        required=True,
+        widget=forms.CheckboxInput(attrs={'class': 'form-check-input'}),
+        error_messages={
+            'required': '登録するには、掲載・審査基準とガイドラインへの同意が必要です。',
+        },
+    )
+
     weekdays = forms.MultipleChoiceField(
         label='曜日',
         choices=WEEKDAY_CHOICES,

--- a/app/community/forms.py
+++ b/app/community/forms.py
@@ -149,12 +149,14 @@ class CommunityUpdateForm(VrcGroupUrlMixin, forms.ModelForm):
 class CommunityCreateForm(VrcGroupUrlMixin, forms.ModelForm):
     """集会新規登録用フォーム."""
 
+    # 同意対象は公開文書として実在する「掲載・審査基準」に限定する
+    # （独立したガイドライン文書は存在しないため、読めないものへの同意を求めない）
     guidelines_agreed = forms.BooleanField(
-        label='掲載・審査基準とガイドラインを確認し、遵守することに同意します。',
+        label='掲載・審査基準を確認し、内容に同意します。',
         required=True,
         widget=forms.CheckboxInput(attrs={'class': 'form-check-input'}),
         error_messages={
-            'required': '登録するには、掲載・審査基準とガイドラインへの同意が必要です。',
+            'required': '登録するには、掲載・審査基準への同意が必要です。',
         },
     )
 

--- a/app/community/templates/community/create.html
+++ b/app/community/templates/community/create.html
@@ -5,10 +5,24 @@
     <div class="container my-5">
         <div class="row">
             <div class="col-md-10 offset-md-1">
-                <div class="alert alert-info" role="note">
-                    登録前に、掲載対象と審査の考え方をまとめた
-                    <a href="{% url 'community:criteria' %}" class="alert-link">掲載・審査基準</a>
-                    をご確認ください。
+                <div id="criteria-summary" class="alert alert-info" role="note">
+                    <h2 class="h5 alert-heading">登録種別と審査基準</h2>
+                    <p>このフォームでは、登録する集会の主な目的に合う「技術系」または「学術系」のタグを選択してください。</p>
+                    <ul class="mb-3">
+                        <li><strong>技術系:</strong> 実践的な技術の習得・共有・発表を主目的とする集会</li>
+                        <li><strong>学術系:</strong> 学術的な知見や研究成果の学習・議論・発表を主目的とする集会</li>
+                        <li><strong>協力団体:</strong> 技術・学術コミュニティへ具体的・継続的・検証可能な貢献を行う団体</li>
+                    </ul>
+                    <p class="mb-2">
+                        協力団体としての登録を希望する場合は、審査基準を確認のうえ、
+                        <a href="https://github.com/noricha-vr/vrc-ta-hub/issues" class="alert-link">運営へお問い合わせください</a>。
+                        <strong>協力団体は、Hubのポスター・アセット設置や、活動内でのHub紹介・宣伝への協力が必須条件です。</strong>
+                    </p>
+                    <p class="mb-0">
+                        対象例や詳しい条件は
+                        <a href="{% url 'community:criteria' %}" class="alert-link">掲載・審査基準</a>
+                        をご確認ください。
+                    </p>
                 </div>
                 <form method="post" enctype="multipart/form-data">
                     {% csrf_token %}
@@ -35,6 +49,13 @@
                             {% bootstrap_field form.description %}
                             {% bootstrap_field form.platform %}
                             {% bootstrap_field form.tags %}
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-header fw-bold">登録前の確認</div>
+                        <div class="card-body">
+                            {% bootstrap_field form.guidelines_agreed %}
                         </div>
                     </div>
 

--- a/app/community/templates/community/create.html
+++ b/app/community/templates/community/create.html
@@ -56,6 +56,9 @@
                         <div class="card-header fw-bold">登録前の確認</div>
                         <div class="card-body">
                             {% bootstrap_field form.guidelines_agreed %}
+                            <p class="text-muted small mb-0">
+                                同意対象: <a href="{% url 'community:criteria' %}" target="_blank" rel="noopener">掲載・審査基準</a>
+                            </p>
                         </div>
                     </div>
 

--- a/app/community/tests/test_community_create.py
+++ b/app/community/tests/test_community_create.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 
 from allauth.socialaccount.models import SocialApp
 from django.contrib.sites.models import Site
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, Client, override_settings
 from django.urls import reverse
 
@@ -29,7 +30,8 @@ class CommunityCreateFormTest(TestCase):
         required_fields = [
             'name', 'start_time', 'duration', 'weekdays', 'frequency', 'organizers',
             'group_url', 'organizer_url', 'sns_url', 'discord', 'twitter_hashtag',
-            'poster_image', 'allow_poster_repost', 'description', 'platform', 'tags'
+            'poster_image', 'allow_poster_repost', 'description', 'platform', 'tags',
+            'guidelines_agreed',
         ]
         for field in required_fields:
             self.assertIn(field, form.fields)
@@ -43,6 +45,14 @@ class CommunityCreateFormTest(TestCase):
         """tagsが必須であることをテスト."""
         form = CommunityCreateForm()
         self.assertTrue(form.fields['tags'].required)
+
+    def test_guidelines_agreement_is_required_and_not_stored_on_model(self):
+        """ガイドライン同意が必須の非モデルフィールドであることをテスト."""
+        form = CommunityCreateForm()
+
+        self.assertTrue(form.fields['guidelines_agreed'].required)
+        self.assertFalse(bool(form.fields['guidelines_agreed'].initial))
+        self.assertNotIn('guidelines_agreed', [field.name for field in Community._meta.fields])
 
     def test_tags_uses_form_tags_only(self):
         """tagsがFORM_TAGS（技術系・学術系）のみを使用していることをテスト."""
@@ -99,6 +109,37 @@ class CommunityCreateViewTest(TestCase):
         )
         self.create_url = reverse('community:create')
 
+    def _make_post_data(self, *, name='テスト集会名', organizer_url=''):
+        """有効な集会登録データを生成する."""
+        test_image = SimpleUploadedFile(
+            name='test_poster.jpg',
+            content=(
+                b'\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x00\x00\x00\x21'
+                b'\xf9\x04\x01\x0a\x00\x01\x00\x2c\x00\x00\x00\x00\x01\x00\x01'
+                b'\x00\x00\x02\x02\x4c\x01\x00\x3b'
+            ),
+            content_type='image/gif',
+        )
+        return {
+            'name': name,
+            'start_time': '20:00',
+            'duration': 60,
+            'weekdays': ['Sat'],
+            'frequency': '毎週',
+            'organizers': 'テスト主催者',
+            'group_url': '',
+            'organizer_url': organizer_url,
+            'sns_url': '',
+            'discord': '',
+            'twitter_hashtag': '',
+            'poster_image': test_image,
+            'allow_poster_repost': True,
+            'description': 'テスト説明',
+            'platform': 'All',
+            'tags': ['tech'],
+            'guidelines_agreed': True,
+        }
+
     def test_unauthenticated_user_redirected_to_login(self):
         """未認証ユーザーがログインページにリダイレクトされることをテスト."""
         response = self.client.get(self.create_url)
@@ -112,6 +153,22 @@ class CommunityCreateViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'community/create.html')
         self.assertContains(response, 'A4比率・縦4096px')
+
+    def test_submission_without_guidelines_agreement_is_rejected(self):
+        """ガイドラインに同意しない送信では集会を作成しないことをテスト."""
+        self.client.login(username='テストユーザー', password='testpass123')
+        post_data = self._make_post_data(name='未同意集会')
+        post_data.pop('guidelines_agreed')
+
+        response = self.client.post(self.create_url, post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(
+            response.context['form'],
+            'guidelines_agreed',
+            '登録するには、掲載・審査基準とガイドラインへの同意が必要です。',
+        )
+        self.assertFalse(Community.objects.filter(name='未同意集会').exists())
 
     def test_user_with_existing_community_can_access_create_page(self):
         """既に集会を持っているユーザーも集会登録ページにアクセスできることをテスト（複数集会対応）."""
@@ -139,39 +196,13 @@ class CommunityCreateViewTest(TestCase):
 
         nameフィールドを含めて送信し、集会が正常に作成されることを確認する。
         """
-        from django.core.files.uploadedfile import SimpleUploadedFile
-
         # Discord通知のモック
         mock_discord_post.return_value = MagicMock(status_code=200)
 
         self.client.login(username='テストユーザー', password='testpass123')
-
-        # テスト用の画像ファイルを作成
-        test_image = SimpleUploadedFile(
-            name='test_poster.jpg',
-            content=b'\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x00\x00\x00\x21\xf9\x04\x01\x0a\x00\x01\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x4c\x01\x00\x3b',
-            content_type='image/gif'
+        post_data = self._make_post_data(
+            organizer_url='https://vrchat.com/home/user/usr_01b02b0e-58b5-4558-a6ca-56dd32dafdad',
         )
-
-        # POSTデータ（nameを含む）
-        post_data = {
-            'name': 'テスト集会名',
-            'start_time': '20:00',
-            'duration': 60,
-            'weekdays': ['Sat'],
-            'frequency': '毎週',
-            'organizers': 'テスト主催者',
-            'group_url': '',
-            'organizer_url': 'https://vrchat.com/home/user/usr_01b02b0e-58b5-4558-a6ca-56dd32dafdad',
-            'sns_url': '',
-            'discord': '',
-            'twitter_hashtag': '',
-            'poster_image': test_image,
-            'allow_poster_repost': True,
-            'description': 'テスト説明',
-            'platform': 'All',
-            'tags': ['tech'],
-        }
 
         response = self.client.post(self.create_url, post_data)
 
@@ -201,39 +232,11 @@ class CommunityCreateViewTest(TestCase):
     @patch('community.views.manage.requests.post')
     def test_community_create_creates_owner_membership(self, mock_discord_post):
         """集会作成時にオーナーとしてCommunityMemberが作成されることをテスト."""
-        from django.core.files.uploadedfile import SimpleUploadedFile
-
         # Discord通知のモック
         mock_discord_post.return_value = MagicMock(status_code=200)
 
         self.client.login(username='テストユーザー', password='testpass123')
-
-        # テスト用の画像ファイルを作成
-        test_image = SimpleUploadedFile(
-            name='test_poster.jpg',
-            content=b'\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x00\x00\x00\x21\xf9\x04\x01\x0a\x00\x01\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x4c\x01\x00\x3b',
-            content_type='image/gif'
-        )
-
-        # POSTデータ
-        post_data = {
-            'name': 'オーナーテスト集会',
-            'start_time': '20:00',
-            'duration': 60,
-            'weekdays': ['Sat'],
-            'frequency': '毎週',
-            'organizers': 'テスト主催者',
-            'group_url': '',
-            'organizer_url': '',
-            'sns_url': '',
-            'discord': '',
-            'twitter_hashtag': '',
-            'poster_image': test_image,
-            'allow_poster_repost': True,
-            'description': 'テスト説明',
-            'platform': 'All',
-            'tags': ['tech'],
-        }
+        post_data = self._make_post_data(name='オーナーテスト集会')
 
         response = self.client.post(self.create_url, post_data)
 
@@ -263,8 +266,6 @@ class CommunityCreateViewTest(TestCase):
     @patch('community.views.manage.requests.post')
     def test_user_with_existing_community_can_create_new_community(self, mock_discord_post):
         """既に集会を持っているユーザーが新しい集会を作成できることをテスト（複数集会対応）."""
-        from django.core.files.uploadedfile import SimpleUploadedFile
-
         # Discord通知のモック
         mock_discord_post.return_value = MagicMock(status_code=200)
 
@@ -282,33 +283,7 @@ class CommunityCreateViewTest(TestCase):
         )
 
         self.client.login(username='テストユーザー', password='testpass123')
-
-        # テスト用の画像ファイルを作成
-        test_image = SimpleUploadedFile(
-            name='test_poster.jpg',
-            content=b'\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x00\x00\x00\x21\xf9\x04\x01\x0a\x00\x01\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x4c\x01\x00\x3b',
-            content_type='image/gif'
-        )
-
-        # POSTデータ
-        post_data = {
-            'name': '新規集会',
-            'start_time': '20:00',
-            'duration': 60,
-            'weekdays': ['Sat'],
-            'frequency': '毎週',
-            'organizers': 'テスト主催者',
-            'group_url': '',
-            'organizer_url': '',
-            'sns_url': '',
-            'discord': '',
-            'twitter_hashtag': '',
-            'poster_image': test_image,
-            'allow_poster_repost': True,
-            'description': 'テスト説明',
-            'platform': 'All',
-            'tags': ['tech'],
-        }
+        post_data = self._make_post_data(name='新規集会')
 
         response = self.client.post(self.create_url, post_data)
 

--- a/app/community/tests/test_community_create.py
+++ b/app/community/tests/test_community_create.py
@@ -166,7 +166,7 @@ class CommunityCreateViewTest(TestCase):
         self.assertFormError(
             response.context['form'],
             'guidelines_agreed',
-            '登録するには、掲載・審査基準とガイドラインへの同意が必要です。',
+            '登録するには、掲載・審査基準への同意が必要です。',
         )
         self.assertFalse(Community.objects.filter(name='未同意集会').exists())
 

--- a/app/community/tests/test_criteria_page.py
+++ b/app/community/tests/test_criteria_page.py
@@ -42,9 +42,19 @@ class CommunityCriteriaPageTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         soup = BeautifulSoup(response.content, 'html.parser')
-        criteria_alert = soup.select_one('div.alert.alert-info[role="note"]')
+        criteria_alert = soup.select_one('#criteria-summary[role="note"]')
         criteria_link = criteria_alert.select_one(f'a.alert-link[href="{self.criteria_url}"]')
         self.assertEqual(criteria_link.get_text(strip=True), '掲載・審査基準')
+        contact_link = criteria_alert.select_one(
+            'a[href="https://github.com/noricha-vr/vrc-ta-hub/issues"]',
+        )
+        self.assertEqual(contact_link.get_text(strip=True), '運営へお問い合わせください')
+        summary_text = criteria_alert.get_text(' ', strip=True)
+        for category in ('技術系', '学術系', '協力団体'):
+            self.assertIn(category, summary_text)
+        self.assertIn('このフォームでは', summary_text)
+        self.assertIn('運営へお問い合わせください', summary_text)
+        self.assertIn('Hub紹介・宣伝への協力が必須条件', summary_text)
 
     def test_common_footer_links_to_criteria(self):
         response = self.client.get(reverse('ta_hub:about'))

--- a/app/community/tests/test_criteria_page.py
+++ b/app/community/tests/test_criteria_page.py
@@ -43,23 +43,25 @@ class CommunityCriteriaPageTest(TestCase):
         self.assertEqual(response.status_code, 200)
         soup = BeautifulSoup(response.content, 'html.parser')
         criteria_alert = soup.select_one('#criteria-summary[role="note"]')
-        criteria_link = criteria_alert.select_one(f'a.alert-link[href="{self.criteria_url}"]')
-        self.assertEqual(criteria_link.get_text(strip=True), '掲載・審査基準')
-        contact_link = criteria_alert.select_one(
-            'a[href="https://github.com/noricha-vr/vrc-ta-hub/issues"]',
+        # 文言の逐語検証はせず、導線（リンク）と各種別への言及だけを検証する
+        # （言い回しの調整で壊れる change-detector を避ける）
+        self.assertIsNotNone(
+            criteria_alert.select_one(f'a[href="{self.criteria_url}"]'),
         )
-        self.assertEqual(contact_link.get_text(strip=True), '運営へお問い合わせください')
+        self.assertIsNotNone(
+            criteria_alert.select_one(
+                'a[href="https://github.com/noricha-vr/vrc-ta-hub/issues"]',
+            ),
+        )
         summary_text = criteria_alert.get_text(' ', strip=True)
         for category in ('技術系', '学術系', '協力団体'):
             self.assertIn(category, summary_text)
-        self.assertIn('このフォームでは', summary_text)
-        self.assertIn('運営へお問い合わせください', summary_text)
-        self.assertIn('Hub紹介・宣伝への協力が必須条件', summary_text)
+        # 協力団体希望者への案内（Hub への宣伝協力が条件であること）が含まれる
+        self.assertIn('Hub紹介・宣伝への協力', summary_text)
 
     def test_common_footer_links_to_criteria(self):
         response = self.client.get(reverse('ta_hub:about'))
 
         self.assertEqual(response.status_code, 200)
         soup = BeautifulSoup(response.content, 'html.parser')
-        footer_link = soup.select_one(f'footer a[href="{self.criteria_url}"]')
-        self.assertEqual(footer_link.get_text(strip=True), '掲載・審査基準')
+        self.assertIsNotNone(soup.select_one(f'footer a[href="{self.criteria_url}"]'))


### PR DESCRIPTION
## なぜこの変更が必要か

- 関連Issue: #586（Closes #586）
- 利用登録の時点で審査基準が見えず、承認可否を予測できないまま申請されていた（Issue #566 の3分割の (B)。基準公開ページは #588 で実装済み）

## 変更内容

- 登録フォーム上部に3種別（技術系・学術系・協力団体）の定義要約と基準公開ページへのリンクを表示
- 協力団体希望者向けに「Hub のポスター/アセット設置・宣伝協力が必須条件」の案内と運営問い合わせ導線を表示
- ガイドライン遵守の同意チェックを必須化（モデル変更なし・forms.BooleanField）

## テスト

- [x] 同意なし送信 → バリデーションエラー / 既存登録フロー緑
- [x] community.tests 327件 OK
- [x] codex レビュー: must-fix なし（should-fix のテスト文言列挙は構造検証に修正済み）

## Screenshot

![登録フォーム](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/5f46fe566dfa-586-create-form.avif)

Closes #586

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)