### PR TITLE
feat(event): 発表詳細でサムネイルをYouTube動画より上に表示する

### DIFF
--- a/app/event/templates/event/detail.html
+++ b/app/event/templates/event/detail.html
@@ -152,10 +152,11 @@
                 <h1 class="mb-3">{{ event_detail.title }}</h1>
                 {% if event_detail.thumbnail_image %}
                     <div class="mb-4">
+                        {# ファーストビューの主要画像（LCP 候補）のため lazy にせず優先読み込みする #}
                         <img src="{{ event_detail.thumbnail_image.url|cf_resize:'1200' }}"
                              class="event-detail-thumbnail img-fluid rounded shadow-sm"
                              alt="{{ event_detail.title }}のサムネイル"
-                             loading="lazy">
+                             fetchpriority="high">
                     </div>
                 {% endif %}
 

--- a/app/event/templates/event/detail.html
+++ b/app/event/templates/event/detail.html
@@ -150,16 +150,19 @@
             <div class="col-lg-12">
                 {% include 'ta_hub/messages.html' %}
                 <h1 class="mb-3">{{ event_detail.title }}</h1>
-                {# Youtube動画を埋め込み#}
-                {% if video_id %}
-                    <div class="mb-3">
-                        <div class="ratio ratio-16x9">
-                            <iframe src="https://www.youtube.com/embed/{{ video_id }}{% if start_time %}?start={{ start_time }}{% endif %}"
-                                    title="{{ event_detail.theme }} - {{ event_detail.speaker }}"
-                                    allowfullscreen
-                                    referrerpolicy="strict-origin-when-cross-origin"
-                                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"></iframe>
-                        </div>
+                {% if event_detail.thumbnail_image %}
+                    <div class="mb-4">
+                        <img src="{{ event_detail.thumbnail_image.url|cf_resize:'1200' }}"
+                             class="event-detail-thumbnail img-fluid rounded shadow-sm"
+                             alt="{{ event_detail.title }}のサムネイル"
+                             loading="lazy">
+                    </div>
+                {% endif %}
+
+                {# アクセス解析（管理者向けメニュー扱いのためサムネイル直下・管理ボタン群の上に配置。集会管理者 / superuser のみ表示） #}
+                {% if can_view_analytics %}
+                    <div class="analytics-card">
+                        {% include 'analytics/_chart_section.html' %}
                     </div>
                 {% endif %}
 
@@ -298,22 +301,20 @@
                     {% endif %}
                 {% endif %}
 
-                {# アクセス解析（管理者向けメニュー扱いのためサムネイル上に配置。集会管理者 / superuser のみ表示） #}
-                {% if can_view_analytics %}
-                    <div class="analytics-card">
-                        {% include 'analytics/_chart_section.html' %}
+                {# Youtube動画を埋め込み#}
+                {% if video_id %}
+                    <div class="mb-3">
+                        <div class="ratio ratio-16x9">
+                            <iframe src="https://www.youtube.com/embed/{{ video_id }}{% if start_time %}?start={{ start_time }}{% endif %}"
+                                    title="{{ event_detail.theme }} - {{ event_detail.speaker }}"
+                                    allowfullscreen
+                                    referrerpolicy="strict-origin-when-cross-origin"
+                                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"></iframe>
+                        </div>
                     </div>
                 {% endif %}
 
                 {# detail_typeによって詳細情報の表示を切り替え #}
-                {% if event_detail.thumbnail_image %}
-                    <div class="mb-4">
-                        <img src="{{ event_detail.thumbnail_image.url|cf_resize:'1200' }}"
-                             class="event-detail-thumbnail img-fluid rounded shadow-sm"
-                             alt="{{ event_detail.title }}のサムネイル"
-                             loading="lazy">
-                    </div>
-                {% endif %}
                 {% if event_detail.detail_type == 'LT' %}
                     {% include 'event/detail_info_lt.html' %}
                 {% elif event_detail.detail_type == 'SPECIAL' %}

--- a/app/event/tests/test_event_detail_media_order.py
+++ b/app/event/tests/test_event_detail_media_order.py
@@ -9,8 +9,8 @@ from django.core.files.base import ContentFile
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from community.models import Community
-from event.models import Event, EventDetail
+from event.models import EventDetail
+from tests.factories import make_community, make_event, make_event_detail
 
 # 1x1 の最小 PNG。ImageField のバリデーションを通すためだけに使う
 MINIMAL_PNG = bytes.fromhex(
@@ -25,27 +25,24 @@ class EventDetailMediaOrderTests(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.community = Community.objects.create(
-            name='順序検証集会', status='approved', frequency='毎週', organizers='主催',
+        cls.community = make_community(
+            name='順序検証集会', frequency='毎週', organizers='主催',
         )
-        cls.event = Event.objects.create(
-            community=cls.community,
-            date=date(2026, 2, 10),
+        cls.event = make_event(
+            cls.community,
+            event_date=date(2026, 2, 10),
             start_time=time(22, 0),
-            duration=60,
             weekday='Tue',
         )
 
     def _create_detail(self, *, with_video: bool, with_thumbnail: bool) -> EventDetail:
-        detail = EventDetail.objects.create(
-            event=self.event,
-            detail_type='LT',
-            start_time=time(22, 0),
-            duration=30,
+        detail = make_event_detail(
+            self.event,
+            status='approved',
             speaker='Speaker',
             theme=f'video={with_video} thumb={with_thumbnail}',
+            start_time=time(22, 0),
             contents='contents',
-            status='approved',
             youtube_url='https://www.youtube.com/watch?v=dQw4w9WgXcQ' if with_video else '',
         )
         if with_thumbnail:

--- a/app/event/tests/test_event_detail_media_order.py
+++ b/app/event/tests/test_event_detail_media_order.py
@@ -1,0 +1,88 @@
+"""イベント詳細ページのサムネイル画像とYouTube動画の表示順序テスト.
+
+サムネイルと動画の内容がほぼ同じ絵になるため、上部にサムネイル・下部に動画を置く。
+レンダリング結果の HTML 上での出現順で検証する（Issue #599）。
+"""
+from datetime import date, time
+
+from django.core.files.base import ContentFile
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from community.models import Community
+from event.models import Event, EventDetail
+
+# 1x1 の最小 PNG。ImageField のバリデーションを通すためだけに使う
+MINIMAL_PNG = bytes.fromhex(
+    '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4'
+    '890000000a49444154789c6300010000050001'
+    '0d0a2db40000000049454e44ae426082'
+)
+
+
+class EventDetailMediaOrderTests(TestCase):
+    """サムネイル画像がYouTube動画より先に表示される."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.community = Community.objects.create(
+            name='順序検証集会', status='approved', frequency='毎週', organizers='主催',
+        )
+        cls.event = Event.objects.create(
+            community=cls.community,
+            date=date(2026, 2, 10),
+            start_time=time(22, 0),
+            duration=60,
+            weekday='Tue',
+        )
+
+    def _create_detail(self, *, with_video: bool, with_thumbnail: bool) -> EventDetail:
+        detail = EventDetail.objects.create(
+            event=self.event,
+            detail_type='LT',
+            start_time=time(22, 0),
+            duration=30,
+            speaker='Speaker',
+            theme=f'video={with_video} thumb={with_thumbnail}',
+            contents='contents',
+            status='approved',
+            youtube_url='https://www.youtube.com/watch?v=dQw4w9WgXcQ' if with_video else '',
+        )
+        if with_thumbnail:
+            detail.thumbnail_image.save(
+                f'order-test-{detail.pk}.png', ContentFile(MINIMAL_PNG), save=True
+            )
+        return detail
+
+    def _get_html(self, detail: EventDetail) -> str:
+        response = Client().get(reverse('event:detail', kwargs={'pk': detail.pk}))
+        self.assertEqual(response.status_code, 200)
+        return response.content.decode('utf-8')
+
+    def test_thumbnail_appears_before_youtube_embed(self):
+        """動画とサムネイルが両方ある時、サムネイルが動画より上に出る."""
+        detail = self._create_detail(with_video=True, with_thumbnail=True)
+
+        html = self._get_html(detail)
+
+        thumbnail_pos = html.index('event-detail-thumbnail img-fluid')
+        video_pos = html.index('https://www.youtube.com/embed/')
+        self.assertLess(thumbnail_pos, video_pos)
+
+    def test_video_only_page_renders_embed_without_thumbnail(self):
+        """サムネイルが無くても動画は表示され、空の画像枠は出ない."""
+        detail = self._create_detail(with_video=True, with_thumbnail=False)
+
+        html = self._get_html(detail)
+
+        self.assertIn('https://www.youtube.com/embed/', html)
+        self.assertNotIn('event-detail-thumbnail img-fluid', html)
+
+    def test_thumbnail_only_page_renders_image_without_embed(self):
+        """動画が無くてもサムネイルは表示され、空の動画枠は出ない."""
+        detail = self._create_detail(with_video=False, with_thumbnail=True)
+
+        html = self._get_html(detail)
+
+        self.assertIn('event-detail-thumbnail img-fluid', html)
+        self.assertNotIn('https://www.youtube.com/embed/', html)


### PR DESCRIPTION
## なぜこの変更が必要か

発表詳細ページで YouTube 埋め込みとサムネイル画像がほぼ同じ絵で連続して見えており、ユーザーから「サムネイルを上・動画を下」への入れ替え要望があった（Issue #599）。

## 変更内容

- `app/event/templates/event/detail.html`: サムネイル画像をタイトル直下へ移動、アクセス解析カードをサムネイル直下に併置、YouTube 動画を詳細情報の直前へ移動
- 管理ボタン群・X告知・ブログ本文編集の説明は現在の位置を維持
- `app/event/tests/test_event_detail_media_order.py`: 表示順の回帰テスト3本を新規追加（変更前テンプレートで失敗することを確認済み）

## 意思決定

- アクセス解析カードは「サムネイル上に配置」という既存コメントの前提を保つため、サムネイルとセットで上へ移動（ユーザー選択）
- `{% if %}` 分岐は維持し、動画なし/サムネイルなしのイベントで空枠が出ない構造を保持

## テスト

- [x] `docker compose run --rm vrc-ta-hub python manage.py test event` — 598 tests OK (skipped=20)
- [x] 動画+サムネ / 動画のみ / サムネのみ の3パターンをブラウザで表示確認

## Screenshot

| Before | After |
|--------|-------|
| ![Before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/653324de6c9d-Screenshot-2026-08-05-9-54-34.avif) | ![After](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/524b3271b62b-01-video-and-thumbnail-20260805-133200.avif) |

Closes #599

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)