### PR TITLE
style(community): 発表履歴の「もっと見る」を中央揃えにする

### DIFF
--- a/app/community/templates/community/detail.html
+++ b/app/community/templates/community/detail.html
@@ -347,7 +347,7 @@
                         {% endfor %}
                         </tbody>
                     </table>
-                    <div class="text-end">
+                    <div class="text-center">
                         <a href="{% url 'event:detail_history' %}?community_name={{ community.name|urlencode }}"
                            class=" btn btn-primary">
                             もっと見る</a>


### PR DESCRIPTION
## なぜこの変更が必要か

集会詳細ページの「発表履歴」セクション最下部にある「もっと見る」ボタンが右下配置で目に留まりにくいため、ユーザーから中央揃えへの変更要望があった（Issue #600、スクリーンショット付き依頼）。

## 変更内容

- `app/community/templates/community/detail.html:350` のラッパーを `text-end` → `text-center` に変更（Bootstrap ユーティリティクラス 1 語のみ）

## 意思決定

- 依頼スコープは発表履歴セクションのみのため、404 行付近の活動履歴セクションの「もっと見る」（`text-end`）は変更していない

## テスト

- [x] `docker compose run --rm vrc-ta-hub python manage.py test community` — 329 tests OK（スタイリングのみのため新規テストなし）
- [x] Playwright でボタン中心とラッパー中心の座標一致（delta 0px）・リンク先不変を確認

## Screenshot

| Before | After |
|--------|-------|
| ![Before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/8e4774f7ed60-Screenshot-2026-08-05-9-50-14.avif) | ![After](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/bec68e4c6efc-01-past-events-more-button-20260805-131302.avif) |

Closes #600

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)