### PR TITLE
feat(event): 発表申請の承認前に開催日・開始時刻を調整できるようにする

### DIFF
--- a/app/event/forms/lt_application.py
+++ b/app/event/forms/lt_application.py
@@ -259,7 +259,9 @@ class LTApplicationReviewForm(forms.Form):
         if event_detail is None:
             return
 
-        today = timezone.now().date()
+        # now().date() は UTC 基準になり、JST の 0〜9 時に前日開催の回まで
+        # 候補へ混入する（終了済みの日へ振替できてしまう）。
+        today = timezone.localdate()
         # 申請フォームと同じ受付中イベントに加え、現在割り当て中のイベントは
         # 受付停止・過去でも必ず候補に残す（据え置き承認を潰さないため）。
         self.fields['event'].queryset = Event.objects.filter(

--- a/app/event/forms/lt_application.py
+++ b/app/event/forms/lt_application.py
@@ -6,6 +6,10 @@ from django.db.models import Q
 from django.utils import timezone
 
 from user_account.forms import normalize_x_account
+from ..datetime_lock import (
+    EVENT_DETAIL_DATETIME_LOCK_MESSAGE,
+    is_event_datetime_locked,
+)
 from ..models import EventDetail, Event
 from ..thumbnail import SLIDE_THUMBNAIL_ASPECT_RATIO_TEXT
 from .mixins import EventDetailMediaFormMixin
@@ -241,9 +245,17 @@ class LTApplicationReviewForm(forms.Form):
         help_text='却下する場合は、申請者に伝える理由を入力してください'
     )
 
-    def __init__(self, *args, event_detail=None, **kwargs):
+    def __init__(self, *args, event_detail=None, user=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.event_detail = event_detail
+        self.user = user
+
+        # 却下では日時を反映しないため必須から外す。required のままだと
+        # 日時欄の欠損だけで却下が通らなくなる。
+        if self.data.get('action') == 'reject':
+            for field_name in ('event', 'start_time', 'duration'):
+                self.fields[field_name].required = False
+
         if event_detail is None:
             return
 
@@ -263,13 +275,42 @@ class LTApplicationReviewForm(forms.Form):
     def clean(self):
         cleaned_data = super().clean()
         action = cleaned_data.get('action')
-        rejection_reason = cleaned_data.get('rejection_reason')
 
         if action == 'reject':
-            if not rejection_reason:
+            if not cleaned_data.get('rejection_reason'):
                 raise ValidationError('却下する場合は理由を入力してください')
-            # 却下時は日時を反映しないため、日時欄の欠損でブロックしない
-            for field_name in ('event', 'start_time', 'duration'):
-                self.errors.pop(field_name, None)
+            return cleaned_data
+
+        if action == 'approve':
+            self._validate_datetime_lock(cleaned_data)
 
         return cleaned_data
+
+    def _validate_datetime_lock(self, cleaned_data) -> None:
+        """Vket コラボ期間中の日時変更を主催者に許さない。
+
+        承認画面が api_v1.perform_update / EventDetailForm と同じロック規約を
+        共有しないと、ここが3つ目の抜け穴になる。
+        """
+        if self.event_detail is None or self.user is None:
+            return
+
+        new_event = cleaned_data.get('event')
+        if new_event is None:
+            return
+
+        # ロック中イベントからの持ち出しを禁止する。移動を許すと「未ロックの
+        # 兄弟イベントへ移してから削除」でロックを迂回できてしまう。
+        if (
+            new_event.pk != self.event_detail.event_id
+            and is_event_datetime_locked(self.event_detail.event, self.user)
+        ):
+            self.add_error('event', EVENT_DETAIL_DATETIME_LOCK_MESSAGE)
+
+        if not is_event_datetime_locked(new_event, self.user):
+            return
+
+        if cleaned_data.get('start_time') != self.event_detail.start_time:
+            self.add_error('start_time', EVENT_DETAIL_DATETIME_LOCK_MESSAGE)
+        if cleaned_data.get('duration') != self.event_detail.duration:
+            self.add_error('duration', EVENT_DETAIL_DATETIME_LOCK_MESSAGE)

--- a/app/event/forms/lt_application.py
+++ b/app/event/forms/lt_application.py
@@ -2,6 +2,7 @@
 
 from django import forms
 from django.core.exceptions import ValidationError
+from django.db.models import Q
 from django.utils import timezone
 
 from user_account.forms import normalize_x_account
@@ -177,8 +178,24 @@ class LTApplicationForm(forms.Form):
         return additional_info
 
 
+WEEKDAY_LABELS = ['月', '火', '水', '木', '金', '土', '日']
+
+
+class EventScheduleChoiceField(forms.ModelChoiceField):
+    """開催日を「日付＋開始時刻」で選べるようにした ModelChoiceField。
+
+    既定の __str__ だと日付が読み取れず、主催者が振替先を選び間違えるため表示を上書きする。
+    """
+
+    def label_from_instance(self, obj):
+        return (
+            f"{obj.date.strftime('%Y年%m月%d日')}({WEEKDAY_LABELS[obj.date.weekday()]}) "
+            f"{obj.start_time.strftime('%H:%M')}"
+        )
+
+
 class LTApplicationReviewForm(forms.Form):
-    """LT申請の承認/却下フォーム"""
+    """LT申請の承認/却下フォーム（承認時の開催日・時刻調整を含む）"""
 
     ACTION_CHOICES = [
         ('approve', '承認する'),
@@ -188,8 +205,29 @@ class LTApplicationReviewForm(forms.Form):
     action = forms.ChoiceField(
         choices=ACTION_CHOICES,
         label='アクション',
-        widget=forms.RadioSelect(attrs={'class': 'form-check-input'}),
         initial='approve'
+    )
+
+    event = EventScheduleChoiceField(
+        queryset=Event.objects.none(),
+        label='開催日',
+        widget=forms.Select(attrs={'class': 'form-select'}),
+    )
+
+    start_time = forms.TimeField(
+        label='開始時刻',
+        input_formats=['%H:%M', '%H:%M:%S'],
+        widget=forms.TimeInput(
+            attrs={'type': 'time', 'class': 'form-control'},
+            format='%H:%M',
+        ),
+    )
+
+    duration = forms.IntegerField(
+        label='発表の持ち時間（分）',
+        min_value=1,
+        max_value=600,
+        widget=forms.NumberInput(attrs={'class': 'form-control', 'min': 1}),
     )
 
     rejection_reason = forms.CharField(
@@ -203,12 +241,35 @@ class LTApplicationReviewForm(forms.Form):
         help_text='却下する場合は、申請者に伝える理由を入力してください'
     )
 
+    def __init__(self, *args, event_detail=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.event_detail = event_detail
+        if event_detail is None:
+            return
+
+        today = timezone.now().date()
+        # 申請フォームと同じ受付中イベントに加え、現在割り当て中のイベントは
+        # 受付停止・過去でも必ず候補に残す（据え置き承認を潰さないため）。
+        self.fields['event'].queryset = Event.objects.filter(
+            community=event_detail.event.community,
+        ).filter(
+            Q(accepts_lt_application=True, date__gte=today) | Q(pk=event_detail.event_id)
+        ).order_by('date', 'start_time')
+
+        self.fields['event'].initial = event_detail.event_id
+        self.fields['start_time'].initial = event_detail.start_time
+        self.fields['duration'].initial = event_detail.duration
+
     def clean(self):
         cleaned_data = super().clean()
         action = cleaned_data.get('action')
         rejection_reason = cleaned_data.get('rejection_reason')
 
-        if action == 'reject' and not rejection_reason:
-            raise ValidationError('却下する場合は理由を入力してください')
+        if action == 'reject':
+            if not rejection_reason:
+                raise ValidationError('却下する場合は理由を入力してください')
+            # 却下時は日時を反映しないため、日時欄の欠損でブロックしない
+            for field_name in ('event', 'start_time', 'duration'):
+                self.errors.pop(field_name, None)
 
         return cleaned_data

--- a/app/event/notifications.py
+++ b/app/event/notifications.py
@@ -111,13 +111,19 @@ def notify_owners_of_new_application(event_detail: EventDetail, request=None) ->
     _send_discord_notification_for_new_application(event_detail, review_url)
 
 
-def notify_applicant_of_result(event_detail: EventDetail, request=None) -> None:
+def notify_applicant_of_result(
+    event_detail: EventDetail,
+    request=None,
+    schedule_changes: list[dict[str, str]] | None = None,
+) -> None:
     """
     申請結果を申請者に通知する
 
     Args:
         event_detail: 承認/却下されたEventDetailインスタンス
         request: HTTPリクエスト（絶対URL生成用）
+        schedule_changes: 主催者が承認時に変更した日時の一覧。
+            ``[{'label': '開催日', 'before': ..., 'after': ...}, ...]`` 形式。
     """
     applicant = event_detail.applicant
     if not applicant or not applicant.email:
@@ -160,6 +166,7 @@ def notify_applicant_of_result(event_detail: EventDetail, request=None) -> None:
         'guide_url': guide_url,
         'list_url': list_url,
         'is_approved': event_detail.status == 'approved',
+        'schedule_changes': schedule_changes or [],
     }
 
     if event_detail.status == 'approved':
@@ -194,7 +201,7 @@ def notify_applicant_of_result(event_detail: EventDetail, request=None) -> None:
         )
 
     # Discord Webhook通知
-    _send_discord_notification_for_result(event_detail)
+    _send_discord_notification_for_result(event_detail, schedule_changes)
 
 
 def _send_discord_notification_for_new_application(
@@ -275,7 +282,10 @@ def _send_discord_notification_for_new_application(
         )
 
 
-def _send_discord_notification_for_result(event_detail: EventDetail) -> None:
+def _send_discord_notification_for_result(
+    event_detail: EventDetail,
+    schedule_changes: list[dict[str, str]] | None = None,
+) -> None:
     """申請結果のDiscord Webhook通知を送信"""
     community = event_detail.event.community
     webhook_url = community.notification_webhook_url
@@ -298,6 +308,22 @@ def _send_discord_notification_for_result(event_detail: EventDetail) -> None:
         {"name": "👤 発表者", "value": event_detail.speaker, "inline": True},
         {"name": "📅 開催日", "value": str(event_detail.event.date), "inline": True},
     ]
+
+    if is_approved:
+        fields.append({
+            "name": "⏰ 開始時刻",
+            "value": event_detail.start_time.strftime("%H:%M"),
+            "inline": True,
+        })
+        if schedule_changes:
+            fields.append({
+                "name": "🔄 日時変更",
+                "value": "\n".join(
+                    f"{change['label']}: {change['before']} → {change['after']}"
+                    for change in schedule_changes
+                ),
+                "inline": False,
+            })
 
     if not is_approved and event_detail.rejection_reason:
         fields.append({

--- a/app/event/templates/event/email/lt_application_result.html
+++ b/app/event/templates/event/email/lt_application_result.html
@@ -92,6 +92,36 @@
             margin-top: 0;
             font-size: 1.1em;
         }
+        .schedule-changes {
+            background-color: #fff3cd;
+            padding: 15px 20px;
+            border-radius: 8px;
+            margin: 20px 0;
+            border: 1px solid #ffc107;
+        }
+        .schedule-changes h3 {
+            color: #856404;
+            margin-top: 0;
+            font-size: 1.1em;
+        }
+        .schedule-changes table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .schedule-changes td {
+            padding: 8px 0;
+            border-bottom: 1px solid #ffe08a;
+            font-size: 1.1em;
+        }
+        .schedule-changes td:first-child {
+            font-weight: bold;
+            width: 120px;
+            color: #856404;
+        }
+        .schedule-changes .before {
+            color: #666;
+            text-decoration: line-through;
+        }
         .next-steps {
             background-color: #d4edda;
             padding: 20px;
@@ -138,6 +168,21 @@
             <p>{{ community.name }}への発表の申請が<span class="status-badge status-rejected">却下</span>されました。</p>
         {% endif %}
 
+        {% if is_approved and schedule_changes %}
+            <div class="schedule-changes">
+                <h3>主催者による日時変更</h3>
+                <p>申請いただいた内容から、以下のとおり変更されました。</p>
+                <table>
+                    {% for change in schedule_changes %}
+                        <tr>
+                            <td>{{ change.label }}</td>
+                            <td><span class="before">{{ change.before }}</span> → <strong>{{ change.after }}</strong></td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            </div>
+        {% endif %}
+
         <div class="application-details">
             <h3>申請内容</h3>
             <table>
@@ -159,7 +204,7 @@
                 </tr>
                 <tr>
                     <td>開始時間</td>
-                    <td>{{ community.start_time|time:"H:i" }}</td>
+                    <td>{{ event_detail.start_time|time:"H:i" }}</td>
                 </tr>
                 <tr>
                     <td>発表の持ち時間</td>

--- a/app/event/templates/event/lt_application_review.html
+++ b/app/event/templates/event/lt_application_review.html
@@ -133,7 +133,8 @@
                             </div>
                         </div>
 
-                        <div class="mb-4 d-none" id="rejection-reason-field">
+                        {# JS 無効でも却下できるよう、エラー再描画時はサーバー側で開く #}
+                        <div class="mb-4 {% if not form.rejection_reason.value and not form.non_field_errors %}d-none{% endif %}" id="rejection-reason-field">
                             <label for="{{ form.rejection_reason.id_for_label }}" class="form-label fw-bold">
                                 {{ form.rejection_reason.label }}
                             </label>
@@ -148,9 +149,10 @@
                             {% endif %}
                         </div>
 
-                        {% if form.non_field_errors %}
+                        {% if form.non_field_errors or form.action.errors %}
                             <div class="alert alert-danger">
                                 {% for error in form.non_field_errors %}{{ error }}{% endfor %}
+                                {% for error in form.action.errors %}{{ error }}{% endfor %}
                             </div>
                         {% endif %}
 

--- a/app/event/templates/event/lt_application_review.html
+++ b/app/event/templates/event/lt_application_review.html
@@ -89,40 +89,57 @@
                     <h5 class="mb-0"><i class="bi bi-check2-square me-2"></i>アクション</h5>
                 </div>
                 <div class="card-body">
-                    <form method="post">
+                    <form method="post" id="review-form">
                         {% csrf_token %}
 
                         <div class="mb-4">
-                            <label class="form-label fw-bold">{{ form.action.label }}</label>
-                            <div class="d-flex gap-4">
-                                {% for radio in form.action %}
-                                    <div class="form-check">
-                                        {{ radio.tag }}
-                                        <label class="form-check-label {% if radio.data.value == 'approve' %}text-success{% else %}text-danger{% endif %}" for="{{ radio.id_for_label }}">
-                                            {% if radio.data.value == 'approve' %}
-                                                <i class="bi bi-check-circle me-1"></i>
-                                            {% else %}
-                                                <i class="bi bi-x-circle me-1"></i>
-                                            {% endif %}
-                                            {{ radio.choice_label }}
-                                        </label>
-                                    </div>
-                                {% endfor %}
-                            </div>
-                            {% if form.action.errors %}
-                                <div class="invalid-feedback d-block">
-                                    {% for error in form.action.errors %}{{ error }}{% endfor %}
+                            <h6 class="fw-bold mb-2">
+                                <i class="bi bi-calendar-event me-2"></i>開催日・時間の調整
+                            </h6>
+                            <p class="text-muted mb-3">
+                                変更すると承認時に反映され、申請者に変更内容が通知されます。
+                                現在の申請内容は
+                                {{ event_detail.event.date|date:"Y年m月d日" }} {{ event_detail.start_time|time:"H:i" }}（{{ event_detail.duration }}分）です。
+                            </p>
+
+                            <div class="row g-3">
+                                <div class="col-md-6">
+                                    <label for="{{ form.event.id_for_label }}" class="form-label fw-bold">{{ form.event.label }}</label>
+                                    {{ form.event }}
+                                    {% if form.event.errors %}
+                                        <div class="invalid-feedback d-block">
+                                            {% for error in form.event.errors %}{{ error }}{% endfor %}
+                                        </div>
+                                    {% endif %}
                                 </div>
-                            {% endif %}
+                                <div class="col-md-3">
+                                    <label for="{{ form.start_time.id_for_label }}" class="form-label fw-bold">{{ form.start_time.label }}</label>
+                                    {{ form.start_time }}
+                                    {% if form.start_time.errors %}
+                                        <div class="invalid-feedback d-block">
+                                            {% for error in form.start_time.errors %}{{ error }}{% endfor %}
+                                        </div>
+                                    {% endif %}
+                                </div>
+                                <div class="col-md-3">
+                                    <label for="{{ form.duration.id_for_label }}" class="form-label fw-bold">{{ form.duration.label }}</label>
+                                    {{ form.duration }}
+                                    {% if form.duration.errors %}
+                                        <div class="invalid-feedback d-block">
+                                            {% for error in form.duration.errors %}{{ error }}{% endfor %}
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </div>
                         </div>
 
-                        <div class="mb-4" id="rejection-reason-field">
-                            <label for="id_rejection_reason" class="form-label fw-bold">
+                        <div class="mb-4 d-none" id="rejection-reason-field">
+                            <label for="{{ form.rejection_reason.id_for_label }}" class="form-label fw-bold">
                                 {{ form.rejection_reason.label }}
                             </label>
                             {{ form.rejection_reason }}
                             {% if form.rejection_reason.help_text %}
-                                <small class="form-text text-muted">{{ form.rejection_reason.help_text }}</small>
+                                <div class="form-text text-muted" id="rejection-reason-help">{{ form.rejection_reason.help_text }}</div>
                             {% endif %}
                             {% if form.rejection_reason.errors %}
                                 <div class="invalid-feedback d-block">
@@ -139,13 +156,20 @@
 
                         <hr class="my-4">
 
-                        <div class="d-flex justify-content-between">
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-3">
                             <a href="{% url 'event:my_list' %}" class="btn btn-outline-secondary">
                                 <i class="bi bi-arrow-left me-2"></i>マイリストに戻る
                             </a>
-                            <button type="submit" class="btn btn-primary">
-                                <i class="bi bi-check-lg me-2"></i>決定
-                            </button>
+                            <div class="d-flex gap-2">
+                                <button type="submit" name="action" value="reject" id="reject-button"
+                                        class="btn btn-outline-danger btn-lg">
+                                    <i class="bi bi-x-circle me-2"></i>却下する
+                                </button>
+                                <button type="submit" name="action" value="approve"
+                                        class="btn btn-success btn-lg">
+                                    <i class="bi bi-check-circle me-2"></i>承認する
+                                </button>
+                            </div>
                         </div>
                     </form>
                 </div>
@@ -164,23 +188,52 @@
 {% if event_detail.status == 'pending' %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    const actionRadios = document.querySelectorAll('input[name="action"]');
     const rejectionField = document.getElementById('rejection-reason-field');
+    const rejectionInput = document.getElementById('{{ form.rejection_reason.id_for_label }}');
+    const rejectButton = document.getElementById('reject-button');
+    if (!rejectionField || !rejectionInput || !rejectButton) {
+        return;
+    }
 
-    function toggleRejectionField() {
-        const selectedAction = document.querySelector('input[name="action"]:checked');
-        if (selectedAction && selectedAction.value === 'reject') {
-            rejectionField.style.display = 'block';
-        } else {
-            rejectionField.style.display = 'none';
+    const feedbackId = 'rejection-reason-hint';
+    const rejectionHelp = document.getElementById('rejection-reason-help');
+
+    function showHint(message) {
+        let hint = document.getElementById(feedbackId);
+        if (!hint) {
+            hint = document.createElement('div');
+            hint.id = feedbackId;
+            // 指示文なので既定の invalid-feedback より大きい本文サイズで出す
+            hint.className = 'text-danger fw-bold mt-1';
+            rejectionInput.insertAdjacentElement('afterend', hint);
+        }
+        hint.textContent = message;
+        // 同趣旨のヘルプ文が二重に並ぶのを防ぐ
+        if (rejectionHelp) {
+            rejectionHelp.classList.add('d-none');
         }
     }
 
-    actionRadios.forEach(function(radio) {
-        radio.addEventListener('change', toggleRejectionField);
-    });
+    // バリデーションエラーで再描画された場合は理由欄を開いたままにする
+    if (rejectionInput.value.trim() !== '') {
+        rejectionField.classList.remove('d-none');
+    }
 
-    toggleRejectionField();
+    rejectButton.addEventListener('click', function(event) {
+        if (rejectionField.classList.contains('d-none')) {
+            // 1クリック目: 理由欄を出して入力を促し、送信は止める
+            event.preventDefault();
+            rejectionField.classList.remove('d-none');
+            rejectionInput.focus();
+            showHint('却下理由を入力してから、もう一度「却下する」を押してください。');
+            return;
+        }
+        if (rejectionInput.value.trim() === '') {
+            event.preventDefault();
+            rejectionInput.focus();
+            showHint('却下理由を入力してください。');
+        }
+    });
 });
 </script>
 {% endif %}

--- a/app/event/tests/test_lt_application.py
+++ b/app/event/tests/test_lt_application.py
@@ -433,6 +433,18 @@ class LTApplicationReviewTest(TestCase):
             status='pending',
         )
 
+    def _review_post_data(self, action='approve', **overrides):
+        """レビューフォームの必須フィールドを埋めた POST データを返す。"""
+        data = {
+            'action': action,
+            'event': self.pending_application.event_id,
+            'start_time': self.pending_application.start_time.strftime('%H:%M'),
+            'duration': self.pending_application.duration,
+            'rejection_reason': '',
+        }
+        data.update(overrides)
+        return data
+
     def test_review_page_requires_login(self):
         """レビューページは未ログインユーザーにはアクセスできない"""
         url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
@@ -468,10 +480,7 @@ class LTApplicationReviewTest(TestCase):
         self.client.force_login(self.owner)
 
         url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
-        response = self.client.post(url, {
-            'action': 'approve',
-            'rejection_reason': '',
-        })
+        response = self.client.post(url, self._review_post_data(action='approve'))
 
         # リダイレクト確認
         self.assertEqual(response.status_code, 302)
@@ -487,10 +496,10 @@ class LTApplicationReviewTest(TestCase):
         self.client.force_login(self.owner)
 
         url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
-        response = self.client.post(url, {
-            'action': 'reject',
-            'rejection_reason': 'Test rejection reason',
-        })
+        response = self.client.post(url, self._review_post_data(
+            action='reject',
+            rejection_reason='Test rejection reason',
+        ))
 
         # リダイレクト確認
         self.assertEqual(response.status_code, 302)
@@ -505,14 +514,118 @@ class LTApplicationReviewTest(TestCase):
         self.client.force_login(self.owner)
 
         url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
-        response = self.client.post(url, {
-            'action': 'reject',
-            'rejection_reason': '',  # 空
-        })
+        response = self.client.post(url, self._review_post_data(action='reject'))
 
         # フォームエラーで再表示
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '却下する場合は理由を入力してください')
+
+    @patch('event.notifications.send_mail')
+    def test_approve_with_rescheduled_event(self, mock_send_mail):
+        """開催日・開始時刻・持ち時間を変更して承認すると EventDetail に反映される"""
+        mock_send_mail.return_value = 1
+        other_event = make_event(self.community, event_date=date.today() + timedelta(days=21))
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        response = self.client.post(url, self._review_post_data(
+            action='approve',
+            event=other_event.pk,
+            start_time='23:30',
+            duration=25,
+        ))
+
+        self.assertEqual(response.status_code, 302)
+        self.pending_application.refresh_from_db()
+        self.assertEqual(self.pending_application.status, 'approved')
+        self.assertEqual(self.pending_application.event_id, other_event.pk)
+        self.assertEqual(self.pending_application.start_time, time(23, 30))
+        self.assertEqual(self.pending_application.duration, 25)
+
+    @patch('event.notifications.send_mail')
+    def test_reject_ignores_schedule_edits(self, mock_send_mail):
+        """却下時は日時の編集値を反映しない"""
+        mock_send_mail.return_value = 1
+        other_event = make_event(self.community, event_date=date.today() + timedelta(days=21))
+        original_event_id = self.pending_application.event_id
+        original_start_time = self.pending_application.start_time
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        response = self.client.post(url, self._review_post_data(
+            action='reject',
+            rejection_reason='内容が集会の趣旨に合いません',
+            event=other_event.pk,
+            start_time='23:30',
+            duration=25,
+        ))
+
+        self.assertEqual(response.status_code, 302)
+        self.pending_application.refresh_from_db()
+        self.assertEqual(self.pending_application.status, 'rejected')
+        self.assertEqual(self.pending_application.event_id, original_event_id)
+        self.assertEqual(self.pending_application.start_time, original_start_time)
+
+    def test_event_choices_limited_to_own_open_future_events(self):
+        """開催日の選択肢は自集会の受付中・未来イベントと現在割当中イベントに限る"""
+        other_community = make_community(name='Other Community')
+        other_community_event = make_event(other_community)
+        past_event = make_event(self.community, event_date=date.today() - timedelta(days=7))
+        closed_event = make_event(
+            self.community,
+            event_date=date.today() + timedelta(days=28),
+            accepts_lt_application=False,
+        )
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        choices = self.client.get(url).context['form'].fields['event'].queryset
+
+        self.assertIn(self.event, choices)
+        self.assertNotIn(other_community_event, choices)
+        self.assertNotIn(past_event, choices)
+        self.assertNotIn(closed_event, choices)
+
+    def test_currently_assigned_event_stays_selectable_when_closed(self):
+        """受付停止済みの割当中イベントも選択肢に残る"""
+        self.event.accepts_lt_application = False
+        self.event.save(update_fields=['accepts_lt_application'])
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        choices = self.client.get(url).context['form'].fields['event'].queryset
+
+        self.assertIn(self.event, choices)
+
+    @patch('event.notifications.send_mail')
+    def test_reschedule_is_shown_in_result_mail(self, mock_send_mail):
+        """日時変更ありで承認するとメール本文に変更前後が載る"""
+        mock_send_mail.return_value = 1
+        other_event = make_event(self.community, event_date=date.today() + timedelta(days=21))
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        self.client.post(url, self._review_post_data(
+            action='approve',
+            event=other_event.pk,
+        ))
+
+        html_message = mock_send_mail.call_args.kwargs['html_message']
+        self.assertIn('主催者による日時変更', html_message)
+        self.assertIn(self.event.date.strftime('%Y-%m-%d'), html_message)
+        self.assertIn(other_event.date.strftime('%Y-%m-%d'), html_message)
+
+    @patch('event.notifications.send_mail')
+    def test_no_reschedule_section_when_unchanged(self, mock_send_mail):
+        """日時を変更せず承認した場合は変更明示セクションを出さない"""
+        mock_send_mail.return_value = 1
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        self.client.post(url, self._review_post_data(action='approve'))
+
+        html_message = mock_send_mail.call_args.kwargs['html_message']
+        self.assertNotIn('主催者による日時変更', html_message)
 
     def test_owner_can_view_approved_application(self):
         """承認済み申請も主催者は閲覧でき、追加情報が表示される"""

--- a/app/event/tests/test_lt_application.py
+++ b/app/event/tests/test_lt_application.py
@@ -616,6 +616,39 @@ class LTApplicationReviewTest(TestCase):
         self.assertIn(other_event.date.strftime('%Y-%m-%d'), html_message)
 
     @patch('event.notifications.send_mail')
+    def test_result_mail_shows_presentation_start_time(self, mock_send_mail):
+        """結果メールには集会ではなく発表個別の開始時刻を載せる"""
+        mock_send_mail.return_value = 1
+        self.pending_application.start_time = time(23, 15)
+        self.pending_application.save(update_fields=['start_time'])
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        self.client.post(url, self._review_post_data(
+            action='approve',
+            start_time='23:15',
+        ))
+
+        html_message = mock_send_mail.call_args.kwargs['html_message']
+        self.assertIn('23:15', html_message)
+
+    @patch('event.notifications.send_mail')
+    def test_approve_keeps_concurrent_applicant_edit(self, mock_send_mail):
+        """レビュー画面を開いた後に申請者が直した内容を承認で巻き戻さない"""
+        mock_send_mail.return_value = 1
+        self.client.force_login(self.owner)
+
+        EventDetail.objects.filter(pk=self.pending_application.pk).update(
+            theme='申請者が直したテーマ'
+        )
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        self.client.post(url, self._review_post_data(action='approve'))
+
+        self.pending_application.refresh_from_db()
+        self.assertEqual(self.pending_application.theme, '申請者が直したテーマ')
+        self.assertEqual(self.pending_application.status, 'approved')
+
+    @patch('event.notifications.send_mail')
     def test_no_reschedule_section_when_unchanged(self, mock_send_mail):
         """日時を変更せず承認した場合は変更明示セクションを出さない"""
         mock_send_mail.return_value = 1

--- a/app/event/tests/test_lt_application.py
+++ b/app/event/tests/test_lt_application.py
@@ -1,8 +1,9 @@
 """LT申請機能のテスト"""
 import re
-from datetime import date, time, timedelta
+from datetime import date, datetime, time, timedelta
 from io import BytesIO
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from PIL import Image
 from django.test import TestCase, Client
@@ -586,6 +587,25 @@ class LTApplicationReviewTest(TestCase):
         self.assertNotIn(past_event, choices)
         self.assertNotIn(closed_event, choices)
 
+    def test_event_choices_exclude_yesterday_in_jst_early_morning(self):
+        """JST 早朝でも前日の回は候補に入らない（UTC 基準だと前日が今日扱いで混入する）"""
+        # JST 2026-08-20 01:30 = UTC 2026-08-19 16:30。now().date() だと 8/19 になる
+        jst_early_morning = datetime(
+            2026, 8, 20, 1, 30, tzinfo=ZoneInfo('Asia/Tokyo')
+        )
+        yesterday_event = make_event(self.community, event_date=date(2026, 8, 19))
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        # 実時刻だけを差し替え、日付の解釈（UTC か JST か）は実装に判定させる
+        with patch(
+            'django.utils.timezone.now',
+            return_value=jst_early_morning.astimezone(ZoneInfo('UTC')),
+        ):
+            choices = self.client.get(url).context['form'].fields['event'].queryset
+
+        self.assertNotIn(yesterday_event, choices)
+
     def test_currently_assigned_event_stays_selectable_when_closed(self):
         """受付停止済みの割当中イベントも選択肢に残る"""
         self.event.accepts_lt_application = False
@@ -647,6 +667,26 @@ class LTApplicationReviewTest(TestCase):
         self.pending_application.refresh_from_db()
         self.assertEqual(self.pending_application.theme, '申請者が直したテーマ')
         self.assertEqual(self.pending_application.status, 'approved')
+
+    @patch('event.notifications.send_mail')
+    def test_reject_keeps_concurrent_schedule_edit(self, mock_send_mail):
+        """却下は日時を触らないので、別経路で変わった日時をそのまま残す"""
+        mock_send_mail.return_value = 1
+        self.client.force_login(self.owner)
+
+        post_data = self._review_post_data(
+            action='reject', rejection_reason='今回は見送ります'
+        )
+        EventDetail.objects.filter(pk=self.pending_application.pk).update(
+            start_time=time(23, 45)
+        )
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        self.client.post(url, post_data)
+
+        self.pending_application.refresh_from_db()
+        self.assertEqual(self.pending_application.start_time, time(23, 45))
+        self.assertEqual(self.pending_application.status, 'rejected')
 
     @patch('event.notifications.send_mail')
     def test_no_reschedule_section_when_unchanged(self, mock_send_mail):

--- a/app/event/tests/test_lt_review_datetime_lock.py
+++ b/app/event/tests/test_lt_review_datetime_lock.py
@@ -1,0 +1,137 @@
+"""発表申請の承認画面が Vket コラボの日時ロックを迂回しないことのテスト。
+
+承認画面の日時調整は api_v1.perform_update / EventDetailForm と同じロック規約を
+共有する必要がある（共有しないと3つ目の迂回経路になる）。
+"""
+
+from datetime import timedelta
+
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from tests.factories import make_community, make_event, make_event_detail
+from user_account.tests.utils import create_discord_linked_user
+from vket.models import VketCollaboration, VketParticipation
+
+
+class LTReviewDatetimeLockTest(TestCase):
+    """コラボ本体イベントに紐づく申請の日時変更を主催者に許さない"""
+
+    def setUp(self):
+        self.client = Client()
+        self.owner = create_discord_linked_user(
+            user_name='LockOwner',
+            email='lock_owner@example.com',
+            password='ownerpass123',
+        )
+        self.applicant = create_discord_linked_user(
+            user_name='LockApplicant',
+            email='lock_applicant@example.com',
+            password='applicantpass123',
+        )
+        self.community = make_community(owner=self.owner)
+
+        today = timezone.localdate()
+        self.collab_event = make_event(
+            self.community, event_date=today + timedelta(days=1)
+        )
+        self.free_event = make_event(
+            self.community, event_date=today + timedelta(days=2)
+        )
+        collaboration = VketCollaboration.objects.create(
+            slug='lt-review-lock-test',
+            name='Vket LT Review Lock Test',
+            period_start=today,
+            period_end=today + timedelta(days=7),
+            registration_deadline=today,
+            lt_deadline=today + timedelta(days=3),
+        )
+        VketParticipation.objects.create(
+            collaboration=collaboration,
+            community=self.community,
+            published_event=self.collab_event,
+            lifecycle=VketParticipation.Lifecycle.ACTIVE,
+        )
+
+        self.application = make_event_detail(
+            self.collab_event,
+            applicant=self.applicant,
+            theme='ロック確認テーマ',
+            speaker='Lock Speaker',
+            duration=15,
+            status='pending',
+        )
+        self.url = reverse(
+            'event:lt_application_review', kwargs={'pk': self.application.pk}
+        )
+
+    def _post_data(self, **overrides):
+        data = {
+            'action': 'approve',
+            'event': self.application.event_id,
+            'start_time': self.application.start_time.strftime('%H:%M'),
+            'duration': self.application.duration,
+            'rejection_reason': '',
+        }
+        data.update(overrides)
+        return data
+
+    def test_start_time_change_on_locked_event_is_rejected(self):
+        """ロック中イベントでは開始時刻を変更できない"""
+        self.client.force_login(self.owner)
+
+        response = self.client.post(self.url, self._post_data(start_time='23:45'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Vketコラボ期間中のため運営のみ変更できます。')
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.status, 'pending')
+
+    def test_duration_change_on_locked_event_is_rejected(self):
+        """ロック中イベントでは持ち時間を変更できない"""
+        self.client.force_login(self.owner)
+
+        response = self.client.post(self.url, self._post_data(duration=55))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Vketコラボ期間中のため運営のみ変更できます。')
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.duration, 15)
+
+    def test_moving_out_of_locked_event_is_rejected(self):
+        """ロック中イベントから未ロックイベントへ持ち出せない"""
+        self.client.force_login(self.owner)
+
+        response = self.client.post(self.url, self._post_data(event=self.free_event.pk))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Vketコラボ期間中のため運営のみ変更できます。')
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.event_id, self.collab_event.pk)
+
+    def test_approve_without_schedule_change_is_allowed(self):
+        """ロック中でも日時を変えない承認は通る"""
+        self.client.force_login(self.owner)
+
+        with self.settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend'):
+            response = self.client.post(self.url, self._post_data())
+
+        self.assertEqual(response.status_code, 302)
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.status, 'approved')
+
+    def test_superuser_can_change_schedule_on_locked_event(self):
+        """運営（superuser）はロック中でも日時を変更できる"""
+        # can_edit は集会メンバーシップで判定するため、運営でも所属が要る
+        self.owner.is_superuser = True
+        self.owner.is_staff = True
+        self.owner.save(update_fields=['is_superuser', 'is_staff'])
+        self.client.force_login(self.owner)
+
+        with self.settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend'):
+            response = self.client.post(self.url, self._post_data(start_time='23:45'))
+
+        self.assertEqual(response.status_code, 302)
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.start_time.strftime('%H:%M'), '23:45')

--- a/app/event/views/lt_application.py
+++ b/app/event/views/lt_application.py
@@ -4,6 +4,7 @@ from datetime import datetime, time, timedelta
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Prefetch
 from django.http import JsonResponse
@@ -194,6 +195,11 @@ class LTApplicationReviewView(LoginRequiredMixin, FormView):
             return redirect('event:lt_application_review', pk=self.event_detail.pk)
         return super().post(request, *args, **kwargs)
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['event_detail'] = self.event_detail
+        return kwargs
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['event_detail'] = self.event_detail
@@ -202,8 +208,10 @@ class LTApplicationReviewView(LoginRequiredMixin, FormView):
 
     def form_valid(self, form):
         action = form.cleaned_data['action']
+        schedule_changes: list[dict[str, str]] = []
 
         if action == 'approve':
+            schedule_changes = self._apply_schedule_changes(form)
             self.event_detail.status = 'approved'
             status_text = '承認'
         else:
@@ -215,15 +223,62 @@ class LTApplicationReviewView(LoginRequiredMixin, FormView):
 
         # 申請者に通知
         from event.notifications import notify_applicant_of_result
-        notify_applicant_of_result(self.event_detail, request=self.request)
+        notify_applicant_of_result(
+            self.event_detail,
+            request=self.request,
+            schedule_changes=schedule_changes,
+        )
 
         messages.success(self.request, f'申請を{status_text}しました。')
         logger.info(
             f'発表申請{status_text}: EventDetail ID={self.event_detail.pk}, '
             f'Community={self.community.name}, Reviewer={self.request.user.user_name}'
         )
+        if schedule_changes:
+            logger.info(
+                '発表申請の日時変更: EventDetail ID=%s, changes=%s',
+                self.event_detail.pk,
+                ', '.join(
+                    f"{c['label']}: {c['before']} → {c['after']}" for c in schedule_changes
+                ),
+            )
 
         return redirect('event:my_list')
+
+    def _apply_schedule_changes(self, form) -> list[dict[str, str]]:
+        """承認時の日時調整を EventDetail へ反映し、変更内容を返す。"""
+        new_event = form.cleaned_data['event']
+        new_start_time = form.cleaned_data['start_time']
+        new_duration = form.cleaned_data['duration']
+
+        # queryset で担保済みだが、他集会への付け替えは実害が大きいので保存直前にも検証する
+        if new_event.community_id != self.community.pk:
+            raise PermissionDenied('他の集会のイベントには変更できません。')
+
+        changes: list[dict[str, str]] = []
+        if new_event.pk != self.event_detail.event_id:
+            changes.append({
+                'label': '開催日',
+                'before': self.event_detail.event.date.strftime('%Y-%m-%d'),
+                'after': new_event.date.strftime('%Y-%m-%d'),
+            })
+            self.event_detail.event = new_event
+        if new_start_time != self.event_detail.start_time:
+            changes.append({
+                'label': '開始時刻',
+                'before': self.event_detail.start_time.strftime('%H:%M'),
+                'after': new_start_time.strftime('%H:%M'),
+            })
+            self.event_detail.start_time = new_start_time
+        if new_duration != self.event_detail.duration:
+            changes.append({
+                'label': '持ち時間',
+                'before': f'{self.event_detail.duration}分',
+                'after': f'{new_duration}分',
+            })
+            self.event_detail.duration = new_duration
+
+        return changes
 
 
 class LTApplicationApproveView(LoginRequiredMixin, View):

--- a/app/event/views/lt_application.py
+++ b/app/event/views/lt_application.py
@@ -212,25 +212,30 @@ class LTApplicationReviewView(LoginRequiredMixin, FormView):
         schedule_changes: list[dict[str, str]] = []
 
         with transaction.atomic():
-            # 申請者は pending 中も内容を編集できるため、全フィールド save だと
-            # その編集を巻き戻す。行ロックして status を再確認し、更新列も限定する。
-            locked = EventDetail.objects.select_for_update().get(pk=self.event_detail.pk)
+            # 申請者は pending 中も内容を編集できる。dispatch 時点のインスタンスを
+            # 保存するとその編集を巻き戻すため、行ロックで取り直した最新行を
+            # 更新基準にする（更新列も限定する）。
+            locked = EventDetail.objects.select_for_update().select_related(
+                'event', 'applicant'
+            ).get(pk=self.event_detail.pk)
             if locked.status != 'pending':
                 messages.info(self.request, 'この申請は既に処理されています。')
-                return redirect('event:lt_application_review', pk=self.event_detail.pk)
+                return redirect('event:lt_application_review', pk=locked.pk)
+
+            self.event_detail = locked
 
             if action == 'approve':
                 schedule_changes = self._apply_schedule_changes(form)
-                self.event_detail.status = 'approved'
+                locked.status = 'approved'
                 status_text = '承認'
                 update_fields = ['status', 'event', 'start_time', 'duration', 'updated_at']
             else:
-                self.event_detail.status = 'rejected'
-                self.event_detail.rejection_reason = form.cleaned_data['rejection_reason']
+                locked.status = 'rejected'
+                locked.rejection_reason = form.cleaned_data['rejection_reason']
                 status_text = '却下'
                 update_fields = ['status', 'rejection_reason', 'updated_at']
 
-            self.event_detail.save(update_fields=update_fields)
+            locked.save(update_fields=update_fields)
 
         # 申請者に通知
         from event.notifications import notify_applicant_of_result

--- a/app/event/views/lt_application.py
+++ b/app/event/views/lt_application.py
@@ -198,6 +198,7 @@ class LTApplicationReviewView(LoginRequiredMixin, FormView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs['event_detail'] = self.event_detail
+        kwargs['user'] = self.request.user
         return kwargs
 
     def get_context_data(self, **kwargs):
@@ -210,16 +211,26 @@ class LTApplicationReviewView(LoginRequiredMixin, FormView):
         action = form.cleaned_data['action']
         schedule_changes: list[dict[str, str]] = []
 
-        if action == 'approve':
-            schedule_changes = self._apply_schedule_changes(form)
-            self.event_detail.status = 'approved'
-            status_text = '承認'
-        else:
-            self.event_detail.status = 'rejected'
-            self.event_detail.rejection_reason = form.cleaned_data['rejection_reason']
-            status_text = '却下'
+        with transaction.atomic():
+            # 申請者は pending 中も内容を編集できるため、全フィールド save だと
+            # その編集を巻き戻す。行ロックして status を再確認し、更新列も限定する。
+            locked = EventDetail.objects.select_for_update().get(pk=self.event_detail.pk)
+            if locked.status != 'pending':
+                messages.info(self.request, 'この申請は既に処理されています。')
+                return redirect('event:lt_application_review', pk=self.event_detail.pk)
 
-        self.event_detail.save()
+            if action == 'approve':
+                schedule_changes = self._apply_schedule_changes(form)
+                self.event_detail.status = 'approved'
+                status_text = '承認'
+                update_fields = ['status', 'event', 'start_time', 'duration', 'updated_at']
+            else:
+                self.event_detail.status = 'rejected'
+                self.event_detail.rejection_reason = form.cleaned_data['rejection_reason']
+                status_text = '却下'
+                update_fields = ['status', 'rejection_reason', 'updated_at']
+
+            self.event_detail.save(update_fields=update_fields)
 
         # 申請者に通知
         from event.notifications import notify_applicant_of_result

--- a/app/website/tests/e2e/test_user_journeys.py
+++ b/app/website/tests/e2e/test_user_journeys.py
@@ -357,8 +357,7 @@ class UserJourneysE2ETests(PlaywrightLiveServerTestCase):
         self.page.goto(
             f'{self.live_server_url}{reverse("event:lt_application_review", kwargs={"pk": application.pk})}'
         )
-        self.page.get_by_label('承認する').check()
-        self.page.get_by_role('button', name=re.compile(r'決定$')).click()
+        self.page.get_by_role('button', name=re.compile(r'承認する$')).click()
         expect(self.page.get_by_text('申請を承認しました。', exact=True)).to_be_visible()
 
         application.refresh_from_db()


### PR DESCRIPTION
## なぜこの変更が必要か

主催者が申請された発表の日時を変更できず、「13日は発表が多いので次の回にしてほしい」といったケースで**一度却下して再申請してもらう**しかなかった。実際に Discord 上で「システム的に日付を変更できないので、27日でもう一度申請をお願いします」というやり取りが発生している（Issue #613）。

申請者は同じ内容を再入力し、主催者は却下と再承認を二度行う。どちらにとっても無駄な往復なので、承認画面でそのまま調整できるようにする。

## 変更内容

- 承認画面に「開催日・時間の調整」セクションを追加。**開催日（同一集会の別イベントへのドロップダウン）・開始時刻・持ち時間**を承認前に変更できる
- 承認/却下を**ラジオボタン＋「決定」から独立したボタン**に変更。却下は理由入力を挟む2クリック方式にして、承認と同じ操作感で誤って却下されるのを防ぐ
- 日時を変更して承認した場合、メール・Discord 通知に**変更前後（8/13 → 8/27）を明示**。申請者が気づかず元の日に来てしまうのを防ぐ
- 既存の Vket コラボ日時ロック（`is_event_datetime_locked`）を承認画面でも適用。ロック中は日時変更と他イベントへの持ち出しを拒否する
- **既存バグ修正**: 結果メールの「開始時間」が集会の開始時刻（`community.start_time`）を表示していたのを、発表個別の開始時刻（`event_detail.start_time`）に是正

## 意思決定

### 採用アプローチ
- **1画面1submit のフォーム統合**を採用。理由: 調整と承認が同じ操作の一部であり、中間状態（保存したが未承認）を作らずに済む
- **却下時は日時の編集値を反映しない**。理由: 日時調整は承認とセットの行為であり、却下する申請の日時を書き換える意味がない
- **開催日の選択肢は申請フォームと同じ基準**（受付中かつ今日以降）＋現在割当中のイベント。受付を締め切った回でも、現在割り当てられている回は据え置き承認できるよう候補に残す

### 却下した代替案
- 「変更を保存」ボタンを分離した2ステップ → 却下: 操作が2回になり、保存済み・未承認という中間状態の管理が増える
- AJAX インライン編集 → 却下: JS が複雑化する割に得るものが少ない（YAGNI）
- 開催日変更時に開始時刻を自動再計算 → 却下: 発表順は主催者が決める運用のため、自動調整はかえって邪魔になる

### トレードオフ
- 主催者の裁量 > 自動整合性: 振替先で他の発表と時刻が重なっても**ブロックしない**。意図的に重ねたいケースがあるため（既存の申請フローも重複チェックはしていない）

### 技術的負債
- 却下理由の必須判定が `LTApplicationReviewForm.clean` と `LTApplicationRejectView`（AJAX 経路）の2箇所に別実装で存在する。今回は触っていないが、いずれ共通化したい
- 振替先での時刻重複を検知していない。主催者向けの警告表示は将来の改善余地

## テスト

- [x] `event` + `api_v1` の全707件パス（`docker compose exec vrc-ta-hub python manage.py test event api_v1`）
- [x] 新規テスト: 日時変更して承認→反映 / 却下時は日時非反映 / 選択肢の制限（他集会・過去・受付停止を除外、割当中は残す）/ 変更ありメールに前後表示 / 変更なしはセクション非表示 / 申請者の並行編集を巻き戻さない / メールに発表個別の開始時刻
- [x] Vket ロック迂回の再発防止テスト5件（開始時刻・持ち時間の変更拒否、ロック中イベントからの持ち出し拒否、日時を変えない承認は許可、運営は変更可）
- [x] `manage.py check` 問題なし
- [x] ローカル実機でドロップダウン表示・初期値・却下2クリックフローを確認（コンソールエラーなし、レイアウト崩れなし）

## Screenshot

承認画面（開催日・開始時刻・持ち時間を調整してから承認/却下できる）

![承認画面](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/d27420ebf902-05-review-final-20260806-140251.avif)

「却下する」を押すと理由欄が開き、入力後にもう一度押すと却下される

![却下フロー](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/1112390d7daa-06-review-reject-final-20260806-140251.avif)

Closes #613

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
