### PR TITLE
feat(user_account): email 検証を mandatory 化しアカウント押し付けを防ぐ

### DIFF
--- a/app/tests/factories.py
+++ b/app/tests/factories.py
@@ -30,6 +30,8 @@ from typing import Optional
 
 from django.contrib.auth import get_user_model
 
+from allauth.account.models import EmailAddress
+
 from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
 
@@ -60,10 +62,42 @@ def make_user(
     Returns:
         作成された ``CustomUser`` インスタンス。
     """
+    user = User.objects.create_user(
+        user_name=user_name,
+        email=email,
+        password=password,
+        **extra,
+    )
+    if email:
+        EmailAddress.objects.create(
+            user=user,
+            email=user.email,
+            verified=True,
+            primary=True,
+        )
+    return user
+
+
+def make_user_without_email_address(
+    user_name: str,
+    email: str,
+    password: str = "testpass123",
+    **extra,
+):
+    """Create a programmatic user before allauth has synchronized its email."""
     return User.objects.create_user(
         user_name=user_name,
         email=email,
         password=password,
+        **extra,
+    )
+
+
+def make_legacy_user(user_name: str, email: str = "", **extra):
+    """Create a legacy-shaped row that may violate current manager requirements."""
+    return User.objects.create(
+        user_name=user_name,
+        email=email,
         **extra,
     )
 

--- a/app/user_account/adapters.py
+++ b/app/user_account/adapters.py
@@ -2,6 +2,7 @@
 import logging
 
 from allauth.account.adapter import DefaultAccountAdapter
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
@@ -105,6 +106,17 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
 
         existing_user = User.objects.filter(email__iexact=email).first()
         if not existing_user:
+            return
+
+        if not EmailAddress.objects.filter(
+            user=existing_user,
+            email__iexact=existing_user.email,
+            verified=True,
+        ).exists():
+            logger.warning(
+                "Skipping auto connect without a verified account email: user_id=%s",
+                existing_user.id,
+            )
             return
 
         if SocialAccount.objects.filter(

--- a/app/user_account/adapters.py
+++ b/app/user_account/adapters.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
+class ConfirmationEmailDeliveryError(Exception):
+    """確認メール生成・送信中の失敗を表す。"""
+
+
 class CustomAccountAdapter(DefaultAccountAdapter):
     """ログイン後の既定リダイレクト先を集会所属状況で切り替える。"""
 
@@ -36,6 +40,13 @@ class CustomAccountAdapter(DefaultAccountAdapter):
     def get_signup_redirect_url(self, request):
         """新規登録後の既定リダイレクト先を返す。"""
         return get_default_login_redirect_url(request.user)
+
+    def send_confirmation_mail(self, request, emailconfirmation, signup):
+        """確認メール処理の失敗を登録フローから識別できる形にする。"""
+        try:
+            return super().send_confirmation_mail(request, emailconfirmation, signup)
+        except Exception as exc:
+            raise ConfirmationEmailDeliveryError from exc
 
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):

--- a/app/user_account/admin.py
+++ b/app/user_account/admin.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 
 from allauth.account.models import EmailAddress
 
+from user_account.forms import consume_email_change_rate_limit
 from user_account.models import CustomUser, APIKey
 
 logger = logging.getLogger(__name__)
@@ -30,7 +31,8 @@ class VerifiedAdminAuthenticationForm(AdminAuthenticationForm):
 
 
 class CustomUserChangeForm(UserChangeForm):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, request=None, **kwargs):
+        self.request = request
         super().__init__(*args, **kwargs)
         self.original_email = self.instance.email
 
@@ -38,6 +40,14 @@ class CustomUserChangeForm(UserChangeForm):
         email = self.cleaned_data['email'].lower()
         if EmailAddress.objects.filter(email__iexact=email).exclude(user=self.instance).exists():
             raise ValidationError('このメールアドレスは既に登録されています。')
+        if (
+            self.instance.pk
+            and email != self.original_email
+            and not consume_email_change_rate_limit(self.request, self.instance)
+        ):
+            raise ValidationError(
+                'メールアドレスの変更回数が上限に達しました。時間をおいて再度お試しください。'
+            )
         return email
 
     def save(self, commit=True):
@@ -71,6 +81,18 @@ class CustomUserAdmin(UserAdmin):
     form = CustomUserChangeForm
     add_form = CustomUserCreationForm
 
+    def get_form(self, request, obj=None, **kwargs):
+        form_class = super().get_form(request, obj, **kwargs)
+        if obj is None:
+            return form_class
+
+        class RequestAwareUserChangeForm(form_class):
+            def __init__(self, *args, **form_kwargs):
+                form_kwargs['request'] = request
+                super().__init__(*args, **form_kwargs)
+
+        return RequestAwareUserChangeForm
+
     def save_model(self, request, obj, form, change):
         requested_email = form.cleaned_data['email'].lower()
         super().save_model(request, obj, form, change)
@@ -84,6 +106,7 @@ class CustomUserAdmin(UserAdmin):
                         'user_id=%s exception_type=%s',
                         obj.pk,
                         type(exc).__name__,
+                        exc_info=True,
                     )
                     self.message_user(
                         request,

--- a/app/user_account/admin.py
+++ b/app/user_account/admin.py
@@ -38,6 +38,8 @@ class CustomUserChangeForm(UserChangeForm):
 
     def clean_email(self):
         email = self.cleaned_data['email'].lower()
+        if CustomUser.objects.filter(email__iexact=email).exclude(pk=self.instance.pk).exists():
+            raise ValidationError('このメールアドレスは既に登録されています。')
         if EmailAddress.objects.filter(email__iexact=email).exclude(user=self.instance).exists():
             raise ValidationError('このメールアドレスは既に登録されています。')
         if (

--- a/app/user_account/admin.py
+++ b/app/user_account/admin.py
@@ -1,17 +1,66 @@
+import logging
+
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm
+from django.contrib.admin.forms import AdminAuthenticationForm
+from django.core.exceptions import ValidationError
+
+from allauth.account.models import EmailAddress
 
 from user_account.models import CustomUser, APIKey
 
+logger = logging.getLogger(__name__)
+
+
+class VerifiedAdminAuthenticationForm(AdminAuthenticationForm):
+    """Require a verified primary identity before creating an admin session."""
+
+    def confirm_login_allowed(self, user):
+        super().confirm_login_allowed(user)
+        if not EmailAddress.objects.filter(
+            user=user,
+            email__iexact=user.email,
+            verified=True,
+        ).exists():
+            raise ValidationError(
+                '管理画面へログインする前にメールアドレスの確認を完了してください。',
+                code='unverified_email',
+            )
+
 
 class CustomUserChangeForm(UserChangeForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.original_email = self.instance.email
+
+    def clean_email(self):
+        email = self.cleaned_data['email'].lower()
+        if EmailAddress.objects.filter(email__iexact=email).exclude(user=self.instance).exists():
+            raise ValidationError('このメールアドレスは既に登録されています。')
+        return email
+
+    def save(self, commit=True):
+        """Keep the current login email until the replacement is confirmed."""
+        user = super().save(commit=False)
+        user.email = self.original_email
+        if commit:
+            user.save()
+            self.save_m2m()
+        return user
+
     class Meta:
         model = CustomUser
         fields = '__all__'
 
 
 class CustomUserCreationForm(UserCreationForm):
+    def clean_email(self):
+        email = self.cleaned_data['email'].lower()
+        if EmailAddress.objects.filter(email__iexact=email).exists():
+            raise ValidationError('このメールアドレスは既に登録されています。')
+        return email
+
     class Meta:
         model = CustomUser
         fields = ('email', 'user_name', 'display_name')
@@ -21,6 +70,35 @@ class CustomUserCreationForm(UserCreationForm):
 class CustomUserAdmin(UserAdmin):
     form = CustomUserChangeForm
     add_form = CustomUserCreationForm
+
+    def save_model(self, request, obj, form, change):
+        requested_email = form.cleaned_data['email'].lower()
+        super().save_model(request, obj, form, change)
+        if change:
+            if requested_email != form.original_email:
+                try:
+                    EmailAddress.objects.add_new_email(request, obj, requested_email)
+                except Exception as exc:
+                    logger.error(
+                        'Failed to send admin email-change confirmation: '
+                        'user_id=%s exception_type=%s',
+                        obj.pk,
+                        type(exc).__name__,
+                    )
+                    self.message_user(
+                        request,
+                        '確認メールを送信できませんでした。現在のメールアドレスは変更されていません。時間をおいて再度お試しください。',
+                        level='WARNING',
+                    )
+        else:
+            # Admin creation is a trusted operator flow, matching
+            # ``createsuperuser`` and the one-time legacy migration.
+            EmailAddress.objects.create(
+                user=obj,
+                email=obj.email,
+                verified=True,
+                primary=True,
+            )
     
     list_display = ('email', 'user_name', 'display_name', 'vrchat_user_id', 'is_staff', 'is_active')
     list_filter = ('is_staff', 'is_active')
@@ -57,3 +135,4 @@ class APIKeyAdmin(admin.ModelAdmin):
 
 
 admin.site.register(CustomUser, CustomUserAdmin)
+admin.site.login_form = VerifiedAdminAuthenticationForm

--- a/app/user_account/forms.py
+++ b/app/user_account/forms.py
@@ -6,6 +6,7 @@ from django.contrib.auth.forms import UserCreationForm, PasswordChangeForm
 from django.core.validators import FileExtensionValidator
 
 from allauth.socialaccount.forms import SignupForm as SocialSignupForm
+from allauth.account.models import EmailAddress
 
 from community.constants import WEEKDAY_CHOICES
 from community.models import Community
@@ -261,7 +262,10 @@ class LocalSignupForm(UserCreationForm):
         email = self.cleaned_data.get('email')
         if email:
             email = email.lower()
-            if CustomUser.objects.filter(email__iexact=email).exists():
+            if (
+                CustomUser.objects.filter(email__iexact=email).exists()
+                or EmailAddress.objects.filter(email__iexact=email).exists()
+            ):
                 raise forms.ValidationError('このメールアドレスは既に登録されています。')
         return email
 
@@ -320,14 +324,32 @@ class CustomUserChangeForm(forms.ModelForm):
     def clean_x_account(self):
         return normalize_x_account(self.cleaned_data.get('x_account', ''))
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # ModelForm._post_clean assigns submitted values to instance before
+        # save(). Email changes must instead stay pending in allauth.
+        self.original_email = self.instance.email
+
     def clean_email(self):
         """メールアドレスを正規化し、他ユーザーとの重複を拒否する。"""
         email = self.cleaned_data.get('email')
         if email:
             email = email.lower()
-            if CustomUser.objects.filter(email__iexact=email).exclude(pk=self.instance.pk).exists():
+            if (
+                CustomUser.objects.filter(email__iexact=email).exclude(pk=self.instance.pk).exists()
+                or EmailAddress.objects.filter(email__iexact=email).exclude(user=self.instance).exists()
+            ):
                 raise forms.ValidationError('このメールアドレスは既に登録されています。')
         return email
+
+    def save(self, commit=True):
+        """Save profile fields while leaving an email change pending."""
+        user = super().save(commit=False)
+        user.email = self.original_email
+        if commit:
+            user.save()
+            self.save_m2m()
+        return user
 
     def clean_vrchat_user_id(self):
         return normalize_vrchat_user_id(self.cleaned_data.get('vrchat_user_id', ''))
@@ -402,4 +424,3 @@ class CustomSocialSignupForm(SocialSignupForm):
                     '既存のアカウントにログインしてから、Discord連携を行ってください。'
                 )
         return email
-

--- a/app/user_account/forms.py
+++ b/app/user_account/forms.py
@@ -4,9 +4,11 @@ from django import forms
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.forms import UserCreationForm, PasswordChangeForm
 from django.core.validators import FileExtensionValidator
+from django.http import HttpRequest
 
 from allauth.socialaccount.forms import SignupForm as SocialSignupForm
 from allauth.account.models import EmailAddress
+from allauth.core import ratelimit
 
 from community.constants import WEEKDAY_CHOICES
 from community.models import Community
@@ -17,6 +19,16 @@ from .vrchat import normalize_vrchat_user_id
 
 X_HANDLE_RE = re.compile(r'^[A-Za-z0-9_]{1,15}\Z')
 X_URL_PREFIX_RE = re.compile(r'^https?://(?:www\.)?(?:x|twitter)\.com/', re.IGNORECASE)
+EMAIL_CHANGE_RATE_LIMIT_ACTION = 'manage_email'
+
+
+def consume_email_change_rate_limit(request: HttpRequest, user: CustomUser) -> bool:
+    """メールアドレス変更用の allauth レート制限を消費する。"""
+    return ratelimit.consume(
+        request,
+        action=EMAIL_CHANGE_RATE_LIMIT_ACTION,
+        user=user,
+    )
 
 
 def normalize_x_account(value: str) -> str:
@@ -353,6 +365,23 @@ class CustomUserChangeForm(forms.ModelForm):
 
     def clean_vrchat_user_id(self):
         return normalize_vrchat_user_id(self.cleaned_data.get('vrchat_user_id', ''))
+
+
+class UserNameChangeForm(forms.ModelForm):
+    """ユーザー名だけを変更するフォーム。"""
+
+    class Meta:
+        model = CustomUser
+        fields = ('user_name',)
+        widgets = {
+            'user_name': forms.TextInput(attrs={'class': 'form-control'}),
+        }
+        labels = {
+            'user_name': '表示用ユーザー名',
+        }
+        help_texts = {
+            'user_name': '表示用と内部識別に使用するユーザー名です。',
+        }
 
 
 class SocialAccountDisconnectForm(forms.Form):

--- a/app/user_account/management/commands/audit_email_verification_backfill.py
+++ b/app/user_account/management/commands/audit_email_verification_backfill.py
@@ -1,0 +1,46 @@
+"""Audit legacy email ownership before the verified-address backfill."""
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from allauth.account.models import EmailAddress
+
+
+class Command(BaseCommand):
+    """Report anonymized compatibility counts without changing account data."""
+
+    help = '0015 email verification backfill の競合を読み取り専用で監査します。'
+
+    def handle(self, *args, **options):
+        User = get_user_model()
+        total = User.objects.count()
+        blank = 0
+        ownership_conflicts = 0
+        duplicate_own_rows = 0
+
+        for user in User.objects.only('pk', 'email').iterator():
+            if not user.email:
+                blank += 1
+                continue
+            matches = list(
+                EmailAddress.objects.filter(email__iexact=user.email).only('user_id')
+            )
+            if any(address.user_id != user.pk for address in matches):
+                ownership_conflicts += 1
+            if sum(address.user_id == user.pk for address in matches) > 1:
+                duplicate_own_rows += 1
+
+        self.stdout.write(
+            'users={total} blank={blank} ownership_conflicts={ownership} '
+            'duplicate_own_rows={duplicates}'.format(
+                total=total,
+                blank=blank,
+                ownership=ownership_conflicts,
+                duplicates=duplicate_own_rows,
+            )
+        )
+        if blank or ownership_conflicts or duplicate_own_rows:
+            raise CommandError(
+                'Email verification backfill audit failed; no account data was changed.'
+            )
+        self.stdout.write(self.style.SUCCESS('Email verification backfill audit passed.'))

--- a/app/user_account/migrations/0015_backfill_verified_email_addresses.py
+++ b/app/user_account/migrations/0015_backfill_verified_email_addresses.py
@@ -1,0 +1,54 @@
+"""Backfill allauth email addresses for pre-verification users."""
+
+from django.db import migrations
+
+
+def backfill_verified_email_addresses(apps, schema_editor):
+    """Create one verified primary EmailAddress for each existing user.
+
+    Refuse ambiguous ownership rather than attempting a potentially unsafe
+    account merge. Values are intentionally omitted from the exception to
+    avoid putting email addresses in migration logs.
+    """
+    User = apps.get_model('user_account', 'CustomUser')
+    EmailAddress = apps.get_model('account', 'EmailAddress')
+
+    if User.objects.filter(email='').exists():
+        raise RuntimeError('Blank user email during email verification migration')
+
+    for user in User.objects.exclude(email='').iterator():
+        email = user.email.lower()
+        matches = list(EmailAddress.objects.filter(email__iexact=email))
+        if any(address.user_id != user.pk for address in matches):
+            raise RuntimeError('EmailAddress ownership conflict during email verification migration')
+
+        own_matches = [address for address in matches if address.user_id == user.pk]
+        if len(own_matches) > 1:
+            raise RuntimeError('Ambiguous EmailAddress rows during email verification migration')
+
+        EmailAddress.objects.filter(user_id=user.pk, primary=True).update(primary=False)
+        if own_matches:
+            address = own_matches[0]
+            address.email = email
+            address.verified = True
+            address.primary = True
+            address.save(update_fields=['email', 'verified', 'primary'])
+        else:
+            EmailAddress.objects.create(
+                user_id=user.pk,
+                email=email,
+                verified=True,
+                primary=True,
+            )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('account', '0009_emailaddress_unique_primary_email'),
+        ('user_account', '0014_alter_customuser_user_name'),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_verified_email_addresses, migrations.RunPython.noop),
+    ]

--- a/app/user_account/models.py
+++ b/app/user_account/models.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, BaseUserManager
 from django.core.validators import RegexValidator
-from django.db import models
+from django.db import models, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 import hashlib
@@ -31,12 +31,29 @@ class CustomUserManager(BaseUserManager):
         if extra_fields.get('is_superuser') is not True:
             raise ValueError('スーパーユーザーはsuperuserである必要があります。')
 
-        return self.create_user(
-            email,
-            user_name=user_name,
-            password=password,
-            **extra_fields,
-        )
+        email = self.normalize_email(email).lower()
+        database = self._db or 'default'
+        with transaction.atomic(using=database):
+            from allauth.account.models import EmailAddress
+
+            if EmailAddress.objects.using(database).filter(email__iexact=email).exists():
+                raise ValueError('このメールアドレスは既に登録されています。')
+            user = self.create_user(
+                email,
+                user_name=user_name,
+                password=password,
+                **extra_fields,
+            )
+            # createsuperuser is a trusted operator flow. Keeping this in the
+            # same transaction prevents a successful CLI run from producing a
+            # staff account that the mandatory verification gate cannot use.
+            EmailAddress.objects.using(database).create(
+                user=user,
+                email=user.email,
+                verified=True,
+                primary=True,
+            )
+        return user
 
 
 class CustomUser(AbstractBaseUser, PermissionsMixin):

--- a/app/user_account/templates/account/user_update.html
+++ b/app/user_account/templates/account/user_update.html
@@ -39,7 +39,7 @@
                                 <label for="{{ form.email.id_for_label }}" class="form-label">{{ form.email.label }}:</label>
                                 {{ form.email }}
                                 <div class="form-text">
-                                    <i class="fas fa-lock me-1"></i>メールアドレスは公開されません
+                                    <i class="fas fa-lock me-1"></i>メールアドレスは公開されません。変更時は新しいアドレスの確認が完了するまで現在のアドレスを使用します。
                                 </div>
                                 {% if form.email.errors %}
                                     <div class="text-danger small">{{ form.email.errors }}</div>

--- a/app/user_account/tests/test_adapters.py
+++ b/app/user_account/tests/test_adapters.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.test import RequestFactory, TestCase, override_settings, tag
 
 from allauth.socialaccount.models import SocialAccount
+from allauth.account.models import EmailAddress
 from community.models import Community, CommunityMember
 from user_account.adapters import CustomSocialAccountAdapter
 from user_account.tests.utils import (
@@ -27,6 +28,12 @@ class CustomSocialAccountAdapterTests(TestCase):
             user_name='existing_user',
             email='existing@example.com',
             password='testpass123',
+        )
+        EmailAddress.objects.create(
+            user=self.existing_user,
+            email=self.existing_user.email,
+            verified=True,
+            primary=True,
         )
 
     def test_is_auto_signup_allowed_returns_true_when_email_exists(self):
@@ -282,8 +289,9 @@ class CustomSocialAccountAdapterTests(TestCase):
 
         sociallogin.connect.assert_not_called()
 
-    def test_pre_social_login_connects_when_no_email_address_record(self):
-        """EmailAddressレコードがなくてもDiscord verified なら自動連携すること."""
+    def test_pre_social_login_skips_when_no_email_address_record(self):
+        """確認済みEmailAddressがなければDiscordを自動連携しないこと."""
+        EmailAddress.objects.filter(user=self.existing_user).delete()
         request = self.factory.get('/accounts/discord/login/callback/')
 
         sociallogin = MagicMock()
@@ -298,7 +306,26 @@ class CustomSocialAccountAdapterTests(TestCase):
 
         self.adapter.pre_social_login(request, sociallogin)
 
-        sociallogin.connect.assert_called_once_with(request, self.existing_user)
+        sociallogin.connect.assert_not_called()
+
+    def test_pre_social_login_skips_when_local_email_is_unverified(self):
+        """Discord側が確認済みでもローカルemail未確認なら自動連携しないこと."""
+        EmailAddress.objects.filter(user=self.existing_user).update(verified=False)
+        request = self.factory.get('/accounts/discord/login/callback/')
+
+        sociallogin = MagicMock()
+        sociallogin.is_existing = False
+        sociallogin.state = {}
+        sociallogin.account.provider = 'discord'
+        sociallogin.account.uid = '123456789'
+        sociallogin.account.extra_data = {
+            'email': 'existing@example.com',
+            'verified': True,
+        }
+
+        self.adapter.pre_social_login(request, sociallogin)
+
+        sociallogin.connect.assert_not_called()
 
     def test_pre_social_login_skips_when_existing_user_has_other_discord_account(self):
         """既存ユーザーが別の Discord アカウントを連携済みなら自動連携しないこと."""

--- a/app/user_account/tests/test_auth_next_redirect.py
+++ b/app/user_account/tests/test_auth_next_redirect.py
@@ -15,7 +15,7 @@ from django.template.loader import render_to_string
 from django.test import Client, RequestFactory, TestCase, override_settings, tag
 from django.urls import reverse
 
-from allauth.account.models import EmailAddress
+from allauth.account.models import EmailAddress, EmailConfirmationHMAC
 from allauth.core.context import request_context
 from allauth.socialaccount.internal.flows.signup import process_signup
 from allauth.socialaccount.models import SocialAccount, SocialLogin
@@ -146,37 +146,55 @@ class AuthNextLinkTests(TestCase):
 @override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS)
 @tag('offline_external_api')
 class LocalSignupNextTests(TestCase):
-    """ローカル登録後のログイン復帰先を検証する."""
+    """ローカル登録後の確認フローの復帰先を検証する."""
 
     def setUp(self) -> None:
         self.client = Client()
         self.register_url = reverse('account:register')
         self.login_url = reverse('account:login')
 
-    def test_local_signup_preserves_safe_next_on_login_redirect(self) -> None:
-        """ローカル登録フォームと登録後ログインURLがnextを保持すること."""
+    def _confirm_signup(self, email: str):
+        address = EmailAddress.objects.get(email=email)
+        confirmation_url = reverse(
+            'account_confirm_email',
+            args=[EmailConfirmationHMAC(address).key],
+        )
+        self.client.get(confirmation_url)
+        return self.client.post(confirmation_url)
+
+    def test_local_signup_preserves_safe_next_through_confirmation(self) -> None:
+        """ローカル登録は同じブラウザでの確認後に安全な復帰先へ戻ること."""
         next_url = '/event/speaker-link/signed-token/'
+        email = 'local-signup-with-next@example.com'
         page_response = self.client.get(self.register_url, {'next': next_url})
         self.assertContains(page_response, f'name="next" value="{next_url}"')
 
         response = self.client.post(self.register_url, {
             'user_name': 'local_signup_with_next',
-            'email': 'local-signup-with-next@example.com',
+            'email': email,
             'password1': 'testpass12345',
             'password2': 'testpass12345',
             'next': next_url,
         })
 
-        redirect_url = urlparse(response.url)
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(redirect_url.path, self.login_url)
-        self.assertEqual(parse_qs(redirect_url.query)['next'], [next_url])
+        self.assertEqual(urlparse(response.url).path, '/accounts/confirm-email/')
 
-    def test_local_signup_rejects_external_next_on_login_redirect(self) -> None:
-        """ローカル登録後ログインURLが外部nextを保持しないこと."""
+        confirmation_response = self._confirm_signup(email)
+
+        self.assertRedirects(
+            confirmation_response,
+            next_url,
+            fetch_redirect_response=False,
+        )
+        self.assertIn('_auth_user_id', self.client.session)
+
+    def test_local_signup_rejects_external_next_for_email_confirmation(self) -> None:
+        """ローカル登録でも外部nextへ遷移しないこと."""
+        email = 'local-signup-external-next@example.com'
         response = self.client.post(self.register_url, {
             'user_name': 'local_signup_external_next',
-            'email': 'local-signup-external-next@example.com',
+            'email': email,
             'password1': 'testpass12345',
             'password2': 'testpass12345',
             'next': 'https://evil.example.com/path',
@@ -184,9 +202,15 @@ class LocalSignupNextTests(TestCase):
 
         self.assertRedirects(
             response,
-            self.login_url,
+            '/accounts/confirm-email/',
             fetch_redirect_response=False,
         )
+
+        confirmation_response = self._confirm_signup(email)
+
+        self.assertEqual(confirmation_response.status_code, 302)
+        self.assertEqual(confirmation_response.url, reverse('event:my_presentations'))
+        self.assertNotIn('evil.example.com', confirmation_response.url)
 
 
 @tag('offline_external_api')

--- a/app/user_account/tests/test_email_address_migration.py
+++ b/app/user_account/tests/test_email_address_migration.py
@@ -1,0 +1,78 @@
+"""Regression tests for the verified EmailAddress backfill migration."""
+
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+from allauth.account.models import EmailAddress
+
+
+class EmailAddressBackfillMigrationTests(TransactionTestCase):
+    """Exercise the migration from the immediately preceding app state."""
+
+    migrate_from = [('user_account', '0014_alter_customuser_user_name')]
+    migrate_to = [('user_account', '0015_backfill_verified_email_addresses')]
+
+    def setUp(self):
+        self.executor = MigrationExecutor(connection)
+        self.executor.migrate(self.migrate_from)
+        self.old_apps = self.executor.loader.project_state(self.migrate_from).apps
+
+    def tearDown(self):
+        MigrationExecutor(connection).migrate(self.migrate_to)
+        super().tearDown()
+
+    def _migrate_forward(self):
+        self.executor = MigrationExecutor(connection)
+        self.executor.migrate(self.migrate_to)
+        return self.executor.loader.project_state(self.migrate_to).apps
+
+    def test_creates_verified_primary_address_and_repairs_primary_state(self):
+        """Create the matching verified primary address and normalize existing rows."""
+        User = self.old_apps.get_model('user_account', 'CustomUser')
+        user = User.objects.create(user_name='legacy', email='Legacy@Example.com')
+        new_user = User.objects.create(user_name='new', email='new@example.com')
+        stale = EmailAddress.objects.create(
+            user_id=user.pk,
+            email='legacy@example.com',
+            verified=False,
+            primary=False,
+        )
+
+        self._migrate_forward()
+        address = EmailAddress.objects.get(pk=stale.pk)
+
+        self.assertEqual(address.email, 'legacy@example.com')
+        self.assertTrue(address.verified)
+        self.assertTrue(address.primary)
+        self.assertTrue(EmailAddress.objects.filter(
+            user_id=new_user.pk,
+            email='new@example.com',
+            verified=True,
+            primary=True,
+        ).exists())
+
+    def test_stops_on_email_address_owned_by_another_user(self):
+        """Fail closed instead of assigning an ambiguous address to a user."""
+        User = self.old_apps.get_model('user_account', 'CustomUser')
+        target = User.objects.create(user_name='target', email='target@example.com')
+        owner = User.objects.create(user_name='owner', email='owner@example.com')
+        conflict = EmailAddress.objects.create(
+            user_id=owner.pk,
+            email=target.email,
+            verified=False,
+            primary=True,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, 'ownership conflict'):
+            self._migrate_forward()
+        conflict.delete()
+
+    def test_stops_when_a_legacy_user_has_no_email(self):
+        """Fail closed because a blank address cannot be made login-compatible."""
+        User = self.old_apps.get_model('user_account', 'CustomUser')
+        blank_user = User.objects.create(user_name='blank', email='')
+
+        with self.assertRaisesRegex(RuntimeError, 'Blank user email'):
+            self._migrate_forward()
+        blank_user.delete()

--- a/app/user_account/tests/test_email_change_controls.py
+++ b/app/user_account/tests/test_email_change_controls.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 
 from allauth.account.models import EmailAddress
 
-from tests.factories import make_user
+from tests.factories import make_user, make_user_without_email_address
 from user_account.adapters import CustomAccountAdapter
 from user_account.tests.utils import (
     TEST_SOCIALACCOUNT_PROVIDERS,
@@ -193,6 +193,38 @@ class EmailChangeFlowTests(TestCase):
             email='admin-limit-rejected@example.com',
         ).exists())
         self.assertEqual(len(mail.outbox), EMAIL_CHANGE_LIMIT)
+
+    def test_admin_rejects_email_owned_by_legacy_user_without_email_address(self):
+        """EmailAddressがない既存ユーザーのemailも管理画面で奪えない。"""
+        admin = User.objects.create_superuser(
+            user_name='legacy_collision_admin',
+            email='legacy-collision-admin@example.com',
+            password='testpass123',
+        )
+        owner = make_user_without_email_address(
+            user_name='legacy_email_owner',
+            email='legacy-owner@example.com',
+        )
+        target = make_user(
+            user_name='legacy_collision_target',
+            email='legacy-collision-target@example.com',
+        )
+        self.client.force_login(admin)
+
+        response = self.client.post(
+            reverse('admin:user_account_customuser_change', args=[target.pk]),
+            self._admin_change_data(target, owner.email.upper()),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'このメールアドレスは既に登録されています')
+        target.refresh_from_db()
+        self.assertEqual(target.email, 'legacy-collision-target@example.com')
+        self.assertFalse(EmailAddress.objects.filter(
+            user=target,
+            email__iexact=owner.email,
+        ).exists())
+        self.assertEqual(len(mail.outbox), 0)
 
     @staticmethod
     def _admin_change_data(user, email):

--- a/app/user_account/tests/test_email_change_controls.py
+++ b/app/user_account/tests/test_email_change_controls.py
@@ -1,0 +1,259 @@
+"""メールアドレス変更の公開経路を回帰テストする。"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
+from django.core import mail
+from django.core.cache import cache
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+
+from allauth.account.models import EmailAddress
+
+from tests.factories import make_user
+from user_account.adapters import CustomAccountAdapter
+from user_account.tests.utils import (
+    TEST_SOCIALACCOUNT_PROVIDERS,
+    create_discord_linked_user,
+)
+
+User = get_user_model()
+EMAIL_CHANGE_LIMIT = 10
+
+
+@override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+class LoginMessageTests(TestCase):
+    """ログイン成功メッセージの表示回数を確認する。"""
+
+    def test_custom_login_does_not_add_a_duplicate_success_message(self):
+        """カスタムビューがログイン成功メッセージを重複して追加しない。"""
+        user = create_discord_linked_user(
+            user_name='login_message_user',
+            email='login-message@example.com',
+            password='testpass123',
+        )
+
+        response = self.client.post(reverse('account:login'), {
+            'username': user.email,
+            'password': 'testpass123',
+        })
+
+        login_messages = [
+            str(message)
+            for message in get_messages(response.wsgi_request)
+            if 'ログインしました' in str(message)
+        ]
+        self.assertEqual(len(login_messages), 1)
+
+
+@override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+class UserNameChangeViewTests(TestCase):
+    """ユーザー名変更画面がメールアドレスを受け付けないことを確認する。"""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = create_discord_linked_user(
+            user_name='name_change_user',
+            email='name-change@example.com',
+            password='testpass123',
+        )
+        self.url = reverse('account:user_name_change')
+        self.client.force_login(self.user)
+
+    def test_user_name_change_form_does_not_render_email_field(self):
+        """ユーザー名変更画面にはメールアドレス入力を表示しない。"""
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'name="email"')
+
+    def test_user_name_change_ignores_tampered_email_post_value(self):
+        """改ざんされたメールアドレスをPOSTしても保存しない。"""
+        response = self.client.post(self.url, {
+            'user_name': 'updated_name',
+            'email': 'tampered@example.com',
+        })
+
+        self.assertRedirects(response, reverse('account:settings'), fetch_redirect_response=False)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.user_name, 'updated_name')
+        self.assertEqual(self.user.email, 'name-change@example.com')
+        self.assertFalse(EmailAddress.objects.filter(
+            user=self.user,
+            email='tampered@example.com',
+        ).exists())
+
+
+@override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+class EmailChangeFlowTests(TestCase):
+    """プロフィールと管理画面のメールアドレス変更を確認する。"""
+
+    def setUp(self):
+        cache.clear()
+        self.client = Client()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    def test_user_update_creates_a_pending_email_address(self):
+        """プロフィール更新は確認前のアドレスを作り現在のログインを維持する。"""
+        user = create_discord_linked_user(
+            user_name='profile_change_user',
+            email='profile-change@example.com',
+            password='testpass123',
+        )
+        self.client.force_login(user)
+
+        response = self.client.post(reverse('account:user_update'), {
+            'display_name': user.display_name,
+            'user_name': user.user_name,
+            'email': 'profile-pending@example.com',
+            'x_account': '',
+            'vrchat_user_id': '',
+        })
+
+        self.assertRedirects(response, reverse('account:settings'), fetch_redirect_response=False)
+        user.refresh_from_db()
+        self.assertEqual(user.email, 'profile-change@example.com')
+        self.assertTrue(EmailAddress.objects.filter(
+            user=user,
+            email='profile-pending@example.com',
+            verified=False,
+            primary=False,
+        ).exists())
+
+    def test_user_update_rejects_the_eleventh_email_change(self):
+        """プロフィール経由の11回目の変更要求を送信前に拒否する。"""
+        user = create_discord_linked_user(
+            user_name='profile_limit_user',
+            email='profile-limit@example.com',
+            password='testpass123',
+        )
+        self.client.force_login(user)
+
+        for index in range(EMAIL_CHANGE_LIMIT):
+            response = self.client.post(reverse('account:user_update'), {
+                'display_name': user.display_name,
+                'user_name': user.user_name,
+                'email': f'profile-limit-{index}@example.com',
+                'x_account': '',
+                'vrchat_user_id': '',
+            })
+            self.assertEqual(response.status_code, 302)
+
+        response = self.client.post(reverse('account:user_update'), {
+            'display_name': user.display_name,
+            'user_name': user.user_name,
+            'email': 'profile-limit-rejected@example.com',
+            'x_account': '',
+            'vrchat_user_id': '',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'メールアドレスの変更回数が上限に達しました')
+        self.assertFalse(EmailAddress.objects.filter(
+            user=user,
+            email='profile-limit-rejected@example.com',
+        ).exists())
+        self.assertEqual(len(mail.outbox), EMAIL_CHANGE_LIMIT)
+
+    def test_admin_rejects_the_eleventh_email_change(self):
+        """管理画面もallauth共有バケットの11回目を送信前に拒否する。"""
+        admin = User.objects.create_superuser(
+            user_name='email_limit_admin',
+            email='email-limit-admin@example.com',
+            password='testpass123',
+        )
+        target = make_user(
+            user_name='admin_limit_target',
+            email='admin-limit-target@example.com',
+            password='testpass123',
+        )
+        self.client.force_login(admin)
+        url = reverse('admin:user_account_customuser_change', args=[target.pk])
+
+        for index in range(EMAIL_CHANGE_LIMIT):
+            response = self.client.post(url, self._admin_change_data(
+                target,
+                f'admin-limit-{index}@example.com',
+            ))
+            self.assertEqual(response.status_code, 302)
+
+        response = self.client.post(url, self._admin_change_data(
+            target,
+            'admin-limit-rejected@example.com',
+        ))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'メールアドレスの変更回数が上限に達しました')
+        self.assertFalse(EmailAddress.objects.filter(
+            user=target,
+            email='admin-limit-rejected@example.com',
+        ).exists())
+        self.assertEqual(len(mail.outbox), EMAIL_CHANGE_LIMIT)
+
+    @staticmethod
+    def _admin_change_data(user, email):
+        return {
+            'email': email,
+            'user_name': user.user_name,
+            'display_name': user.display_name,
+            'vrchat_user_id': '',
+            'password': user.password,
+            'is_active': 'on',
+            'date_joined_0': user.date_joined.strftime('%Y-%m-%d'),
+            'date_joined_1': user.date_joined.strftime('%H:%M:%S'),
+            '_save': '保存',
+        }
+
+
+@override_settings(
+    EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+    SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS,
+)
+class RegisterMailFailureTests(TestCase):
+    """確認メール送信失敗時のローカル登録を確認する。"""
+
+    def test_register_keeps_the_committed_unverified_identity_on_mail_failure(self):
+        """送信に失敗してもログイン画面へ戻し、再送可能な状態を残す。"""
+        with patch.object(
+            CustomAccountAdapter,
+            'send_mail',
+            side_effect=RuntimeError('simulated mail failure'),
+        ):
+            response = self.client.post(reverse('account:register'), {
+                'user_name': 'signup_mail_failure',
+                'email': 'signup-mail-failure@example.com',
+                'password1': 'testpass12345',
+                'password2': 'testpass12345',
+            })
+
+        self.assertRedirects(response, reverse('account:login'), fetch_redirect_response=False)
+        messages = [str(message) for message in get_messages(response.wsgi_request)]
+        self.assertIn(
+            '登録は完了しました。確認メールの送信に失敗したため、ログイン画面から再送してください。',
+            messages,
+        )
+        user = User.objects.get(user_name='signup_mail_failure')
+        self.assertTrue(EmailAddress.objects.filter(
+            user=user,
+            email='signup-mail-failure@example.com',
+            verified=False,
+            primary=True,
+        ).exists())
+
+    @patch(
+        'user_account.view_modules.session.complete_signup',
+        side_effect=RuntimeError('simulated non-mail failure'),
+    )
+    def test_register_does_not_mask_non_mail_failures(self, _complete_signup):
+        """メール送信以外の登録障害は送信失敗として握りつぶさない。"""
+        with self.assertRaises(RuntimeError):
+            self.client.post(reverse('account:register'), {
+                'user_name': 'signup_non_mail_failure',
+                'email': 'signup-non-mail-failure@example.com',
+                'password1': 'testpass12345',
+                'password2': 'testpass12345',
+            })

--- a/app/user_account/tests/test_email_verification.py
+++ b/app/user_account/tests/test_email_verification.py
@@ -1,0 +1,447 @@
+"""Email verification flows exposed by the local account views."""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.core import mail
+from django.test import Client, TestCase, override_settings
+from django.urls import resolve, reverse
+
+from allauth.account.models import EmailAddress, EmailConfirmationHMAC
+
+from tests.factories import make_user, make_user_without_email_address
+from user_account.adapters import CustomAccountAdapter
+from user_account.tests.utils import create_discord_linked_user
+from user_account.tests.utils import TEST_SOCIALACCOUNT_PROVIDERS
+from user_account.views import CustomLoginView
+
+User = get_user_model()
+
+
+@override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+class EmailVerificationViewTests(TestCase):
+    """Verify local login and pending email-change behavior."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_api_auth_login_uses_custom_login_view(self):
+        """Route the DRF login path through mandatory verification."""
+        self.assertEqual(resolve('/api-auth/login/').func.view_class, CustomLoginView)
+
+    def test_createsuperuser_has_verified_primary_email(self):
+        """Keep trusted CLI-created administrators usable after migration."""
+        user = User.objects.create_superuser(
+            user_name='trusted_admin',
+            email='trusted-admin@example.com',
+            password='testpass123',
+        )
+
+        self.assertTrue(EmailAddress.objects.filter(
+            user=user,
+            email=user.email,
+            verified=True,
+            primary=True,
+        ).exists())
+
+    def test_admin_login_blocks_unverified_staff(self):
+        """Prevent Django admin from bypassing mandatory verification."""
+        user = make_user(
+            user_name='pending_staff',
+            email='pending-staff@example.com',
+            password='testpass123',
+            is_staff=True,
+        )
+        EmailAddress.objects.filter(user=user).update(verified=False)
+
+        response = self.client.post(reverse('admin:login'), {
+            'username': user.email,
+            'password': 'testpass123',
+            'next': reverse('admin:index'),
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'メールアドレスの確認を完了してください')
+        self.assertNotIn('_auth_user_id', self.client.session)
+
+    def test_admin_created_user_has_verified_primary_email(self):
+        """Treat an authenticated operator's admin creation as trusted."""
+        admin = User.objects.create_superuser(
+            user_name='creating_admin',
+            email='creating-admin@example.com',
+            password='testpass123',
+        )
+        self.client.force_login(admin)
+
+        response = self.client.post(reverse('admin:user_account_customuser_add'), {
+            'email': 'admin-created@example.com',
+            'user_name': 'admin_created',
+            'display_name': 'Admin Created',
+            'password1': 'testpass12345',
+            'password2': 'testpass12345',
+            '_save': '保存',
+        })
+
+        self.assertEqual(response.status_code, 302)
+        user = User.objects.get(email='admin-created@example.com')
+        self.assertTrue(EmailAddress.objects.filter(
+            user=user,
+            email=user.email,
+            verified=True,
+            primary=True,
+        ).exists())
+
+    def test_admin_creation_rejects_another_users_pending_email(self):
+        """Prevent trusted creation from claiming a pending email identity."""
+        admin = User.objects.create_superuser(
+            user_name='pending_collision_admin',
+            email='pending-collision-admin@example.com',
+            password='testpass123',
+        )
+        owner = make_user(
+            user_name='pending_owner',
+            email='pending-owner@example.com',
+        )
+        EmailAddress.objects.create(
+            user=owner,
+            email='claimed-pending@example.com',
+            verified=False,
+            primary=False,
+        )
+        self.client.force_login(admin)
+
+        response = self.client.post(reverse('admin:user_account_customuser_add'), {
+            'email': 'claimed-pending@example.com',
+            'user_name': 'rejected_admin_created',
+            'display_name': 'Rejected',
+            'password1': 'testpass12345',
+            'password2': 'testpass12345',
+            '_save': '保存',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'このメールアドレスは既に登録されています')
+        self.assertFalse(User.objects.filter(user_name='rejected_admin_created').exists())
+
+    def test_createsuperuser_rejects_another_users_pending_email(self):
+        """Prevent the trusted CLI path from claiming a pending email identity."""
+        owner = make_user(
+            user_name='cli_pending_owner',
+            email='cli-pending-owner@example.com',
+        )
+        EmailAddress.objects.create(
+            user=owner,
+            email='cli-claimed-pending@example.com',
+            verified=False,
+            primary=False,
+        )
+
+        with self.assertRaisesRegex(ValueError, '既に登録されています'):
+            User.objects.create_superuser(
+                user_name='rejected_cli_admin',
+                email='cli-claimed-pending@example.com',
+                password='testpass123',
+            )
+
+        self.assertFalse(User.objects.filter(user_name='rejected_cli_admin').exists())
+
+    def test_admin_email_change_stays_pending_until_confirmation(self):
+        """Apply the staged email-change contract to Django admin edits too."""
+        admin = User.objects.create_superuser(
+            user_name='changing_admin',
+            email='changing-admin@example.com',
+            password='testpass123',
+        )
+        target = make_user(
+            user_name='admin_change_target',
+            email='admin-change-old@example.com',
+            password='testpass123',
+        )
+        self.client.force_login(admin)
+
+        response = self.client.post(
+            reverse('admin:user_account_customuser_change', args=[target.pk]),
+            {
+                'email': 'admin-change-new@example.com',
+                'user_name': target.user_name,
+                'display_name': target.display_name,
+                'vrchat_user_id': '',
+                'password': target.password,
+                'is_active': 'on',
+                'date_joined_0': target.date_joined.strftime('%Y-%m-%d'),
+                'date_joined_1': target.date_joined.strftime('%H:%M:%S'),
+                '_save': '保存',
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        target.refresh_from_db()
+        self.assertEqual(target.email, 'admin-change-old@example.com')
+        self.assertTrue(EmailAddress.objects.filter(
+            user=target,
+            email='admin-change-new@example.com',
+            verified=False,
+            primary=False,
+        ).exists())
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_admin_email_change_mail_failure_keeps_old_login(self):
+        """Show an operator warning while leaving the staged change retryable."""
+        admin = User.objects.create_superuser(
+            user_name='mail_failure_admin',
+            email='mail-failure-admin@example.com',
+            password='testpass123',
+        )
+        target = make_user(
+            user_name='admin_mail_failure_target',
+            email='admin-mail-failure-old@example.com',
+        )
+        self.client.force_login(admin)
+
+        with patch.object(
+            CustomAccountAdapter,
+            'send_mail',
+            side_effect=RuntimeError('simulated mail failure'),
+        ):
+            response = self.client.post(
+                reverse('admin:user_account_customuser_change', args=[target.pk]),
+                {
+                    'email': 'admin-mail-failure-new@example.com',
+                    'user_name': target.user_name,
+                    'display_name': target.display_name,
+                    'vrchat_user_id': '',
+                    'password': target.password,
+                    'is_active': 'on',
+                    'date_joined_0': target.date_joined.strftime('%Y-%m-%d'),
+                    'date_joined_1': target.date_joined.strftime('%H:%M:%S'),
+                    '_save': '保存',
+                },
+                follow=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '確認メールを送信できませんでした')
+        target.refresh_from_db()
+        self.assertEqual(target.email, 'admin-mail-failure-old@example.com')
+        self.assertTrue(EmailAddress.objects.filter(
+            user=target,
+            email='admin-mail-failure-new@example.com',
+            verified=False,
+            primary=False,
+        ).exists())
+
+    def test_api_auth_login_blocks_unverified_email(self):
+        """Apply the same mandatory verification gate to DRF's login path."""
+        user = make_user(
+            user_name='pending_api_user',
+            email='pending-api@example.com',
+            password='testpass123',
+        )
+        EmailAddress.objects.filter(user=user).update(verified=False)
+
+        response = self.client.post('/api-auth/login/', {
+            'username': user.email, 'password': 'testpass123',
+        })
+
+        self.assertRedirects(response, '/accounts/confirm-email/', fetch_redirect_response=False)
+        self.assertNotIn('_auth_user_id', self.client.session)
+
+    def test_login_syncs_missing_email_address_as_unverified(self):
+        """Send verification instead of locking a programmatically created user out."""
+        user = make_user_without_email_address(
+            user_name='missing_address_user',
+            email='missing-address@example.com',
+            password='testpass123',
+        )
+        self.assertFalse(EmailAddress.objects.filter(user=user).exists())
+
+        response = self.client.post(reverse('account:login'), {
+            'username': user.email,
+            'password': 'testpass123',
+        })
+
+        self.assertRedirects(
+            response,
+            '/accounts/confirm-email/',
+            fetch_redirect_response=False,
+        )
+        self.assertTrue(EmailAddress.objects.filter(
+            user=user,
+            email=user.email,
+            verified=False,
+            primary=False,
+        ).exists())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertNotIn('_auth_user_id', self.client.session)
+
+    def test_api_auth_login_allows_verified_email(self):
+        """Keep DRF's session login available to verified users."""
+        user = create_discord_linked_user(
+            user_name='verified_api_user',
+            email='verified-api@example.com',
+            password='testpass123',
+        )
+
+        response = self.client.post('/api-auth/login/', {
+            'username': user.email,
+            'password': 'testpass123',
+            'next': '/api/v1/event-details/',
+        })
+
+        self.assertRedirects(response, '/api/v1/event-details/', fetch_redirect_response=False)
+        self.assertEqual(self.client.session['_auth_user_id'], str(user.pk))
+
+    @override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS)
+    def test_local_registration_confirmation_enables_login(self):
+        """Confirm the registration address through allauth before allowing login."""
+        response = self.client.post(reverse('account:register'), {
+            'user_name': 'confirmed_signup_user',
+            'email': 'confirmed-signup@example.com',
+            'password1': 'testpass12345',
+            'password2': 'testpass12345',
+        })
+        self.assertRedirects(response, '/accounts/confirm-email/', fetch_redirect_response=False)
+        self.assertEqual(len(mail.outbox), 1)
+
+        user = User.objects.get(email='confirmed-signup@example.com')
+        address = EmailAddress.objects.get(user=user, email=user.email)
+        self.assertFalse(address.verified)
+
+        confirmation_url = reverse(
+            'account_confirm_email',
+            args=[EmailConfirmationHMAC(address).key],
+        )
+        self.client.get(confirmation_url)
+        self.client.post(confirmation_url)
+        address.refresh_from_db()
+        self.assertTrue(address.verified)
+
+        self.client.logout()
+        response = self.client.post(reverse('account:login'), {
+            'username': user.email,
+            'password': 'testpass12345',
+        })
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.client.session['_auth_user_id'], str(user.pk))
+
+    def test_unverified_login_resends_confirmation_without_authenticating(self):
+        """Keep an unverified user logged out until their address is confirmed."""
+        user = make_user(
+            user_name='pending_login_user',
+            email='pending-login@example.com',
+            password='testpass123',
+        )
+        address = EmailAddress.objects.get(user=user)
+        address.verified = False
+        address.save(update_fields=['verified'])
+
+        response = self.client.post(reverse('account:login'), {
+            'username': user.email, 'password': 'testpass123',
+        })
+
+        self.assertRedirects(response, '/accounts/confirm-email/', fetch_redirect_response=False)
+        self.assertNotIn('_auth_user_id', self.client.session)
+        self.assertEqual(len(mail.outbox), 1)
+
+        address.set_verified()
+        response = self.client.post(reverse('account:login'), {
+            'username': user.email, 'password': 'testpass123',
+        })
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('_auth_user_id', self.client.session)
+
+    def test_email_change_stays_pending_until_confirmation(self):
+        """Keep the old primary address until allauth confirms the replacement."""
+        user = create_discord_linked_user(
+            user_name='test_update_user',
+            email='test_update@example.com',
+            password='testpass123',
+        )
+        self.client.force_login(user)
+
+        response = self.client.post(reverse('account:user_update'), {
+            'display_name': '更新済み表示名',
+            'user_name': user.user_name,
+            'email': 'new-update@example.com',
+            'x_account': '',
+            'vrchat_user_id': '',
+        })
+
+        self.assertRedirects(response, reverse('account:settings'), fetch_redirect_response=False)
+        user.refresh_from_db()
+        self.assertEqual(user.email, 'test_update@example.com')
+        self.assertTrue(EmailAddress.objects.filter(
+            user=user, email=user.email, verified=True, primary=True,
+        ).exists())
+        self.assertTrue(EmailAddress.objects.filter(
+            user=user, email='new-update@example.com', verified=False, primary=False,
+        ).exists())
+        self.assertEqual(len(mail.outbox), 1)
+
+        pending = EmailAddress.objects.get(user=user, email='new-update@example.com')
+        confirmation_url = reverse('account_confirm_email', args=[EmailConfirmationHMAC(pending).key])
+        self.client.get(confirmation_url)
+        self.client.post(confirmation_url)
+
+        user.refresh_from_db()
+        self.assertEqual(user.email, 'new-update@example.com')
+        self.assertTrue(EmailAddress.objects.filter(
+            user=user, email=user.email, verified=True, primary=True,
+        ).exists())
+        self.assertFalse(EmailAddress.objects.filter(
+            user=user, email='test_update@example.com',
+        ).exists())
+
+    def test_email_change_mail_failure_keeps_old_login_and_allows_retry(self):
+        """Keep profile updates usable while an email delivery failure stays retryable."""
+        user = create_discord_linked_user(
+            user_name='mail_failure_user',
+            email='mail-failure@example.com',
+            password='testpass123',
+        )
+        self.client.force_login(user)
+
+        with patch.object(
+            CustomAccountAdapter,
+            'send_mail',
+            side_effect=RuntimeError('simulated mail failure'),
+        ):
+            response = self.client.post(reverse('account:user_update'), {
+                'display_name': '送信失敗後も保存',
+                'user_name': user.user_name,
+                'email': 'mail-failure-new@example.com',
+                'x_account': '',
+                'vrchat_user_id': '',
+            })
+
+        self.assertRedirects(
+            response,
+            reverse('account:settings'),
+            fetch_redirect_response=False,
+        )
+        user.refresh_from_db()
+        self.assertEqual(user.display_name, '送信失敗後も保存')
+        self.assertEqual(user.email, 'mail-failure@example.com')
+        self.assertTrue(EmailAddress.objects.filter(
+            user=user,
+            email='mail-failure-new@example.com',
+            verified=False,
+            primary=False,
+        ).exists())
+
+        cache.clear()
+        response = self.client.post(reverse('account:user_update'), {
+            'display_name': user.display_name,
+            'user_name': user.user_name,
+            'email': 'mail-failure-new@example.com',
+            'x_account': '',
+            'vrchat_user_id': '',
+        })
+
+        self.assertRedirects(
+            response,
+            reverse('account:settings'),
+            fetch_redirect_response=False,
+        )
+        self.assertEqual(len(mail.outbox), 1)

--- a/app/user_account/tests/test_email_verification.py
+++ b/app/user_account/tests/test_email_verification.py
@@ -247,6 +247,33 @@ class EmailVerificationViewTests(TestCase):
         self.assertRedirects(response, '/accounts/confirm-email/', fetch_redirect_response=False)
         self.assertNotIn('_auth_user_id', self.client.session)
 
+    def test_unverified_login_without_remember_expires_when_browser_closes(self):
+        """Preserve remember-off after email confirmation resumes the login."""
+        user = make_user(
+            user_name='pending_session_user',
+            email='pending-session@example.com',
+            password='testpass123',
+        )
+        address = EmailAddress.objects.get(user=user)
+        address.verified = False
+        address.save(update_fields=['verified'])
+
+        response = self.client.post(reverse('account:login'), {
+            'username': user.email,
+            'password': 'testpass123',
+        })
+
+        self.assertRedirects(response, '/accounts/confirm-email/', fetch_redirect_response=False)
+        confirmation_url = reverse(
+            'account_confirm_email',
+            args=[EmailConfirmationHMAC(address).key],
+        )
+        self.client.get(confirmation_url)
+        self.client.post(confirmation_url)
+
+        self.assertIn('_auth_user_id', self.client.session)
+        self.assertTrue(self.client.session.get_expire_at_browser_close())
+
     def test_login_syncs_missing_email_address_as_unverified(self):
         """Send verification instead of locking a programmatically created user out."""
         user = make_user_without_email_address(

--- a/app/user_account/tests/test_email_verification_audit.py
+++ b/app/user_account/tests/test_email_verification_audit.py
@@ -1,0 +1,54 @@
+"""Tests for the read-only legacy email verification audit."""
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from allauth.account.models import EmailAddress
+
+from tests.factories import make_legacy_user, make_user, make_user_without_email_address
+
+class EmailVerificationBackfillAuditTests(TestCase):
+    """Reject legacy states that cannot be migrated without guessing ownership."""
+
+    def test_reports_only_counts_for_a_compatible_database(self):
+        make_user(user_name='compatible', email='compatible@example.com')
+        stdout = StringIO()
+
+        call_command('audit_email_verification_backfill', stdout=stdout)
+
+        output = stdout.getvalue()
+        self.assertIn('users=1 blank=0 ownership_conflicts=0 duplicate_own_rows=0', output)
+        self.assertNotIn('compatible@example.com', output)
+
+    def test_rejects_an_email_address_owned_by_another_user(self):
+        target = make_user_without_email_address(
+            user_name='target',
+            email='target@example.com',
+            password='testpass123',
+        )
+        owner = make_user(user_name='owner', email='owner@example.com')
+        EmailAddress.objects.create(
+            user=owner,
+            email=target.email,
+            verified=False,
+            primary=False,
+        )
+        stdout = StringIO()
+
+        with self.assertRaises(CommandError):
+            call_command('audit_email_verification_backfill', stdout=stdout)
+
+        self.assertIn('ownership_conflicts=1', stdout.getvalue())
+        self.assertNotIn(target.email, stdout.getvalue())
+
+    def test_rejects_a_blank_legacy_email(self):
+        make_legacy_user(user_name='blank', email='')
+        stdout = StringIO()
+
+        with self.assertRaises(CommandError):
+            call_command('audit_email_verification_backfill', stdout=stdout)
+
+        self.assertIn('blank=1', stdout.getvalue())

--- a/app/user_account/tests/test_social_signup_username.py
+++ b/app/user_account/tests/test_social_signup_username.py
@@ -85,7 +85,7 @@ class DiscordAutoSignupUserNameTests(TestCase):
         self.assertEqual(created.user_name, 'PROBE_NAME')
 
     def test_unique_discord_username_is_saved_as_is(self):
-        """重複がない場合も従来どおり Discord ユーザー名が保存されること."""
+        """検証済みDiscordメールは mandatory でも確認済みとして保存されること."""
         created = self._auto_signup(
             discord_username='solo_name',
             email='flow-solo@example.com',
@@ -93,3 +93,9 @@ class DiscordAutoSignupUserNameTests(TestCase):
         )
 
         self.assertEqual(created.user_name, 'solo_name')
+        self.assertTrue(EmailAddress.objects.filter(
+            user=created,
+            email='flow-solo@example.com',
+            verified=True,
+            primary=True,
+        ).exists())

--- a/app/user_account/tests/test_views.py
+++ b/app/user_account/tests/test_views.py
@@ -1,9 +1,12 @@
 """認証ビューのテスト."""
 from django.contrib.auth import get_user_model
+from django.core import mail
 from django.contrib.messages import get_messages
 from django.conf import settings
 from django.test import Client, TestCase, override_settings, tag
 from django.urls import reverse
+
+from allauth.account.models import EmailAddress
 
 from community.models import Community, CommunityMember
 from tests.factories import make_community
@@ -556,8 +559,9 @@ class RegisterViewTests(TestCase):
         self.assertContains(response, 'name="password2"')
 
     @override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS)
-    def test_register_page_creates_local_user_without_discord_oauth(self):
-        """Discord OAuth 未設定時はローカルユーザーを作成できること."""
+    @override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+    def test_register_page_creates_unverified_local_user_without_discord_oauth(self):
+        """ローカル登録は未検証 primary address と確認メールを作成すること."""
         response = self.client.post(self.register_url, {
             'user_name': 'local_signup_user',
             'email': 'local-signup@example.com',
@@ -565,9 +569,12 @@ class RegisterViewTests(TestCase):
             'password2': 'testpass12345',
         }, follow=True)
 
-        self.assertRedirects(response, reverse('account:login'))
-        self.assertTrue(User.objects.filter(user_name='local_signup_user').exists())
-        self.assertContains(response, 'アカウントを作成しました。ログインしてください。')
+        self.assertRedirects(response, '/accounts/confirm-email/', fetch_redirect_response=False)
+        user = User.objects.get(user_name='local_signup_user')
+        self.assertTrue(EmailAddress.objects.filter(
+            user=user, email=user.email, verified=False, primary=True,
+        ).exists())
+        self.assertEqual(len(mail.outbox), 1)
 
 
 @tag('offline_external_api')

--- a/app/user_account/tests/utils.py
+++ b/app/user_account/tests/utils.py
@@ -2,6 +2,7 @@
 from django.contrib.auth import get_user_model
 
 from allauth.socialaccount.models import SocialAccount
+from allauth.account.models import EmailAddress
 
 User = get_user_model()
 
@@ -46,6 +47,12 @@ def create_discord_linked_user(user_name, email, password, discord_uid=None, **e
         email=email,
         password=password,
         **extra_fields,
+    )
+    EmailAddress.objects.create(
+        user=user,
+        email=user.email,
+        verified=True,
+        primary=True,
     )
     SocialAccount.objects.create(
         user=user,

--- a/app/user_account/view_modules/profile.py
+++ b/app/user_account/view_modules/profile.py
@@ -1,14 +1,20 @@
 """プロフィールと設定画面に関する view 群."""
 
+import logging
+
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from django.utils.safestring import mark_safe
 from django.views.generic import TemplateView, UpdateView
 
+from allauth.account.models import EmailAddress
+
 from analytics import services as analytics_services
 from community.models import CommunityMember
 from user_account.forms import CustomUserChangeForm
+
+logger = logging.getLogger(__name__)
 
 
 class UserNameChangeView(LoginRequiredMixin, UpdateView):
@@ -33,8 +39,34 @@ class UserUpdateView(LoginRequiredMixin, UpdateView):
         return self.request.user
 
     def form_valid(self, form):
-        messages.success(self.request, 'ユーザー情報が更新されました。')
-        return super().form_valid(form)
+        new_email = form.cleaned_data['email']
+        old_email = form.original_email
+        response = super().form_valid(form)
+        if new_email != old_email:
+            try:
+                EmailAddress.objects.add_new_email(self.request, self.request.user, new_email)
+            except Exception as exc:
+                # The current email remains authoritative. allauth may have
+                # committed a pending row before the mail backend failed, so a
+                # later submission of the same address acts as a safe resend.
+                logger.error(
+                    'Failed to send email-change confirmation: '
+                    'user_id=%s exception_type=%s',
+                    self.request.user.pk,
+                    type(exc).__name__,
+                )
+                messages.warning(
+                    self.request,
+                    '確認メールを送信できませんでした。現在のメールアドレスは変更されていません。時間をおいて再度お試しください。',
+                )
+            else:
+                messages.success(
+                    self.request,
+                    '確認メールを新しいメールアドレスに送信しました。確認完了まで現在のメールアドレスを使用します。',
+                )
+        else:
+            messages.success(self.request, 'ユーザー情報が更新されました。')
+        return response
 
 
 class SettingsView(LoginRequiredMixin, TemplateView):

--- a/app/user_account/view_modules/profile.py
+++ b/app/user_account/view_modules/profile.py
@@ -12,13 +12,17 @@ from allauth.account.models import EmailAddress
 
 from analytics import services as analytics_services
 from community.models import CommunityMember
-from user_account.forms import CustomUserChangeForm
+from user_account.forms import (
+    CustomUserChangeForm,
+    UserNameChangeForm,
+    consume_email_change_rate_limit,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class UserNameChangeView(LoginRequiredMixin, UpdateView):
-    form_class = CustomUserChangeForm
+    form_class = UserNameChangeForm
     success_url = reverse_lazy('account:settings')
     template_name = 'account/user_name_change.html'
 
@@ -41,6 +45,15 @@ class UserUpdateView(LoginRequiredMixin, UpdateView):
     def form_valid(self, form):
         new_email = form.cleaned_data['email']
         old_email = form.original_email
+        if new_email != old_email and not consume_email_change_rate_limit(
+            self.request,
+            self.request.user,
+        ):
+            form.add_error(
+                'email',
+                'メールアドレスの変更回数が上限に達しました。時間をおいて再度お試しください。',
+            )
+            return self.form_invalid(form)
         response = super().form_valid(form)
         if new_email != old_email:
             try:
@@ -54,6 +67,7 @@ class UserUpdateView(LoginRequiredMixin, UpdateView):
                     'user_id=%s exception_type=%s',
                     self.request.user.pk,
                     type(exc).__name__,
+                    exc_info=True,
                 )
                 messages.warning(
                     self.request,

--- a/app/user_account/view_modules/session.py
+++ b/app/user_account/view_modules/session.py
@@ -41,6 +41,8 @@ class CustomLoginView(LoginView):
     def form_valid(self, form):
         """allauth の確認ステージを通じてログインする."""
         remember = form.cleaned_data.get('remember')
+        session_expiry = app_settings.SESSION_COOKIE_AGE if remember else 0
+        self.request.session.set_expiry(session_expiry)
         response = perform_login(
             self.request,
             form.get_user(),
@@ -48,8 +50,6 @@ class CustomLoginView(LoginView):
             redirect_url=self.get_redirect_url() or get_default_login_redirect_url(form.get_user()),
             email=form.cleaned_data['username'].lower(),
         )
-        if self.request.user.is_authenticated and not remember:
-            self.request.session.set_expiry(0)
         return response
 
     def get_context_data(self, **kwargs):

--- a/app/user_account/view_modules/session.py
+++ b/app/user_account/view_modules/session.py
@@ -1,15 +1,17 @@
 """ログイン・ログアウト・登録に関する view 群."""
 
-from urllib.parse import urlencode
-
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LoginView, LogoutView, PasswordChangeView, RedirectURLMixin
 from django.shortcuts import redirect
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import FormView, TemplateView
+
+from allauth.account import app_settings
+from allauth.account.utils import complete_signup, perform_login, setup_user_email
+from django.db import transaction
 
 from user_account.discord_oauth import is_discord_oauth_available
 from user_account.forms import (
@@ -32,15 +34,22 @@ class CustomLoginView(LoginView):
         return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
-        """ログイン成功時に remember 設定からセッション期限を決める."""
+        """allauth の確認ステージを通じてログインする."""
         remember = form.cleaned_data.get('remember')
-        response = super().form_valid(form)
-        if not remember:
+        response = perform_login(
+            self.request,
+            form.get_user(),
+            email_verification=app_settings.EmailVerificationMethod.MANDATORY,
+            redirect_url=self.get_redirect_url() or get_default_login_redirect_url(form.get_user()),
+            email=form.cleaned_data['username'],
+        )
+        if self.request.user.is_authenticated:
+            messages.info(self.request, 'ログインしました。')
+        if self.request.user.is_authenticated and not remember:
             self.request.session.set_expiry(0)
         return response
 
     def get_success_url(self):
-        messages.info(self.request, 'ログインしました。')
         redirect_url = self.get_redirect_url()
         if redirect_url:
             return redirect_url
@@ -80,21 +89,22 @@ class RegisterView(RedirectURLMixin, FormView):
         context['redirect_field_value'] = self.get_redirect_url()
         return context
 
-    def get_success_url(self):
-        """安全な遷移先を引き継いでログイン画面へ移動する."""
-        login_url = reverse('account:login')
-        redirect_url = self.get_redirect_url()
-        if not redirect_url:
-            return login_url
-        return f'{login_url}?{urlencode({self.redirect_field_name: redirect_url})}'
-
     def form_valid(self, form):
         if self.discord_oauth_enabled:
             return redirect('account:register')
 
-        form.save()
-        messages.success(self.request, 'アカウントを作成しました。ログインしてください。')
-        return super().form_valid(form)
+        with transaction.atomic():
+            user = form.save()
+            setup_user_email(self.request, user, [])
+        # Send only after the user and its unverified primary address commit.
+        # A mail delivery failure deliberately leaves this state for login resend.
+        redirect_url = self.get_redirect_url() or get_default_login_redirect_url(user)
+        return complete_signup(
+            self.request,
+            user,
+            app_settings.EmailVerificationMethod.MANDATORY,
+            redirect_url,
+        )
 
 
 class CustomPasswordChangeView(LoginRequiredMixin, PasswordChangeView):

--- a/app/user_account/view_modules/session.py
+++ b/app/user_account/view_modules/session.py
@@ -1,5 +1,7 @@
 """ログイン・ログアウト・登録に関する view 群."""
 
+import logging
+
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LoginView, LogoutView, PasswordChangeView, RedirectURLMixin
@@ -13,6 +15,7 @@ from allauth.account import app_settings
 from allauth.account.utils import complete_signup, perform_login, setup_user_email
 from django.db import transaction
 
+from user_account.adapters import ConfirmationEmailDeliveryError
 from user_account.discord_oauth import is_discord_oauth_available
 from user_account.forms import (
     BootstrapAuthenticationForm,
@@ -20,6 +23,8 @@ from user_account.forms import (
     LocalSignupForm,
 )
 from user_account.login_redirect import get_default_login_redirect_url
+
+logger = logging.getLogger(__name__)
 
 
 @method_decorator(ensure_csrf_cookie, name='dispatch')
@@ -41,19 +46,11 @@ class CustomLoginView(LoginView):
             form.get_user(),
             email_verification=app_settings.EmailVerificationMethod.MANDATORY,
             redirect_url=self.get_redirect_url() or get_default_login_redirect_url(form.get_user()),
-            email=form.cleaned_data['username'],
+            email=form.cleaned_data['username'].lower(),
         )
-        if self.request.user.is_authenticated:
-            messages.info(self.request, 'ログインしました。')
         if self.request.user.is_authenticated and not remember:
             self.request.session.set_expiry(0)
         return response
-
-    def get_success_url(self):
-        redirect_url = self.get_redirect_url()
-        if redirect_url:
-            return redirect_url
-        return get_default_login_redirect_url(self.request.user)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -99,12 +96,25 @@ class RegisterView(RedirectURLMixin, FormView):
         # Send only after the user and its unverified primary address commit.
         # A mail delivery failure deliberately leaves this state for login resend.
         redirect_url = self.get_redirect_url() or get_default_login_redirect_url(user)
-        return complete_signup(
-            self.request,
-            user,
-            app_settings.EmailVerificationMethod.MANDATORY,
-            redirect_url,
-        )
+        try:
+            return complete_signup(
+                self.request,
+                user,
+                app_settings.EmailVerificationMethod.MANDATORY,
+                redirect_url,
+            )
+        except ConfirmationEmailDeliveryError as exc:
+            logger.error(
+                'Failed to send signup confirmation: user_id=%s exception_type=%s',
+                user.pk,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            messages.warning(
+                self.request,
+                '登録は完了しました。確認メールの送信に失敗したため、ログイン画面から再送してください。',
+            )
+            return redirect('account:login')
 
 
 class CustomPasswordChangeView(LoginRequiredMixin, PasswordChangeView):

--- a/app/website/settings/authentication.py
+++ b/app/website/settings/authentication.py
@@ -23,7 +23,12 @@ AUTHENTICATION_BACKENDS = [
 # django-allauth 設定
 ACCOUNT_LOGIN_METHODS = {'email'}
 ACCOUNT_SIGNUP_FIELDS = ['email*', 'password1*', 'password2*']
-ACCOUNT_EMAIL_VERIFICATION = 'none'
+ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
+ACCOUNT_CHANGE_EMAIL = True
+# Confirmation links only resume the signup login in the browser that started
+# registration. This preserves a validated ``next`` without turning a leaked,
+# reusable confirmation link into a session-independent login link.
+ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = True
 ACCOUNT_USER_MODEL_USERNAME_FIELD = 'user_name'
 ACCOUNT_SESSION_REMEMBER = None  # ユーザーに選択させる
 SOCIALACCOUNT_AUTO_SIGNUP = True

--- a/app/website/urls.py
+++ b/app/website/urls.py
@@ -21,6 +21,7 @@ from django.views.generic import RedirectView
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 from ta_hub.health import health_check
+from user_account.views import CustomLoginView
 
 urlpatterns = [
     # Cloud Run readiness/liveness probe 用（DB + cache 疎通確認）
@@ -36,6 +37,9 @@ urlpatterns = [
     path('accounts/', include('allauth.urls')),
     path('twitter/', include('twitter.urls')),
     path('api/v1/', include('api_v1.urls')),
+    # Keep DRF's logout and password endpoints, while preventing its login view
+    # from bypassing allauth's mandatory email-verification login stage.
+    path('api-auth/login/', CustomLoginView.as_view(), name='api-auth-login'),
     path('api-auth/', include('rest_framework.urls')),
     # API Documentation: schema endpoint is always available; UI is DEBUG-only
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ VRC技術学術ハブの開発、運用、調査メモ、利用ガイドをま�
 - [提案書](proposals/index.md)
 - [Giga Week 2025 Winter 下書き](giga-week-2025-winter/index.md)
 - [Vket 2026 Summer 動画アーカイブ下書き](giga-week-2026-summer/index.md)
+- [Vket 2026 Summer - Vket技術学術WEEK 動画アーカイブ](giga-week-2026-summer/draft-article.md)
 
 ## 分析・調査メモ
 
@@ -95,4 +96,6 @@ VRC技術学術ハブの開発、運用、調査メモ、利用ガイドをま�
 - [Issue #500 Campaign UTM validator migration](research/issue-500-analytics-campaign-migration.md)
 - [Issue #529 offline runner と Docker network-none の遮断結果](research/issue-529-offline-network-none.md)
 - [Issue #542 Google→DB 同期デッドコード削除](research/issue-542-google-to-db-sync-removal.md)
+- [Issue #566 協力団体の公開審査基準](research/issue-566-community-criteria.md)
+- [Issue #570 終了済み Vket バナー調査](research/issue-570-expired-vket-banner.md)
 - [Sentry エラートラッキング](sentry.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,6 @@ VRC技術学術ハブの開発、運用、調査メモ、利用ガイドをま�
 - [提案書](proposals/index.md)
 - [Giga Week 2025 Winter 下書き](giga-week-2025-winter/index.md)
 - [Vket 2026 Summer 動画アーカイブ下書き](giga-week-2026-summer/index.md)
-- [Vket 2026 Summer - Vket技術学術WEEK 動画アーカイブ](giga-week-2026-summer/draft-article.md)
 
 ## 分析・調査メモ
 
@@ -96,6 +95,4 @@ VRC技術学術ハブの開発、運用、調査メモ、利用ガイドをま�
 - [Issue #500 Campaign UTM validator migration](research/issue-500-analytics-campaign-migration.md)
 - [Issue #529 offline runner と Docker network-none の遮断結果](research/issue-529-offline-network-none.md)
 - [Issue #542 Google→DB 同期デッドコード削除](research/issue-542-google-to-db-sync-removal.md)
-- [Issue #566 協力団体の公開審査基準](research/issue-566-community-criteria.md)
-- [Issue #570 終了済み Vket バナー調査](research/issue-570-expired-vket-banner.md)
 - [Sentry エラートラッキング](sentry.md)

--- a/docs/migration-rollback.md
+++ b/docs/migration-rollback.md
@@ -123,6 +123,21 @@ gcloud run jobs execute vrc-ta-hub-migrate \
 - CI/CD パイプラインに組み込みやすいが、ジョブ実行ログから rollback の成否を確認する必要がある
 - 緊急時は方式 A の方が手数が少なく早い
 
+### user_account 0015 の適用前監査
+
+`user_account.0015_backfill_verified_email_addresses` は既存ユーザーを確認済みにする前に、
+空メール・別ユーザー所有の `EmailAddress`・同一ユーザーの重複行がないことを確認する。
+新しいイメージで次の読み取り専用コマンドを実行し、`audit passed` を確認してから migration を適用する。
+出力は件数のみで、メールアドレスやユーザー ID はログに残さない。
+
+```bash
+python manage.py audit_email_verification_backfill
+python manage.py migrate user_account 0015 --plan
+python manage.py migrate user_account 0015
+```
+
+監査または migration が停止した場合は、所有者を推測して修正せず、対象データの確認後に再実行する。
+
 ## 危険な migration の見分け方
 
 PR レビュー時点で**「rollback コストが高い」**と判断するためのチェックリスト。


### PR DESCRIPTION
## なぜこの変更が必要か

email ログイン化（#579/#596）後も `ACCOUNT_EMAIL_VERIFICATION='none'` のままで、攻撃者が被害者の Discord 登録メールを先回りしてローカル登録すると、被害者の初回 Discord ログインで攻撃者アカウントに自動紐付けされる「アカウント押し付け」経路が残っていた（Issue #593、セキュリティレビュー MEDIUM 指摘由来）。

## 変更内容

- `ACCOUNT_EMAIL_VERIFICATION = 'mandatory'` 化。新規ローカル登録は確認メール検証完了までログイン不可
- 既存全ユーザーは data migration（0015）で verified EmailAddress を作成しログイン影響ゼロ（空 email・所有権競合は fail-closed で停止、事前監査コマンド `audit_email_verification_backfill` 付き）
- Discord 自動紐付け（`pre_social_login`）は verified な EmailAddress を持つユーザーのみ connect 対象に
- 検証バイパス経路の同時封鎖: 自前 `CustomLoginView` で verified 必須化（allauth の mandatory は自前ビューを素通りするため）、`/api-auth/login/` を同ビューへ差し替え、Django admin ログインも verified 必須化
- email 変更は段階的検証へ: 旧アドレス維持 → 新アドレス確認完了後に切替。変更経路には allauth `manage_email` レート制限を適用
- RegisterView は確認メール送信フローへ変更（送信失敗時も 500 にせず登録完了 + 再送案内）

## 意思決定

### 採用アプローチ
- mandatory + 既存ユーザー verified 化を採用（ユーザー確認済み）。理由: 押し付けリスクの完全遮断。optional では未検証アカウントが残る
- `/api-auth/login/` は利用実態を否定できないため削除せず、verified 強制の `CustomLoginView` に差し替えて互換維持
- `UserNameChangeView` は email フィールドを持たない専用フォーム（`UserNameChangeForm`）に分離（レビュー P1: 同一フォーム共有で email 変更が黙って消えるリグレッションの修正）

### 却下した代替案
- optional（検証メールのみ送りログイン可）→ 却下: 未検証アカウント残存
- 検証なしで紐付け条件のみ修正 → 却下: 総当たり系の別リスクが残る

### スコープ外（Issue 化済み）
- メール列挙耐性・pending squatting・ロックアウト DoS 回復導線 → #609

## テスト

- [x] フルスイート 2,192 件成功（skipped 23）、`user_account` 263 件
- [x] migration 冪等性・reverse→forward・所有権競合の fail-closed をテストで実測
- [x] 既存ユーザーのログイン担保は 3 重（backfill / superuser 作成時 verified / 取りこぼしは sync_email_address が未検証行を作り確認メール再送）
- [x] コード品質 + セキュリティの 2 レビュー実施、P1/HIGH（email 変更バイパス）と P2 群を修正済み

## Screenshot

スクショなし: 画面差分は user_update.html のヘルプ文言 1 行のみ（認証必須ページ）。フローの検証はテストで担保

## 運用ノート（マージ後）

- **本番反映前に migration 0015 の手動適用が必要**（本リポは migration 自動適用を意図的に導入していない）。手順・ロールバックは `docs/migration-rollback.md` 参照。適用前に `python manage.py audit_email_verification_backfill` で事前監査可能

Closes #593

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)