### PR TITLE
feat(community): メンバー管理で同名ユーザーを識別できる情報を併記する

### DIFF
--- a/app/community/templates/community/member_manage.html
+++ b/app/community/templates/community/member_manage.html
@@ -87,19 +87,17 @@
                     </span>
                     {# 同名ユーザーの誤操作防止: メールアドレスは出さず、Discord連携の有無と登録日で区別する #}
                     {% if member.has_discord_link %}
-                    <span class="badge bg-light text-dark border ms-2" title="Discord連携あり">
+                    <span class="badge bg-light text-dark border ms-2">
                         <i class="bi bi-discord me-1" aria-hidden="true"></i>Discord連携あり
                     </span>
                     {% else %}
-                    <span class="badge bg-light text-muted border ms-2" title="Discord連携なし">
+                    <span class="badge bg-light text-muted border ms-2">
                         <i class="bi bi-slash-circle me-1" aria-hidden="true"></i>Discord連携なし
                     </span>
                     {% endif %}
-                    <div class="text-muted mt-1">
-                        <small>
-                            <i class="bi bi-person-plus me-1" aria-hidden="true"></i>登録日 {{ member.user.date_joined|date:"Y/m/d" }}
-                            <span class="ms-2"><i class="bi bi-calendar-plus me-1" aria-hidden="true"></i>メンバー追加 {{ member.created_at|date:"Y/m/d" }}</span>
-                        </small>
+                    <div class="text-muted small mt-1">
+                        <i class="bi bi-person-plus me-1" aria-hidden="true"></i>登録日 {{ member.user.date_joined|date:"Y/m/d" }}
+                        <span class="ms-2"><i class="bi bi-calendar-plus me-1" aria-hidden="true"></i>メンバー追加 {{ member.created_at|date:"Y/m/d" }}</span>
                     </div>
                 </div>
                 {% if not member.is_owner or members|length > 1 %}

--- a/app/community/templates/community/member_manage.html
+++ b/app/community/templates/community/member_manage.html
@@ -96,7 +96,8 @@
                     </span>
                     {% endif %}
                     <div class="text-muted small mt-1">
-                        <i class="bi bi-person-plus me-1" aria-hidden="true"></i>登録日 {{ member.user.date_joined|date:"Y/m/d" }}
+                        {# 同日登録の同名ユーザーも区別できるよう時刻（分）まで表示する #}
+                        <i class="bi bi-person-plus me-1" aria-hidden="true"></i>登録日 {{ member.user.date_joined|date:"Y/m/d H:i" }}
                         <span class="ms-2"><i class="bi bi-calendar-plus me-1" aria-hidden="true"></i>メンバー追加 {{ member.created_at|date:"Y/m/d" }}</span>
                     </div>
                 </div>

--- a/app/community/templates/community/member_manage.html
+++ b/app/community/templates/community/member_manage.html
@@ -85,7 +85,22 @@
                     <span class="badge {% if member.is_owner %}bg-primary{% else %}bg-secondary{% endif %} ms-2">
                         {{ member.get_role_display }}
                     </span>
-                    <small class="text-muted ms-2">{{ member.created_at|date:"Y/m/d" }} 追加</small>
+                    {# 同名ユーザーの誤操作防止: メールアドレスは出さず、Discord連携の有無と登録日で区別する #}
+                    {% if member.has_discord_link %}
+                    <span class="badge bg-light text-dark border ms-2" title="Discord連携あり">
+                        <i class="bi bi-discord me-1" aria-hidden="true"></i>Discord連携あり
+                    </span>
+                    {% else %}
+                    <span class="badge bg-light text-muted border ms-2" title="Discord連携なし">
+                        <i class="bi bi-slash-circle me-1" aria-hidden="true"></i>Discord連携なし
+                    </span>
+                    {% endif %}
+                    <div class="text-muted mt-1">
+                        <small>
+                            <i class="bi bi-person-plus me-1" aria-hidden="true"></i>登録日 {{ member.user.date_joined|date:"Y/m/d" }}
+                            <span class="ms-2"><i class="bi bi-calendar-plus me-1" aria-hidden="true"></i>メンバー追加 {{ member.created_at|date:"Y/m/d" }}</span>
+                        </small>
+                    </div>
                 </div>
                 {% if not member.is_owner or members|length > 1 %}
                 {% if member.user != request.user or not member.is_owner %}

--- a/app/community/tests/test_member_identity_display.py
+++ b/app/community/tests/test_member_identity_display.py
@@ -1,0 +1,109 @@
+"""同名メンバーの識別表示とメールアドレス非露出の検証。
+
+user_name の unique 制約解除（#579）により、メンバー管理画面で完全に同じ表示名の
+ユーザーが並び得る。権限操作（削除・昇格）で別人を誤操作しないための副次情報が
+出ていること、その副次情報に email が含まれないことを振る舞いとして検証する。
+"""
+from django.db import connection
+from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from community.models import CommunityMember
+from tests.factories import (
+    make_community,
+    make_community_member,
+    make_discord_linked_user,
+    make_user,
+)
+
+DUPLICATE_NAME = 'かぶり太郎'
+
+
+class SameNameMemberIdentificationTest(TestCase):
+    """同名ユーザーが視覚的に区別できることの検証"""
+
+    def setUp(self):
+        self.client = Client()
+        self.owner = make_user(user_name='オーナー', email='owner@example.com')
+        # 表示名が完全一致する2人（片方だけ Discord 連携あり）
+        self.duplicate_linked = make_discord_linked_user(
+            user_name=DUPLICATE_NAME, email='dup-linked@example.com'
+        )
+        self.duplicate_unlinked = make_user(
+            user_name=DUPLICATE_NAME, email='dup-unlinked@example.com'
+        )
+
+        self.community = make_community(name='テスト集会', owner=self.owner)
+        for user in (self.duplicate_linked, self.duplicate_unlinked):
+            make_community_member(
+                self.community, user, role=CommunityMember.Role.STAFF
+            )
+
+        self.url = reverse(
+            'community:member_manage', kwargs={'pk': self.community.pk}
+        )
+
+    def test_same_name_members_are_distinguishable(self):
+        """同名メンバーの行に Discord 連携有無の差分が出る"""
+        self.client.force_login(self.owner)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        members = {m.user_id: m for m in response.context['members']}
+        self.assertTrue(members[self.duplicate_linked.pk].has_discord_link)
+        self.assertFalse(members[self.duplicate_unlinked.pk].has_discord_link)
+
+        content = response.content.decode()
+        self.assertIn('Discord連携あり', content)
+        self.assertIn('Discord連携なし', content)
+
+    def test_registration_date_is_rendered_for_each_member(self):
+        """各メンバーの登録日が描画され、副次情報として使える"""
+        joined = self.duplicate_unlinked.date_joined.replace(
+            year=2020, month=1, day=15
+        )
+        self.duplicate_unlinked.date_joined = joined
+        self.duplicate_unlinked.save(update_fields=['date_joined'])
+        self.client.force_login(self.owner)
+
+        response = self.client.get(self.url)
+
+        self.assertContains(response, '2020/01/15')
+
+    def test_member_emails_are_not_exposed(self):
+        """他メンバーのメールアドレスはレスポンスに現れない"""
+        self.client.force_login(self.owner)
+
+        response = self.client.get(self.url)
+
+        content = response.content.decode()
+        for user in (self.duplicate_linked, self.duplicate_unlinked):
+            self.assertNotIn(user.email, content)
+            # ローカルパートだけでも識別子として漏れないこと
+            self.assertNotIn(user.email.split('@')[0], content)
+
+    def test_query_count_does_not_grow_with_member_count(self):
+        """メンバーが増えてもクエリ数が増えない（Discord 連携判定の N+1 防止）"""
+        self.client.force_login(self.owner)
+        # 初回リクエストはセッション初期化などの追加クエリを含むため、計測前に温める
+        self.client.get(self.url)
+
+        with CaptureQueriesContext(connection) as before:
+            self.client.get(self.url)
+
+        for index in range(5):
+            extra = make_discord_linked_user(
+                user_name=DUPLICATE_NAME,
+                email=f'extra{index}@example.com',
+                discord_uid=f'discord-extra-{index}',
+            )
+            make_community_member(
+                self.community, extra, role=CommunityMember.Role.STAFF
+            )
+
+        with CaptureQueriesContext(connection) as after:
+            self.client.get(self.url)
+
+        self.assertEqual(len(after.captured_queries), len(before.captured_queries))

--- a/app/community/views/member.py
+++ b/app/community/views/member.py
@@ -1,8 +1,10 @@
 """メンバー管理系ビュー: 集会切り替え、メンバー管理、招待."""
 import logging
 
+from allauth.socialaccount.models import SocialAccount
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Exists, OuterRef
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -91,7 +93,14 @@ class CommunityMemberManageView(LoginRequiredMixin, AuthenticatedForbiddenMixin,
         context = super().get_context_data(**kwargs)
         community = get_object_or_404(Community, pk=self.kwargs['pk'])
         context['community'] = community
-        context['members'] = community.members.select_related('user').order_by('role', 'created_at')
+        # user_name の unique 制約解除により同名メンバーが並び得るため、
+        # email を出さずに識別できる副次情報（Discord 連携の有無・登録日）を併記する。
+        # Exists() で 1 クエリに畳み込み、メンバー数ぶんの SocialAccount 参照（N+1）を避ける。
+        context['members'] = community.members.select_related('user').annotate(
+            has_discord_link=Exists(
+                SocialAccount.objects.filter(user=OuterRef('user_id'), provider='discord')
+            )
+        ).order_by('role', 'created_at')
         # 有効な招待リンク一覧を取得
         context['invitations'] = community.invitations.filter(
             expires_at__gt=timezone.now()

--- a/app/event/notifications.py
+++ b/app/event/notifications.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.timezone import localtime
 
 from event.models import EventDetail
 from website.constants import build_site_url
@@ -351,9 +352,12 @@ def notify_speaker_account_linked(event_detail: EventDetail, user) -> None:
     if not webhook_url:
         return
 
+    # user_name の unique 制約解除で同名ユーザーが存在し得るため、登録日を添えて誤認を防ぐ。
+    # email は「公開しない」とサインアップ時に約束しているため通知にも載せない。
+    joined_on = localtime(user.date_joined).strftime("%Y/%m/%d")
     payload = {
         "content": (
-            f"{event_detail.theme} に {user.display_label} が"
+            f"{event_detail.theme} に {user.display_label}（登録日 {joined_on}）が"
             "アカウントを紐づけました"
         ),
         "allowed_mentions": {"parse": []},

--- a/app/event/tests/test_notifications.py
+++ b/app/event/tests/test_notifications.py
@@ -15,6 +15,7 @@ from event.notifications import (
     notify_owners_of_new_application,
     notify_applicant_of_result,
     notify_slide_material_published,
+    notify_speaker_account_linked,
     _send_discord_notification_for_new_application,
     _send_discord_notification_for_result,
 )
@@ -373,3 +374,40 @@ class DiscordWebhookSafeLoggingTest(TestCase):
                 self.assertNotIn("secret-token", logs)
                 self.assertNotIn("request failed", logs)
                 self.assertNotIn("Traceback", logs)
+
+
+class SpeakerAccountLinkedNotificationTest(TestCase):
+    """notify_speaker_account_linked の同名ユーザー識別と email 非露出"""
+
+    def setUp(self):
+        self.owner = _make_user("owner-link", "owner-link@example.com")
+        self.community = _make_community(owner=self.owner, webhook_url=WEBHOOK_URL)
+        self.event = _make_event(self.community)
+        self.event_detail = _make_event_detail(self.event)
+        self.speaker = _make_user("かぶり太郎", "linked-speaker@example.com")
+        self.speaker.date_joined = self.speaker.date_joined.replace(
+            year=2024, month=3, day=9
+        )
+        self.speaker.save(update_fields=["date_joined"])
+
+    @patch("event.notifications.post_discord_webhook")
+    def test_content_includes_registration_date_for_disambiguation(self, mock_post):
+        """同名ユーザーを区別できるよう登録日が本文に含まれる"""
+        mock_post.return_value = MagicMock(ok=True, status_code=200)
+
+        notify_speaker_account_linked(self.event_detail, self.speaker)
+
+        payload = mock_post.call_args.args[1]
+        self.assertIn(self.speaker.display_label, payload["content"])
+        self.assertIn("2024/03/09", payload["content"])
+
+    @patch("event.notifications.post_discord_webhook")
+    def test_content_does_not_expose_email(self, mock_post):
+        """通知本文にメールアドレスを含めない"""
+        mock_post.return_value = MagicMock(ok=True, status_code=200)
+
+        notify_speaker_account_linked(self.event_detail, self.speaker)
+
+        payload = mock_post.call_args.args[1]
+        self.assertNotIn(self.speaker.email, payload["content"])
+        self.assertNotIn(self.speaker.email.split("@")[0], payload["content"])

--- a/app/event/tests/test_speaker_invite.py
+++ b/app/event/tests/test_speaker_invite.py
@@ -214,16 +214,15 @@ class SpeakerInviteTests(TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(duplicate_response.status_code, 200)
-        webhook_mock.assert_called_once_with(
-            webhook_url,
-            {
-                "content": (
-                    "署名付き招待URLの発表 に "
-                    f"{self.speaker.display_label} がアカウントを紐づけました"
-                ),
-                "allowed_mentions": {"parse": []},
-            },
-        )
+        # 検証の主眼は「重複POSTでも通知は1回だけ」。本文の細部（識別用の登録日など）は
+        # 変わり得るため、宛先と主要素のみを確認して change-detector 化を避ける。
+        webhook_mock.assert_called_once()
+        called_url, payload = webhook_mock.call_args.args
+        self.assertEqual(called_url, webhook_url)
+        self.assertIn("署名付き招待URLの発表", payload["content"])
+        self.assertIn(self.speaker.display_label, payload["content"])
+        self.assertIn("アカウントを紐づけました", payload["content"])
+        self.assertEqual(payload["allowed_mentions"], {"parse": []})
 
     def test_confirmation_skips_discord_notification_without_webhook(self):
         self.client.force_login(self.speaker)


### PR DESCRIPTION
## なぜこの変更が必要か

user_name の unique 制約解除（#579 フォローアップ、PR #604）により、メンバー管理画面・Discord 通知で同名ユーザーが完全一致で並び得る。owner が権限操作（削除）する画面で別人を誤認しないよう、識別可能な副次情報が必要（Issue #603）。

## 変更内容

- `app/community/views/member.py`: `Exists()` サブクエリで `has_discord_link` を注釈（N+1 回避）
- `app/community/templates/community/member_manage.html`: Discord 連携有無バッジ + 登録日/メンバー追加日を併記
- `app/event/notifications.py`: 発表者アカウント紐づけの Discord 通知本文に登録日を追加
- テスト: 同名識別・email 非露出・クエリ数非増加の6テストを追加、通知本文の完全一致 assert を主要素検証に緩和

## 意思決定

### 採用アプローチ
- 識別子は「Discord 連携有無 + 登録日」を採用。理由: email は「公開されません」の約束があり owner にも出せない。pk 下数桁は #601（連番 pk 露出廃止）の方向性と逆行する
- アイコンは FontAwesome ではなく Bootstrap Icons を使用。理由: 当該テンプレート・周辺画面が `bi bi-*` で統一済みのため一貫性を優先

### 却下した代替案
- email 併記 → 却下: サインアップ時の非公開約束に反する
- pk 下数桁 → 却下: #601 と矛盾

## テスト

- [x] `docker compose run --rm vrc-ta-hub python manage.py test`（全体）— 2159 tests OK (skipped 23)
- [x] レビューでミューテーション5種（provider 差し替え / 登録日削除×2 / email 露出 / N+1 化）の全検知を確認
- [x] セキュリティレビュー: ブロッキングなし（権限は owner 限定画面、email 非露出、XSS なし、webhook mention 抑止維持）
- [x] ブラウザ確認: 同名2人が Discord 連携有無 + 登録日で区別できることをスクリーンショットで確認

## Screenshot

![member-manage](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/344fd625c0f6-01-member-manage-desktop-20260805-131700.avif)

Closes #603

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)