### PR TITLE
feat(user_account): ログイン試行のレートリミットを導入する

### DIFF
--- a/app/ta_hub/health.py
+++ b/app/ta_hub/health.py
@@ -8,7 +8,7 @@ zombie プロセスへの誤ルーティングを防ぐため、DB と cache の
 - cache 失敗は status を ng にしない（cache 未設定でも生存判定したい）
 """
 
-from django.core.cache import cache
+from django.core.cache import caches
 from django.db import connection
 from django.http import JsonResponse
 
@@ -16,6 +16,11 @@ from django.http import JsonResponse
 _HEALTH_CACHE_KEY = "_health_probe"
 _HEALTH_CACHE_VALUE = "1"
 _HEALTH_CACHE_TTL_SEC = 5
+
+
+def _get_health_cache():
+    """現在のsettingsからhealth probe専用cacheを取得する。"""
+    return caches['healthcheck']
 
 
 def health_check(request):
@@ -35,8 +40,9 @@ def health_check(request):
         checks["status"] = "ng"
 
     try:
-        cache.set(_HEALTH_CACHE_KEY, _HEALTH_CACHE_VALUE, _HEALTH_CACHE_TTL_SEC)
-        if cache.get(_HEALTH_CACHE_KEY) != _HEALTH_CACHE_VALUE:
+        health_cache = _get_health_cache()
+        health_cache.set(_HEALTH_CACHE_KEY, _HEALTH_CACHE_VALUE, _HEALTH_CACHE_TTL_SEC)
+        if health_cache.get(_HEALTH_CACHE_KEY) != _HEALTH_CACHE_VALUE:
             raise RuntimeError("cache roundtrip failed")
         checks["cache"] = "ok"
     except Exception:

--- a/app/ta_hub/tests/test_health.py
+++ b/app/ta_hub/tests/test_health.py
@@ -45,7 +45,7 @@ class HealthCheckTest(TestCase):
     def test_health_keeps_ok_when_only_cache_fails(self):
         """cache 失敗時も status=ok を返す（cache 未設定環境でも生存判定したい）"""
         with patch(
-            'ta_hub.health.cache.set',
+            'ta_hub.health._get_health_cache',
             side_effect=Exception('cache down'),
         ):
             response = self.client.get('/health')
@@ -58,7 +58,8 @@ class HealthCheckTest(TestCase):
 
     def test_health_cache_roundtrip_mismatch_marks_cache_ng(self):
         """cache.get が想定外の値を返すと cache=ng になる（status は ok のまま）"""
-        with patch('ta_hub.health.cache.get', return_value='unexpected'):
+        with patch('ta_hub.health._get_health_cache') as get_cache:
+            get_cache.return_value.get.return_value = 'unexpected'
             response = self.client.get('/health')
 
         self.assertEqual(response.status_code, 200)

--- a/app/user_account/adapters.py
+++ b/app/user_account/adapters.py
@@ -6,8 +6,10 @@ from allauth.account.models import EmailAddress
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
+from django.http import HttpRequest
 from django.urls import reverse
 
+from ta_hub.utils import get_client_ip as get_trusted_client_ip
 from user_account.login_redirect import get_default_login_redirect_url
 
 logger = logging.getLogger(__name__)
@@ -21,6 +23,15 @@ class ConfirmationEmailDeliveryError(Exception):
 
 class CustomAccountAdapter(DefaultAccountAdapter):
     """ログイン後の既定リダイレクト先を集会所属状況で切り替える。"""
+
+    def get_client_ip(self, request: HttpRequest) -> str:
+        """Cloud Runの信頼済みXFF契約から安全にclient IPを返す。
+
+        allauth既定実装はXFFが信頼proxy数より短いと設定例外を送出する。
+        既存の共通utilityへ揃え、欠落時はREMOTE_ADDR、1要素ならその値、
+        2要素以上ならCloud Runが付与した末尾から2番目を使う。
+        """
+        return get_trusted_client_ip(request)
 
     def clean_username(self, username, shallow=False):
         """user_name の重複を検証エラーにしない。

--- a/app/user_account/admin.py
+++ b/app/user_account/admin.py
@@ -8,13 +8,19 @@ from django.core.exceptions import ValidationError
 
 from allauth.account.models import EmailAddress
 
-from user_account.forms import consume_email_change_rate_limit
+from user_account.forms import (
+    AllauthAuthenticationFormMixin,
+    consume_email_change_rate_limit,
+)
 from user_account.models import CustomUser, APIKey
 
 logger = logging.getLogger(__name__)
 
 
-class VerifiedAdminAuthenticationForm(AdminAuthenticationForm):
+class VerifiedAdminAuthenticationForm(
+    AllauthAuthenticationFormMixin,
+    AdminAuthenticationForm,
+):
     """Require a verified primary identity before creating an admin session."""
 
     def confirm_login_allowed(self, user):

--- a/app/user_account/forms.py
+++ b/app/user_account/forms.py
@@ -6,9 +6,10 @@ from django.contrib.auth.forms import UserCreationForm, PasswordChangeForm
 from django.core.validators import FileExtensionValidator
 from django.http import HttpRequest
 
-from allauth.socialaccount.forms import SignupForm as SocialSignupForm
+from allauth.account.adapter import get_adapter
 from allauth.account.models import EmailAddress
 from allauth.core import ratelimit
+from allauth.socialaccount.forms import SignupForm as SocialSignupForm
 
 from community.constants import WEEKDAY_CHOICES
 from community.models import Community
@@ -229,10 +230,13 @@ class BootstrapAuthenticationForm(AuthenticationForm):
 
     def authenticate_user(self, email, password):
         """メールアドレスを使用してユーザーを認証する。"""
-        from django.contrib.auth import authenticate
-
-        # Django標準フォームとの互換性のため、入力名は username のままにする。
-        return authenticate(self.request, username=email, password=password)
+        # adapter 経由にすることで、allauth のログイン失敗制限と
+        # 成功時のカウンタ rollback を同じ認証チェーンで適用する。
+        return get_adapter().authenticate(
+            self.request,
+            email=email,
+            password=password,
+        )
 
 
 class BootstrapPasswordChangeForm(PasswordChangeForm):

--- a/app/user_account/forms.py
+++ b/app/user_account/forms.py
@@ -193,7 +193,31 @@ class CustomUserCreationForm(UserCreationForm):
         return user
 
 
-class BootstrapAuthenticationForm(AuthenticationForm):
+class AllauthAuthenticationFormMixin:
+    """Django認証フォームをallauthの失敗制限付き認証へ接続する。"""
+
+    def clean(self):
+        email = self.cleaned_data.get('username')
+        password = self.cleaned_data.get('password')
+
+        if email is not None and password:
+            self.user_cache = self.authenticate_user(email, password)
+            if self.user_cache is None:
+                raise self.get_invalid_login_error()
+            self.confirm_login_allowed(self.user_cache)
+
+        return self.cleaned_data
+
+    def authenticate_user(self, email, password):
+        """allauth adapter経由でemailとpasswordを認証する。"""
+        return get_adapter().authenticate(
+            self.request,
+            email=email,
+            password=password,
+        )
+
+
+class BootstrapAuthenticationForm(AllauthAuthenticationFormMixin, AuthenticationForm):
     """メールアドレスで認証するフォーム。"""
 
     username = forms.EmailField(
@@ -214,29 +238,6 @@ class BootstrapAuthenticationForm(AuthenticationForm):
         for name, field in self.fields.items():
             if name != 'remember':
                 field.widget.attrs.update({'class': 'form-control'})
-
-    def clean(self):
-        email = self.cleaned_data.get('username')
-        password = self.cleaned_data.get('password')
-
-        if email is not None and password:
-            self.user_cache = self.authenticate_user(email, password)
-            if self.user_cache is None:
-                raise self.get_invalid_login_error()
-            else:
-                self.confirm_login_allowed(self.user_cache)
-
-        return self.cleaned_data
-
-    def authenticate_user(self, email, password):
-        """メールアドレスを使用してユーザーを認証する。"""
-        # adapter 経由にすることで、allauth のログイン失敗制限と
-        # 成功時のカウンタ rollback を同じ認証チェーンで適用する。
-        return get_adapter().authenticate(
-            self.request,
-            email=email,
-            password=password,
-        )
 
 
 class BootstrapPasswordChangeForm(PasswordChangeForm):

--- a/app/user_account/migrations/0016_login_rate_limit_cache.py
+++ b/app/user_account/migrations/0016_login_rate_limit_cache.py
@@ -1,0 +1,39 @@
+"""Create the shared cache table used by login rate limiting."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Create the cache table without adding a runtime Django model."""
+
+    dependencies = [
+        ('user_account', '0015_backfill_verified_email_addresses'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.CreateModel(
+                    name='LoginRateLimitCache',
+                    fields=[
+                        (
+                            'cache_key',
+                            models.CharField(
+                                max_length=255,
+                                primary_key=True,
+                                serialize=False,
+                            ),
+                        ),
+                        ('value', models.TextField()),
+                        ('expires', models.DateTimeField(db_index=True)),
+                    ],
+                    options={
+                        'db_table': 'login_rate_limit_cache',
+                    },
+                ),
+            ],
+            # DatabaseCache does not need a runtime model. Keeping it out of
+            # migration state prevents a later makemigrations from deleting it.
+            state_operations=[],
+        ),
+    ]

--- a/app/user_account/templates/account/login.html
+++ b/app/user_account/templates/account/login.html
@@ -39,6 +39,13 @@
                         {% endif %}
                         <form method="post">
                             {% csrf_token %}
+                            {% if form.non_field_errors %}
+                                <div class="alert alert-danger" role="alert">
+                                    {% for error in form.non_field_errors %}
+                                        <div>{{ error }}</div>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
                             {% if redirect_field_value %}
                                 <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
                             {% endif %}

--- a/app/user_account/tests/test_account_adapter_ip.py
+++ b/app/user_account/tests/test_account_adapter_ip.py
@@ -1,0 +1,41 @@
+"""allauth account adapterのclient IP識別テスト。"""
+
+from django.http import HttpRequest
+from django.test import RequestFactory, SimpleTestCase
+
+from user_account.adapters import CustomAccountAdapter
+
+
+class CustomAccountAdapterClientIpTests(SimpleTestCase):
+    """allauthのIPキーをCloud RunのXFF契約から安全に取得する。"""
+
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.adapter = CustomAccountAdapter()
+
+    def _request(self, forwarded_for: str | None) -> HttpRequest:
+        request = self.factory.post('/account/login/')
+        request.META['REMOTE_ADDR'] = '192.0.2.10'
+        if forwarded_for is not None:
+            request.META['HTTP_X_FORWARDED_FOR'] = forwarded_for
+        return request
+
+    def test_missing_xff_uses_remote_addr(self) -> None:
+        request = self._request(None)
+
+        self.assertEqual(self.adapter.get_client_ip(request), '192.0.2.10')
+
+    def test_single_xff_value_uses_that_value(self) -> None:
+        request = self._request('203.0.113.10')
+
+        self.assertEqual(self.adapter.get_client_ip(request), '203.0.113.10')
+
+    def test_two_xff_values_use_cloud_run_client(self) -> None:
+        request = self._request('203.0.113.10, 10.128.0.1')
+
+        self.assertEqual(self.adapter.get_client_ip(request), '203.0.113.10')
+
+    def test_spoofed_xff_prefix_is_ignored(self) -> None:
+        request = self._request('198.51.100.99, 203.0.113.10, 10.128.0.1')
+
+        self.assertEqual(self.adapter.get_client_ip(request), '203.0.113.10')

--- a/app/user_account/tests/test_login_rate_limit.py
+++ b/app/user_account/tests/test_login_rate_limit.py
@@ -1,0 +1,111 @@
+"""ログイン失敗レート制限の振る舞いテスト."""
+
+from django.core.cache import cache
+from django.test import Client, TestCase, override_settings, tag
+from django.urls import reverse
+
+from user_account.tests.utils import (
+    TEST_SOCIALACCOUNT_PROVIDERS_WITH_APPS,
+    create_discord_linked_user,
+)
+
+
+RATE_LIMIT_MESSAGE = 'ログイン失敗が連続しています。時間が経ってからやり直してください。'
+CLOUD_RUN_XFF = '203.0.113.10, 10.128.0.1'
+
+
+@override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS_WITH_APPS)
+@tag('offline_external_api')
+class LoginRateLimitTests(TestCase):
+    """通常画面とDRF画面に同じログイン失敗制限を適用する."""
+
+    def setUp(self) -> None:
+        cache.clear()
+        self.client = Client()
+        self.login_url = reverse('account:login')
+        self.api_login_url = reverse('api-auth-login')
+        self.user = create_discord_linked_user(
+            user_name='rate_limit_user',
+            email='rate-limit@example.com',
+            password='testpass123',
+        )
+
+    def tearDown(self) -> None:
+        cache.clear()
+
+    def _post_login(
+        self,
+        url: str,
+        *,
+        email: str = 'rate-limit@example.com',
+        password: str = 'wrong-password',
+        forwarded_for: str = CLOUD_RUN_XFF,
+    ):
+        return self.client.post(
+            url,
+            {'username': email, 'password': password},
+            HTTP_X_FORWARDED_FOR=forwarded_for,
+        )
+
+    def test_same_email_is_blocked_after_five_failures_across_login_paths(self) -> None:
+        """通常/API経路の失敗を同じemailバケットで数える."""
+        responses = [self._post_login(self.login_url) for _ in range(3)]
+        responses += [self._post_login(self.api_login_url) for _ in range(2)]
+
+        for response in responses:
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, RATE_LIMIT_MESSAGE)
+
+        blocked = self._post_login(self.login_url)
+
+        self.assertEqual(blocked.status_code, 200)
+        self.assertContains(blocked, RATE_LIMIT_MESSAGE)
+
+    def test_cache_reset_recovers_a_locked_out_user(self) -> None:
+        """期限切れ相当のカウンタ消去後は正しい認証を再開できる."""
+        for _ in range(6):
+            self._post_login(self.login_url)
+        cache.clear()
+
+        response = self._post_login(
+            self.login_url,
+            password='testpass123',
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.client.session['_auth_user_id'], str(self.user.pk))
+
+    def test_successful_logins_do_not_increase_failure_counter(self) -> None:
+        """成功時rollbackにより後続の初回失敗をブロックしない."""
+        for _ in range(5):
+            response = self._post_login(
+                self.login_url,
+                password='testpass123',
+            )
+            self.assertEqual(response.status_code, 302)
+            self.client.logout()
+
+        failed = self._post_login(self.login_url)
+
+        self.assertEqual(failed.status_code, 200)
+        self.assertNotContains(failed, RATE_LIMIT_MESSAGE)
+
+    def test_spoofed_xff_prefix_does_not_bypass_ip_limit(self) -> None:
+        """Cloud Run XFFの左側を変えてもclient IPを共有する."""
+        for attempt in range(10):
+            response = self._post_login(
+                self.login_url,
+                email=f'absent-{attempt}@example.com',
+                forwarded_for=f'198.51.100.{attempt}, 203.0.113.20, 10.128.0.1',
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, RATE_LIMIT_MESSAGE)
+
+        blocked = self._post_login(
+            self.login_url,
+            email='another-absent@example.com',
+            forwarded_for='192.0.2.99, 203.0.113.20, 10.128.0.1',
+        )
+
+        self.assertEqual(blocked.status_code, 200)
+        self.assertContains(blocked, RATE_LIMIT_MESSAGE)

--- a/app/user_account/tests/test_login_rate_limit.py
+++ b/app/user_account/tests/test_login_rate_limit.py
@@ -10,14 +10,20 @@ from user_account.tests.utils import (
 )
 
 
-RATE_LIMIT_MESSAGE = 'ログイン失敗が連続しています。時間が経ってからやり直してください。'
+RATE_LIMIT_ERROR_CODE = 'too_many_login_attempts'
 CLOUD_RUN_XFF = '203.0.113.10, 10.128.0.1'
+
+
+def get_non_field_error_codes(response) -> set[str | None]:
+    """レスポンスの認証フォームから非フィールドエラーcodeを返す。"""
+    form = response.context['form']
+    return {error.code for error in form.non_field_errors().as_data()}
 
 
 @override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS_WITH_APPS)
 @tag('offline_external_api')
 class LoginRateLimitTests(TestCase):
-    """通常画面とDRF画面に同じログイン失敗制限を適用する."""
+    """同一LoginView/Formを公開する2 URLで失敗制限を共有する."""
 
     def setUp(self) -> None:
         cache.clear()
@@ -39,27 +45,36 @@ class LoginRateLimitTests(TestCase):
         *,
         email: str = 'rate-limit@example.com',
         password: str = 'wrong-password',
-        forwarded_for: str = CLOUD_RUN_XFF,
+        forwarded_for: str | None = CLOUD_RUN_XFF,
     ):
+        headers = {}
+        if forwarded_for is not None:
+            headers['HTTP_X_FORWARDED_FOR'] = forwarded_for
         return self.client.post(
             url,
             {'username': email, 'password': password},
-            HTTP_X_FORWARDED_FOR=forwarded_for,
+            **headers,
         )
 
     def test_same_email_is_blocked_after_five_failures_across_login_paths(self) -> None:
-        """通常/API経路の失敗を同じemailバケットで数える."""
+        """同一View/Formの2 URLで同じemailバケットを数える."""
         responses = [self._post_login(self.login_url) for _ in range(3)]
         responses += [self._post_login(self.api_login_url) for _ in range(2)]
 
         for response in responses:
             self.assertEqual(response.status_code, 200)
-            self.assertNotContains(response, RATE_LIMIT_MESSAGE)
+            self.assertNotIn(
+                RATE_LIMIT_ERROR_CODE,
+                get_non_field_error_codes(response),
+            )
 
         blocked = self._post_login(self.login_url)
 
         self.assertEqual(blocked.status_code, 200)
-        self.assertContains(blocked, RATE_LIMIT_MESSAGE)
+        self.assertIn(
+            RATE_LIMIT_ERROR_CODE,
+            get_non_field_error_codes(blocked),
+        )
 
     def test_cache_reset_recovers_a_locked_out_user(self) -> None:
         """期限切れ相当のカウンタ消去後は正しい認証を再開できる."""
@@ -88,10 +103,32 @@ class LoginRateLimitTests(TestCase):
         failed = self._post_login(self.login_url)
 
         self.assertEqual(failed.status_code, 200)
-        self.assertNotContains(failed, RATE_LIMIT_MESSAGE)
+        self.assertNotIn(
+            RATE_LIMIT_ERROR_CODE,
+            get_non_field_error_codes(failed),
+        )
+
+    def test_missing_xff_does_not_raise_and_email_limit_still_blocks(self) -> None:
+        """XFF欠落時はREMOTE_ADDRへ縮退し、500にせずemail制限を保つ."""
+        responses = [
+            self._post_login(self.login_url, forwarded_for=None)
+            for _ in range(6)
+        ]
+
+        for response in responses[:5]:
+            self.assertEqual(response.status_code, 200)
+            self.assertNotIn(
+                RATE_LIMIT_ERROR_CODE,
+                get_non_field_error_codes(response),
+            )
+        self.assertEqual(responses[-1].status_code, 200)
+        self.assertIn(
+            RATE_LIMIT_ERROR_CODE,
+            get_non_field_error_codes(responses[-1]),
+        )
 
     def test_spoofed_xff_prefix_does_not_bypass_ip_limit(self) -> None:
-        """Cloud Run XFFの左側を変えてもclient IPを共有する."""
+        """ユーザー供給prefixを変えてもCloud Run clientのIP制限を回避できない."""
         for attempt in range(10):
             response = self._post_login(
                 self.login_url,
@@ -99,7 +136,10 @@ class LoginRateLimitTests(TestCase):
                 forwarded_for=f'198.51.100.{attempt}, 203.0.113.20, 10.128.0.1',
             )
             self.assertEqual(response.status_code, 200)
-            self.assertNotContains(response, RATE_LIMIT_MESSAGE)
+            self.assertNotIn(
+                RATE_LIMIT_ERROR_CODE,
+                get_non_field_error_codes(response),
+            )
 
         blocked = self._post_login(
             self.login_url,
@@ -108,4 +148,54 @@ class LoginRateLimitTests(TestCase):
         )
 
         self.assertEqual(blocked.status_code, 200)
-        self.assertContains(blocked, RATE_LIMIT_MESSAGE)
+        self.assertIn(
+            RATE_LIMIT_ERROR_CODE,
+            get_non_field_error_codes(blocked),
+        )
+
+
+@override_settings(SOCIALACCOUNT_PROVIDERS=TEST_SOCIALACCOUNT_PROVIDERS_WITH_APPS)
+@tag('offline_external_api')
+class AdminLoginRateLimitTests(TestCase):
+    """最高権限のadminログインにもallauth失敗制限を適用する."""
+
+    def setUp(self) -> None:
+        cache.clear()
+        self.client = Client()
+        self.login_url = reverse('admin:login')
+        self.user = create_discord_linked_user(
+            user_name='rate_limit_admin',
+            email='rate-limit-admin@example.com',
+            password='testpass123',
+        )
+        self.user.is_staff = True
+        self.user.is_superuser = True
+        self.user.save(update_fields=['is_staff', 'is_superuser'])
+
+    def tearDown(self) -> None:
+        cache.clear()
+
+    def test_admin_login_is_blocked_after_five_failures(self) -> None:
+        responses = [
+            self.client.post(
+                self.login_url,
+                {
+                    'username': self.user.email,
+                    'password': 'wrong-password',
+                },
+                HTTP_X_FORWARDED_FOR=CLOUD_RUN_XFF,
+            )
+            for _ in range(6)
+        ]
+
+        for response in responses[:5]:
+            self.assertEqual(response.status_code, 200)
+            self.assertNotIn(
+                RATE_LIMIT_ERROR_CODE,
+                get_non_field_error_codes(response),
+            )
+        self.assertEqual(responses[-1].status_code, 200)
+        self.assertIn(
+            RATE_LIMIT_ERROR_CODE,
+            get_non_field_error_codes(responses[-1]),
+        )

--- a/app/website/settings/authentication.py
+++ b/app/website/settings/authentication.py
@@ -25,6 +25,11 @@ ACCOUNT_LOGIN_METHODS = {'email'}
 ACCOUNT_SIGNUP_FIELDS = ['email*', 'password1*', 'password2*']
 ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
 ACCOUNT_CHANGE_EMAIL = True
+# 同一 email は5回/5分、同一IPは10回/分で制限する。allauth の既定値を
+# 明示して、ライブラリ更新でブルートフォース対策の強度が変わらないようにする。
+ACCOUNT_RATE_LIMITS = {
+    'login_failed': '10/m/ip,5/300s/key',
+}
 # Confirmation links only resume the signup login in the browser that started
 # registration. This preserves a validated ``next`` without turning a leaked,
 # reusable confirmation link into a session-independent login link.

--- a/app/website/settings/base.py
+++ b/app/website/settings/base.py
@@ -79,6 +79,9 @@ INSTALLED_APPS = [
 SITE_ID = 1
 
 REST_FRAMEWORK = {
+    # Cloud RunがXFF末尾へ付与するclient/proxyの2要素だけを信頼する。
+    # 左側にユーザーが追加した値をanon throttleの識別子へ使わせない。
+    'NUM_PROXIES': 2,
     'DEFAULT_THROTTLE_CLASSES': [
         'rest_framework.throttling.AnonRateThrottle',
         'rest_framework.throttling.UserRateThrottle'

--- a/app/website/settings/caching.py
+++ b/app/website/settings/caching.py
@@ -27,12 +27,44 @@ TIMEOUT は短期キャッシュ前提 (5 分)。長期に保持したい用途�
 import sys
 from os import environ
 
+from django.core.exceptions import ImproperlyConfigured
+
 from .base import TESTING
 
 # デフォルト TTL (秒)。短期キャッシュ前提
 DEFAULT_CACHE_TIMEOUT = 300
 # 同一 Redis を別プロジェクトと共有してもキー衝突を防ぐためのプレフィックス
 CACHE_KEY_PREFIX = 'vrc-ta-hub'
+DATABASE_CACHE_BACKEND = 'django.core.cache.backends.db.DatabaseCache'
+# 既定の300件では、ランダムemailを使った攻撃で有効なレート制限キーまで
+# 頻繁にcullされる。100,000件を上限にし、cull時の削除量も1/4へ抑える。
+DATABASE_CACHE_OPTIONS = {
+    'MAX_ENTRIES': 100_000,
+    'CULL_FREQUENCY': 4,
+}
+HEALTHCHECK_CACHE = {
+    'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    'LOCATION': 'vrc-ta-hub-healthcheck',
+    'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
+    'KEY_PREFIX': CACHE_KEY_PREFIX,
+}
+
+
+def validate_cloud_run_cache_backend(
+    caches_config: dict,
+    *,
+    is_cloud_run: bool,
+    is_test_run: bool,
+) -> None:
+    """Cloud Runの共有cache契約に違反する設定を起動時に拒否する。"""
+    if (
+        is_cloud_run
+        and not is_test_run
+        and caches_config['default']['BACKEND'] != DATABASE_CACHE_BACKEND
+    ):
+        raise ImproperlyConfigured(
+            'Cloud Run requires DatabaseCache for the default cache backend.'
+        )
 
 REDIS_URL = environ.get('REDIS_URL', '').strip()
 # K_SERVICE は Cloud Run が全revisionへ自動設定する予約済み環境変数。
@@ -55,10 +87,11 @@ if IS_TEST_RUN:
 elif IS_CLOUD_RUN:
     CACHES = {
         'default': {
-            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+            'BACKEND': DATABASE_CACHE_BACKEND,
             'LOCATION': 'login_rate_limit_cache',
             'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
             'KEY_PREFIX': CACHE_KEY_PREFIX,
+            'OPTIONS': DATABASE_CACHE_OPTIONS,
         }
     }
 elif REDIS_URL:
@@ -79,3 +112,15 @@ else:
             'KEY_PREFIX': CACHE_KEY_PREFIX,
         }
     }
+
+# health probeはDB疎通を別に検査するため、default cacheへ書き込まず
+# process内LocMemの往復だけを確認する。
+CACHES['healthcheck'] = HEALTHCHECK_CACHE
+
+# Cloud RunでLocMemへ静かに縮退すると、複数instanceのレート制限が分断される。
+# 設定順序の変更や将来の分岐追加で契約が崩れた場合は起動時に失敗させる。
+validate_cloud_run_cache_backend(
+    CACHES,
+    is_cloud_run=IS_CLOUD_RUN,
+    is_test_run=IS_TEST_RUN,
+)

--- a/app/website/settings/caching.py
+++ b/app/website/settings/caching.py
@@ -1,28 +1,33 @@
 """Django キャッシュ戦略
 
-ローカル開発: LocMemCache (プロセス内、追加依存なし)
-本番: REDIS_URL 設定時に RedisCache を自動採用
+Cloud Run: DatabaseCache（DB経由でプロセス・インスタンス間共有）
+ローカル開発: LocMemCache（既存の Redis があれば RedisCache）
 
 base.py で定義済みの CACHES を環境変数に基づいて上書きする。
 settings/__init__.py のロード順 (base → ... → caching) により、
 ここでの定義が最終的な CACHES として採用される。
 
 選択ロジック:
-- REDIS_URL が空 (未設定) → LocMemCache。プロセス単体の開発・テスト用途で
-  追加依存なしに動く。Cloud Run の単一インスタンス環境でも実害は少ない
-- REDIS_URL が設定済み → RedisCache。複数 worker / Cloud Run instance 間で
-  状態を共有したい本番向け。Django 4.0+ 組み込みの
+- Django test runner → LocMemCache。SimpleTestCase がDRF throttle経由で
+  DBアクセスするのを避け、既存のDB禁止テスト契約を維持する
+- Cloud Run → DatabaseCache。allauth のレート制限は default
+  cache alias を固定利用するため、専用aliasではなくdefaultをDB共有にする。
+  テーブルは user_account migration で先に作成してから新revisionへ切り替える
+- ローカルで REDIS_URL が設定済み → RedisCache。既存の共有Redisを維持する。
+  Django 4.0+ 組み込みの
   django.core.cache.backends.redis.RedisCache を使うので新規パッケージ不要
   (Django 5.2 で動作確認済み)
+- 上記以外 → LocMemCache。ローカル開発でキャッシュテーブルを要求しない
 
-KEY_PREFIX を付けることで、同一 Redis を別プロジェクトと共有してもキーが
-衝突しない。LocMem でも prefix を揃えておくことで `cache.make_key` の挙動が
-本番と一致し、テストでハマるリスクを減らせる。
+KEY_PREFIX を付けることで、共有キャッシュ上のキー衝突を防ぐ。
 
 TIMEOUT は短期キャッシュ前提 (5 分)。長期に保持したい用途では呼び出し側で
 個別に timeout 引数を渡す方針。
 """
+import sys
 from os import environ
+
+from .base import TESTING
 
 # デフォルト TTL (秒)。短期キャッシュ前提
 DEFAULT_CACHE_TIMEOUT = 300
@@ -30,8 +35,33 @@ DEFAULT_CACHE_TIMEOUT = 300
 CACHE_KEY_PREFIX = 'vrc-ta-hub'
 
 REDIS_URL = environ.get('REDIS_URL', '').strip()
+# K_SERVICE は Cloud Run が全revisionへ自動設定する予約済み環境変数。
+# DEBUG の設定漏れに左右されず、DatabaseCache を Cloud Run だけに限定する。
+IS_CLOUD_RUN = bool(environ.get('K_SERVICE', '').strip())
 
-if REDIS_URL:
+# `TESTING=true` はCIや明示実行、`manage.py test` はローカル・composeの
+# 通常実行を捕捉する。base.TESTING は環境変数由来の値なので両方をここで併用する。
+IS_TEST_RUN = TESTING or 'test' in sys.argv
+
+if IS_TEST_RUN:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'vrc-ta-hub-tests',
+            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
+            'KEY_PREFIX': CACHE_KEY_PREFIX,
+        }
+    }
+elif IS_CLOUD_RUN:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+            'LOCATION': 'login_rate_limit_cache',
+            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
+            'KEY_PREFIX': CACHE_KEY_PREFIX,
+        }
+    }
+elif REDIS_URL:
     CACHES = {
         'default': {
             'BACKEND': 'django.core.cache.backends.redis.RedisCache',

--- a/app/website/settings/caching.py
+++ b/app/website/settings/caching.py
@@ -25,6 +25,7 @@ TIMEOUT は短期キャッシュ前提 (5 分)。長期に保持したい用途�
 個別に timeout 引数を渡す方針。
 """
 import sys
+from collections.abc import Sequence
 from os import environ
 
 from django.core.exceptions import ImproperlyConfigured
@@ -66,6 +67,57 @@ def validate_cloud_run_cache_backend(
             'Cloud Run requires DatabaseCache for the default cache backend.'
         )
 
+
+def build_caches(
+    *,
+    is_cloud_run: bool,
+    is_testing: bool,
+    redis_url: str | None,
+) -> dict:
+    """実行環境に対応するDjango cache設定を組み立てる。"""
+    normalized_redis_url = (redis_url or '').strip()
+
+    if is_testing:
+        default_cache = {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'vrc-ta-hub-tests',
+            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
+            'KEY_PREFIX': CACHE_KEY_PREFIX,
+        }
+    elif is_cloud_run:
+        default_cache = {
+            'BACKEND': DATABASE_CACHE_BACKEND,
+            'LOCATION': 'login_rate_limit_cache',
+            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
+            'KEY_PREFIX': CACHE_KEY_PREFIX,
+            'OPTIONS': DATABASE_CACHE_OPTIONS.copy(),
+        }
+    elif normalized_redis_url:
+        default_cache = {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'LOCATION': normalized_redis_url,
+            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
+            'KEY_PREFIX': CACHE_KEY_PREFIX,
+        }
+    else:
+        default_cache = {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'vrc-ta-hub-local',
+            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
+            'KEY_PREFIX': CACHE_KEY_PREFIX,
+        }
+
+    return {
+        'default': default_cache,
+        'healthcheck': HEALTHCHECK_CACHE.copy(),
+    }
+
+
+def detect_test_run(*, testing: bool, argv: Sequence[str]) -> bool:
+    """環境変数またはDjango test runnerの引数からテスト実行を判定する。"""
+    return testing or 'test' in argv
+
+
 REDIS_URL = environ.get('REDIS_URL', '').strip()
 # K_SERVICE は Cloud Run が全revisionへ自動設定する予約済み環境変数。
 # DEBUG の設定漏れに左右されず、DatabaseCache を Cloud Run だけに限定する。
@@ -73,49 +125,14 @@ IS_CLOUD_RUN = bool(environ.get('K_SERVICE', '').strip())
 
 # `TESTING=true` はCIや明示実行、`manage.py test` はローカル・composeの
 # 通常実行を捕捉する。base.TESTING は環境変数由来の値なので両方をここで併用する。
-IS_TEST_RUN = TESTING or 'test' in sys.argv
+IS_TEST_RUN = detect_test_run(testing=TESTING, argv=sys.argv)
 
-if IS_TEST_RUN:
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-            'LOCATION': 'vrc-ta-hub-tests',
-            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
-            'KEY_PREFIX': CACHE_KEY_PREFIX,
-        }
-    }
-elif IS_CLOUD_RUN:
-    CACHES = {
-        'default': {
-            'BACKEND': DATABASE_CACHE_BACKEND,
-            'LOCATION': 'login_rate_limit_cache',
-            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
-            'KEY_PREFIX': CACHE_KEY_PREFIX,
-            'OPTIONS': DATABASE_CACHE_OPTIONS,
-        }
-    }
-elif REDIS_URL:
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
-            'LOCATION': REDIS_URL,
-            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
-            'KEY_PREFIX': CACHE_KEY_PREFIX,
-        }
-    }
-else:
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-            'LOCATION': 'vrc-ta-hub-local',
-            'TIMEOUT': DEFAULT_CACHE_TIMEOUT,
-            'KEY_PREFIX': CACHE_KEY_PREFIX,
-        }
-    }
-
-# health probeはDB疎通を別に検査するため、default cacheへ書き込まず
-# process内LocMemの往復だけを確認する。
-CACHES['healthcheck'] = HEALTHCHECK_CACHE
+# test判定とCloud Run判定が同時に真でも、build_caches内でtestを優先する。
+CACHES = build_caches(
+    is_cloud_run=IS_CLOUD_RUN,
+    is_testing=IS_TEST_RUN,
+    redis_url=REDIS_URL,
+)
 
 # Cloud RunでLocMemへ静かに縮退すると、複数instanceのレート制限が分断される。
 # 設定順序の変更や将来の分岐追加で契約が崩れた場合は起動時に失敗させる。

--- a/app/website/settings/security.py
+++ b/app/website/settings/security.py
@@ -40,6 +40,10 @@ ALLOWED_HOSTS = _build_allowed_hosts()
 # ローカルでは .env.local で HTTP_X_FORWARDED_PROTO=http を設定して is_secure()=False を保証する。
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+# Cloud Run が XFF 末尾へ追加する client / Google frontend の2要素を信頼する。
+# nginx はこのチェーンを追加せず透過し、左側の偽装値をIP制限キーに使わせない。
+ALLAUTH_TRUSTED_PROXY_COUNT = 2
+
 # 本番環境のセキュリティ強化
 if not DEBUG:
     SESSION_COOKIE_SECURE = True

--- a/app/website/tests/test_cache.py
+++ b/app/website/tests/test_cache.py
@@ -8,6 +8,7 @@ caching.py で定義した CACHES 設定が以下を満たすことを検証す�
 4. TIMEOUT で値が expire する
 """
 
+import json
 import os
 import subprocess
 import sys
@@ -16,11 +17,15 @@ import time
 from django.conf import settings
 from django.core.cache import cache, caches
 from django.core.cache.backends.db import DatabaseCache
+from django.core.exceptions import ImproperlyConfigured
 from django.db import connection
 from django.test import SimpleTestCase, TestCase, override_settings
 
+from website.settings.caching import validate_cloud_run_cache_backend
 
-SETTINGS_BACKEND_PROBE = """
+
+SETTINGS_CACHE_PROBE = """
+import json
 import os
 import sys
 
@@ -29,21 +34,21 @@ if os.environ.pop('FORCE_MANAGE_TEST', '') == '1':
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'website.settings')
 from django.conf import settings
-print(settings.CACHES['default']['BACKEND'])
+print(json.dumps(settings.CACHES))
 """
 
 
 class CacheBackendSelectionTest(SimpleTestCase):
     """環境ごとのsettingsロードでdefault cacheを選択する."""
 
-    def _probe_backend(self, **environment: str) -> str:
+    def _probe_caches(self, **environment: str) -> dict:
         probe_environment = os.environ.copy()
         for name in ('K_SERVICE', 'REDIS_URL', 'TESTING', 'FORCE_MANAGE_TEST'):
             probe_environment.pop(name, None)
         probe_environment.update(environment)
 
         completed = subprocess.run(
-            [sys.executable, '-c', SETTINGS_BACKEND_PROBE],
+            [sys.executable, '-c', SETTINGS_CACHE_PROBE],
             cwd=settings.BASE_DIR,
             env=probe_environment,
             capture_output=True,
@@ -51,32 +56,73 @@ class CacheBackendSelectionTest(SimpleTestCase):
             check=True,
             timeout=20,
         )
-        return completed.stdout.strip().splitlines()[-1]
+        return json.loads(completed.stdout.strip().splitlines()[-1])
 
     def test_cloud_run_uses_database_cache(self) -> None:
-        backend = self._probe_backend(K_SERVICE='vrc-ta-hub')
+        caches_config = self._probe_caches(K_SERVICE='vrc-ta-hub')
+        default = caches_config['default']
 
-        self.assertEqual(backend, 'django.core.cache.backends.db.DatabaseCache')
+        self.assertEqual(
+            default['BACKEND'],
+            'django.core.cache.backends.db.DatabaseCache',
+        )
+        self.assertEqual(default['OPTIONS']['MAX_ENTRIES'], 100_000)
+        self.assertEqual(default['OPTIONS']['CULL_FREQUENCY'], 4)
+        self.assertEqual(
+            caches_config['healthcheck']['BACKEND'],
+            'django.core.cache.backends.locmem.LocMemCache',
+        )
+
+    def test_cloud_run_rejects_non_database_default_cache(self) -> None:
+        invalid_caches = {
+            'default': {
+                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            }
+        }
+
+        with self.assertRaises(ImproperlyConfigured):
+            validate_cloud_run_cache_backend(
+                invalid_caches,
+                is_cloud_run=True,
+                is_test_run=False,
+            )
 
     def test_testing_environment_overrides_cloud_run(self) -> None:
-        backend = self._probe_backend(K_SERVICE='vrc-ta-hub', TESTING='true')
+        caches_config = self._probe_caches(K_SERVICE='vrc-ta-hub', TESTING='true')
 
-        self.assertEqual(backend, 'django.core.cache.backends.locmem.LocMemCache')
+        self.assertEqual(
+            caches_config['default']['BACKEND'],
+            'django.core.cache.backends.locmem.LocMemCache',
+        )
 
     def test_manage_test_argv_overrides_cloud_run(self) -> None:
-        backend = self._probe_backend(K_SERVICE='vrc-ta-hub', FORCE_MANAGE_TEST='1')
+        caches_config = self._probe_caches(
+            K_SERVICE='vrc-ta-hub',
+            FORCE_MANAGE_TEST='1',
+        )
 
-        self.assertEqual(backend, 'django.core.cache.backends.locmem.LocMemCache')
+        self.assertEqual(
+            caches_config['default']['BACKEND'],
+            'django.core.cache.backends.locmem.LocMemCache',
+        )
 
     def test_local_without_redis_uses_locmem(self) -> None:
-        backend = self._probe_backend()
+        caches_config = self._probe_caches()
 
-        self.assertEqual(backend, 'django.core.cache.backends.locmem.LocMemCache')
+        self.assertEqual(
+            caches_config['default']['BACKEND'],
+            'django.core.cache.backends.locmem.LocMemCache',
+        )
 
     def test_local_with_existing_redis_uses_redis_cache(self) -> None:
-        backend = self._probe_backend(REDIS_URL='redis://cache.example.invalid:6379/1')
+        caches_config = self._probe_caches(
+            REDIS_URL='redis://cache.example.invalid:6379/1',
+        )
 
-        self.assertEqual(backend, 'django.core.cache.backends.redis.RedisCache')
+        self.assertEqual(
+            caches_config['default']['BACKEND'],
+            'django.core.cache.backends.redis.RedisCache',
+        )
 
 
 class CacheRoundTripTest(TestCase):

--- a/app/website/tests/test_cache.py
+++ b/app/website/tests/test_cache.py
@@ -8,58 +8,37 @@ caching.py で定義した CACHES 設定が以下を満たすことを検証す�
 4. TIMEOUT で値が expire する
 """
 
-import json
-import os
-import subprocess
-import sys
 import time
 
-from django.conf import settings
 from django.core.cache import cache, caches
 from django.core.cache.backends.db import DatabaseCache
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connection
 from django.test import SimpleTestCase, TestCase, override_settings
 
-from website.settings.caching import validate_cloud_run_cache_backend
-
-
-SETTINGS_CACHE_PROBE = """
-import json
-import os
-import sys
-
-if os.environ.pop('FORCE_MANAGE_TEST', '') == '1':
-    sys.argv = ['manage.py', 'test']
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'website.settings')
-from django.conf import settings
-print(json.dumps(settings.CACHES))
-"""
+from website.settings.caching import (
+    build_caches,
+    detect_test_run,
+    validate_cloud_run_cache_backend,
+)
 
 
 class CacheBackendSelectionTest(SimpleTestCase):
-    """環境ごとのsettingsロードでdefault cacheを選択する."""
+    """環境フラグからdefault cacheを決定的に選択する."""
 
-    def _probe_caches(self, **environment: str) -> dict:
-        probe_environment = os.environ.copy()
-        for name in ('K_SERVICE', 'REDIS_URL', 'TESTING', 'FORCE_MANAGE_TEST'):
-            probe_environment.pop(name, None)
-        probe_environment.update(environment)
-
-        completed = subprocess.run(
-            [sys.executable, '-c', SETTINGS_CACHE_PROBE],
-            cwd=settings.BASE_DIR,
-            env=probe_environment,
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=20,
+    def test_test_run_is_detected_from_setting_or_manage_command(self) -> None:
+        self.assertTrue(detect_test_run(testing=True, argv=['manage.py']))
+        self.assertTrue(
+            detect_test_run(testing=False, argv=['manage.py', 'test'])
         )
-        return json.loads(completed.stdout.strip().splitlines()[-1])
+        self.assertFalse(detect_test_run(testing=False, argv=['manage.py', 'check']))
 
     def test_cloud_run_uses_database_cache(self) -> None:
-        caches_config = self._probe_caches(K_SERVICE='vrc-ta-hub')
+        caches_config = build_caches(
+            is_cloud_run=True,
+            is_testing=False,
+            redis_url=None,
+        )
         default = caches_config['default']
 
         self.assertEqual(
@@ -88,17 +67,10 @@ class CacheBackendSelectionTest(SimpleTestCase):
             )
 
     def test_testing_environment_overrides_cloud_run(self) -> None:
-        caches_config = self._probe_caches(K_SERVICE='vrc-ta-hub', TESTING='true')
-
-        self.assertEqual(
-            caches_config['default']['BACKEND'],
-            'django.core.cache.backends.locmem.LocMemCache',
-        )
-
-    def test_manage_test_argv_overrides_cloud_run(self) -> None:
-        caches_config = self._probe_caches(
-            K_SERVICE='vrc-ta-hub',
-            FORCE_MANAGE_TEST='1',
+        caches_config = build_caches(
+            is_cloud_run=True,
+            is_testing=True,
+            redis_url='redis://cache.example.invalid:6379/1',
         )
 
         self.assertEqual(
@@ -107,7 +79,11 @@ class CacheBackendSelectionTest(SimpleTestCase):
         )
 
     def test_local_without_redis_uses_locmem(self) -> None:
-        caches_config = self._probe_caches()
+        caches_config = build_caches(
+            is_cloud_run=False,
+            is_testing=False,
+            redis_url=None,
+        )
 
         self.assertEqual(
             caches_config['default']['BACKEND'],
@@ -115,8 +91,10 @@ class CacheBackendSelectionTest(SimpleTestCase):
         )
 
     def test_local_with_existing_redis_uses_redis_cache(self) -> None:
-        caches_config = self._probe_caches(
-            REDIS_URL='redis://cache.example.invalid:6379/1',
+        caches_config = build_caches(
+            is_cloud_run=False,
+            is_testing=False,
+            redis_url='redis://cache.example.invalid:6379/1',
         )
 
         self.assertEqual(

--- a/app/website/tests/test_cache.py
+++ b/app/website/tests/test_cache.py
@@ -2,21 +2,85 @@
 
 caching.py で定義した CACHES 設定が以下を満たすことを検証する:
 
-1. LocMem バックエンドで set/get が round-trip できる
+1. テスト用 LocMemCache で set/get が round-trip できる
 2. KEY_PREFIX (vrc-ta-hub) がキーに付与される
-3. TIMEOUT で値が expire する
-
-REDIS_URL が未設定のテスト環境では LocMemCache が採用される想定。
+3. 本番用 DatabaseCache の共有テーブルが利用できる
+4. TIMEOUT で値が expire する
 """
 
+import os
+import subprocess
+import sys
 import time
 
+from django.conf import settings
 from django.core.cache import cache, caches
-from django.test import TestCase, override_settings
+from django.core.cache.backends.db import DatabaseCache
+from django.db import connection
+from django.test import SimpleTestCase, TestCase, override_settings
+
+
+SETTINGS_BACKEND_PROBE = """
+import os
+import sys
+
+if os.environ.pop('FORCE_MANAGE_TEST', '') == '1':
+    sys.argv = ['manage.py', 'test']
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'website.settings')
+from django.conf import settings
+print(settings.CACHES['default']['BACKEND'])
+"""
+
+
+class CacheBackendSelectionTest(SimpleTestCase):
+    """環境ごとのsettingsロードでdefault cacheを選択する."""
+
+    def _probe_backend(self, **environment: str) -> str:
+        probe_environment = os.environ.copy()
+        for name in ('K_SERVICE', 'REDIS_URL', 'TESTING', 'FORCE_MANAGE_TEST'):
+            probe_environment.pop(name, None)
+        probe_environment.update(environment)
+
+        completed = subprocess.run(
+            [sys.executable, '-c', SETTINGS_BACKEND_PROBE],
+            cwd=settings.BASE_DIR,
+            env=probe_environment,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=20,
+        )
+        return completed.stdout.strip().splitlines()[-1]
+
+    def test_cloud_run_uses_database_cache(self) -> None:
+        backend = self._probe_backend(K_SERVICE='vrc-ta-hub')
+
+        self.assertEqual(backend, 'django.core.cache.backends.db.DatabaseCache')
+
+    def test_testing_environment_overrides_cloud_run(self) -> None:
+        backend = self._probe_backend(K_SERVICE='vrc-ta-hub', TESTING='true')
+
+        self.assertEqual(backend, 'django.core.cache.backends.locmem.LocMemCache')
+
+    def test_manage_test_argv_overrides_cloud_run(self) -> None:
+        backend = self._probe_backend(K_SERVICE='vrc-ta-hub', FORCE_MANAGE_TEST='1')
+
+        self.assertEqual(backend, 'django.core.cache.backends.locmem.LocMemCache')
+
+    def test_local_without_redis_uses_locmem(self) -> None:
+        backend = self._probe_backend()
+
+        self.assertEqual(backend, 'django.core.cache.backends.locmem.LocMemCache')
+
+    def test_local_with_existing_redis_uses_redis_cache(self) -> None:
+        backend = self._probe_backend(REDIS_URL='redis://cache.example.invalid:6379/1')
+
+        self.assertEqual(backend, 'django.core.cache.backends.redis.RedisCache')
 
 
 class CacheRoundTripTest(TestCase):
-    """LocMem キャッシュの基本的な set/get 動作."""
+    """テスト用キャッシュの基本的な set/get 動作."""
 
     def setUp(self) -> None:
         # 他テストとのキー衝突を避けるためクリアしてから開始
@@ -30,6 +94,22 @@ class CacheRoundTripTest(TestCase):
     def test_get_returns_none_for_missing_key(self) -> None:
         """未設定のキーは None が返る (Fail Loud ではなく Django 標準仕様)."""
         self.assertIsNone(cache.get('test_key_nonexistent'))
+
+    @override_settings(
+        CACHES={
+            'default': {
+                'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+                'LOCATION': 'login_rate_limit_cache',
+                'KEY_PREFIX': 'vrc-ta-hub',
+            }
+        }
+    )
+    def test_shared_database_cache_table_is_available(self) -> None:
+        """本番と同じDBバックエンドで共有テーブルを利用できる."""
+        self.assertIsInstance(caches['default'], DatabaseCache)
+        self.assertIn('login_rate_limit_cache', connection.introspection.table_names())
+        caches['default'].set('database-cache-roundtrip', 'shared', timeout=60)
+        self.assertEqual(caches['default'].get('database-cache-roundtrip'), 'shared')
 
 
 class CacheKeyPrefixTest(TestCase):

--- a/app/website/tests/test_nginx_config.py
+++ b/app/website/tests/test_nginx_config.py
@@ -51,3 +51,14 @@ class NginxConfigTest(SimpleTestCase):
             'proxy_set_header X-Forwarded-Proto $scheme;',
             self.nginx_config,
         )
+
+    def test_nginx_preserves_cloud_run_forwarded_for_chain(self):
+        """Cloud Runが付与した2ホップを増減させずDjangoへ渡す."""
+        self.assertIn(
+            'proxy_set_header X-Forwarded-For $http_x_forwarded_for;',
+            self.nginx_config,
+        )
+        self.assertNotIn(
+            'proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;',
+            self.nginx_config,
+        )

--- a/app/website/tests/test_proxy_rate_limit_settings.py
+++ b/app/website/tests/test_proxy_rate_limit_settings.py
@@ -1,0 +1,42 @@
+"""Proxy経由レート制限のclient IP識別テスト。"""
+
+from django.conf import settings
+from django.test import RequestFactory, SimpleTestCase
+from rest_framework.throttling import AnonRateThrottle
+
+
+class DrfProxyIdentificationTests(SimpleTestCase):
+    """DRF anon throttleをCloud Runの信頼済み2要素へ揃える。"""
+
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.throttle = AnonRateThrottle()
+
+    def _ident(self, forwarded_for: str | None) -> str:
+        request = self.factory.get('/api/v1/events/')
+        request.META['REMOTE_ADDR'] = '192.0.2.10'
+        if forwarded_for is not None:
+            request.META['HTTP_X_FORWARDED_FOR'] = forwarded_for
+        return self.throttle.get_ident(request)
+
+    def test_num_proxies_matches_allauth_contract(self) -> None:
+        self.assertEqual(settings.REST_FRAMEWORK['NUM_PROXIES'], 2)
+        self.assertEqual(settings.ALLAUTH_TRUSTED_PROXY_COUNT, 2)
+
+    def test_missing_xff_uses_remote_addr(self) -> None:
+        self.assertEqual(self._ident(None), '192.0.2.10')
+
+    def test_single_xff_value_uses_that_value(self) -> None:
+        self.assertEqual(self._ident('203.0.113.10'), '203.0.113.10')
+
+    def test_two_xff_values_use_cloud_run_client(self) -> None:
+        self.assertEqual(
+            self._ident('203.0.113.10, 10.128.0.1'),
+            '203.0.113.10',
+        )
+
+    def test_user_supplied_prefix_is_ignored(self) -> None:
+        self.assertEqual(
+            self._ident('198.51.100.99, 203.0.113.10, 10.128.0.1'),
+            '203.0.113.10',
+        )

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,6 +18,29 @@ Google Cloud側のBuild Trigger設定で限定する。GitHub Actionsの`safe-to
 GitHub Actionsの隔離PRゲートは[テスト方針](testing.md#github-actions-の隔離pr承認ゲート)を参照。
 必要なTrigger filterを確認できない環境では、自動deployを有効化しない。
 
+## DatabaseCache migrationの先行適用
+
+Cloud BuildはDjango migrationを自動実行しない。Cloud Runではログイン失敗回数と
+DRF throttleを複数インスタンス間で共有するため、default cacheが
+`login_rate_limit_cache` テーブルを使う。新revisionにトラフィックを入れる前に
+`user_account.0016_login_rate_limit_cache` を必ず適用する。
+
+```bash
+gcloud run jobs execute vrc-ta-hub-migrate \
+  --region=asia-northeast1 \
+  --args="migrate,user_account,0016"
+```
+
+実行ログで成功を確認し、`showmigrations user_account`で `0016` が適用済みに
+なってからdeploy・トラフィック切り替えへ進む。新revisionが動作中にこの
+migrationを戻すとログインとAPI throttleがDBエラーになるため、rollback時は
+先に旧revisionへトラフィックを戻す。
+
+Cloud Run以外はLocMemCache（`REDIS_URL` 設定時は既存Redis）を使う。Cloud Runでは
+DRF throttleもDatabaseCacheに乗るため、複数インスタンス間の精度が上がる一方、
+Cloud SQLのread/writeとレイテンシを監視する。`cache.clear()` を行う管理コマンドは
+ログイン失敗回数とDRF throttleも一括解除するため、必要時のみ実行する。
+
 ## ヘルスチェック {#health}
 
 Cloud Run の readiness / liveness probe 用に `/health` エンドポイントを提供する。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,6 +41,30 @@ DRF throttleもDatabaseCacheに乗るため、複数インスタンス間の精�
 Cloud SQLのread/writeとレイテンシを監視する。`cache.clear()` を行う管理コマンドは
 ログイン失敗回数とDRF throttleも一括解除するため、必要時のみ実行する。
 
+DatabaseCacheはランダムemailによるキー大量生成で既定300件から有効な制限キーが
+押し出されないよう、`MAX_ENTRIES=100000`、`CULL_FREQUENCY=4`とする。パスワード
+リセット完了時はallauthが対象emailの失敗カウンタを解除し、正規ユーザーの回復手段になる。
+
+### 期限切れcache行の定期削除
+
+`expires`にはindexがある。Cloud SQLの不要行とcull負荷を抑えるため、次の処理を
+1時間ごとを目安に、トラフィックの少ない時間帯で実行する。削除件数だけを出力し、
+cache keyやemailはログへ出さない。Cloud Run Job化は別タスクとする。
+
+```bash
+python manage.py shell <<'PY'
+from django.db import connection
+from django.utils import timezone
+
+table = connection.ops.quote_name('login_rate_limit_cache')
+with connection.cursor() as cursor:
+    cursor.execute(f'DELETE FROM {table} WHERE expires < %s', [timezone.now()])
+    print(f'deleted={cursor.rowcount}')
+PY
+```
+
+全レート制限を解除する`cache.clear()`は定期清掃には使わない。
+
 ## ヘルスチェック {#health}
 
 Cloud Run の readiness / liveness probe 用に `/health` エンドポイントを提供する。
@@ -57,7 +81,8 @@ Cloud Run の readiness / liveness probe 用に `/health` エンドポイント�
 
 - **DB の疎通失敗は致命的**: 503 を返してロードバランサから外す。zombie プロセスへの誤ルーティングを防ぐ。
 - **cache 失敗は無視**: cache が未設定でも生存判定したいので、`cache=ng` でも `status=ok` を維持する。
-- **軽量実装**: クエリは `connection.ensure_connection()` のみ、cache は短い TTL の往復確認のみ。
+- **軽量実装**: DBは`connection.ensure_connection()`で確認し、cacheは専用LocMem aliasを往復する。
+  probeごとにDatabaseCacheへINSERTしないため、Cloud SQLへの追加書き込みは発生しない。
 
 ### 動作確認
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ VRC技術学術ハブの開発、運用、調査メモ、利用ガイドをま�
 - [提案書](proposals/index.md)
 - [Giga Week 2025 Winter 下書き](giga-week-2025-winter/index.md)
 - [Vket 2026 Summer 動画アーカイブ下書き](giga-week-2026-summer/index.md)
+- [Vket 2026 Summer - Vket技術学術WEEK 動画アーカイブ](giga-week-2026-summer/draft-article.md)
 
 ## 分析・調査メモ
 
@@ -95,4 +96,6 @@ VRC技術学術ハブの開発、運用、調査メモ、利用ガイドをま�
 - [Issue #500 Campaign UTM validator migration](research/issue-500-analytics-campaign-migration.md)
 - [Issue #529 offline runner と Docker network-none の遮断結果](research/issue-529-offline-network-none.md)
 - [Issue #542 Google→DB 同期デッドコード削除](research/issue-542-google-to-db-sync-removal.md)
+- [Issue #566 協力団体の公開審査基準](research/issue-566-community-criteria.md)
+- [Issue #570 終了済み Vket バナー調査](research/issue-570-expired-vket-banner.md)
 - [Sentry エラートラッキング](sentry.md)

--- a/nginx-app.conf
+++ b/nginx-app.conf
@@ -45,7 +45,9 @@ server {
         proxy_pass  http://127.0.0.1:8000;
         proxy_set_header Host $django_upstream_host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Cloud Run が末尾に追加した client / Google frontend を保持する。
+        # nginx の remote_addr を重ねると信頼ホップ数がずれて誤ロックになる。
+        proxy_set_header X-Forwarded-For $http_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_http_version 1.1;
         include     /uwsgi_params; # the uwsgi_params file you installed


### PR DESCRIPTION
## なぜこの変更が必要か

email ログイン化（#579/#596）で識別子が収集可能な情報に近づき、総当たり攻撃の現実性が上がったが、ログイン試行にレートリミット・ブルートフォース防御が存在しなかった（Issue #594、セキュリティレビュー MEDIUM 指摘由来）。

## 変更内容

- allauth 標準 `login_failed` レートを採用: 同一 email 5回/300秒・同一 IP 10回/分。成功ログインはカウンタに加算せず、TTL 満了またはパスワードリセット完了で回復
- 全ログイン経路で統一適用: 通常ログイン / `/api-auth/login/` / **Django admin ログイン**（adapter 経由認証に統一）
- カウンタ保存先: Cloud Run（`K_SERVICE` 判定）のみ DatabaseCache（`MAX_ENTRIES=100000` 明示 — 既定 300 だと辞書順 cull で email バケットが優先削除され制限が無効化されるため）。テストは LocMem（`TESTING` + `'test' in sys.argv` の二重判定）。Cloud Run で DatabaseCache 以外になったら起動失敗する fail-fast 検証付き
- migration 0016 でキャッシュテーブル作成（`SeparateDatabaseAndState`、往復検証済み）
- XFF 処理の堅牢化: nginx は Cloud Run の XFF を透過し（信頼プロキシ数 2 と整合）、client IP 取得は既存 `ta_hub.utils.get_client_ip` を adapter で再利用（XFF 0/1/2/3 要素すべてで 500 にならないことをテストで担保）
- DRF throttle に `NUM_PROXIES=2` を設定（XFF 左側偽装による anon throttle 回避を封鎖）
- health probe のキャッシュチェックは専用 LocMem alias に分離（probe 毎の Cloud SQL 書き込みを回避）

## 意思決定

### 採用アプローチ
- django-axes 等の新規依存を増やさず allauth 標準レートで実現（#593 で認証チェーンが allauth 経由に統一済みのため設定+薄い adapter で足りる）
- カウンタ共有は DatabaseCache（新規インフラ・Redis を追加しない方針。Cloud Run 複数インスタンス間で共有）

### 却下した代替案
- django-axes 導入 → 却下: 依存追加とミドルウェア順序管理が増えるのに対し、allauth 標準で要件を満たせる
- レート制限専用キャッシュ alias + 独自 adapter → 却下: allauth の制約に対して複雑化が見合わない

### 副作用（文書化済み）
- DRF throttle も本番で DatabaseCache に乗るため Cloud SQL 負荷が増える（複数インスタンス間の throttle 精度は向上）。運用監視事項は docs/deployment.md 参照

## テスト

- [x] フルスイート 2,217 件成功（skipped 23）
- [x] 閾値超過ブロック / TTL 回復 / 成功ログイン非加算 / admin 経路の制限適用 / XFF 0-3 要素 / 偽装 prefix 耐性を振る舞いテストで担保（実時間 sleep なし）
- [x] migration 0015→0016→0015→0016 往復成功
- [x] コード品質 + セキュリティの 2 レビュー実施、HIGH 2 件（cull 無効化・XFF 500）含む 9 件をすべて修正済み

## Screenshot

スクショなし: 画面差分はログイン画面のエラー表示（allauth 標準文言）のみ。挙動はテストで担保

## 運用ノート（マージ後）

- **本番反映前に migration 0016（キャッシュテーブル作成）の手動適用が必要**（0015 と併せて適用。本リポは migration 自動適用を意図的に導入していない）
- 期限切れキャッシュ行の定期清掃手順は docs/deployment.md 参照

Closes #594

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)