### PR TITLE
fix(event): 承認画面の開催日と申請者の重複表示を整理する

### DIFF
--- a/app/event/forms/lt_application.py
+++ b/app/event/forms/lt_application.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.utils import timezone
 
+from community.constants import WEEKDAY_ABBR, weekday_code
 from user_account.forms import normalize_x_account
 from ..datetime_lock import (
     EVENT_DETAIL_DATETIME_LOCK_MESSAGE,
@@ -182,20 +183,16 @@ class LTApplicationForm(forms.Form):
         return additional_info
 
 
-WEEKDAY_LABELS = ['月', '火', '水', '木', '金', '土', '日']
-
-
 class EventScheduleChoiceField(forms.ModelChoiceField):
-    """開催日を「日付＋開始時刻」で選べるようにした ModelChoiceField。
+    """開催日を日付で選べるようにした ModelChoiceField。
 
     既定の __str__ だと日付が読み取れず、主催者が振替先を選び間違えるため表示を上書きする。
+    集会の開始時刻は隣の「開始時刻」欄（発表個別の時刻）と紛らわしいので出さない。
     """
 
     def label_from_instance(self, obj):
-        return (
-            f"{obj.date.strftime('%Y年%m月%d日')}({WEEKDAY_LABELS[obj.date.weekday()]}) "
-            f"{obj.start_time.strftime('%H:%M')}"
-        )
+        weekday = WEEKDAY_ABBR[weekday_code(obj.date)]
+        return f"{obj.date.strftime('%Y年%m月%d日')}({weekday})"
 
 
 class LTApplicationReviewForm(forms.Form):

--- a/app/event/templates/event/lt_application_review.html
+++ b/app/event/templates/event/lt_application_review.html
@@ -57,10 +57,13 @@
                                     <th scope="row" class="bg-light">発表の持ち時間</th>
                                     <td>{{ event_detail.duration }}分</td>
                                 </tr>
+                                {# 代理申請でのみ意味がある情報なので、発表者と同名なら出さない #}
+                                {% if event_detail.applicant and event_detail.applicant.display_label != event_detail.speaker %}
                                 <tr>
                                     <th scope="row" class="bg-light">申請者</th>
                                     <td>{{ event_detail.applicant.display_label }}</td>
                                 </tr>
+                                {% endif %}
                                 <tr>
                                     <th scope="row" class="bg-light">申請日時</th>
                                     <td>{{ event_detail.created_at|date:"Y年m月d日 H:i" }}</td>

--- a/app/event/tests/test_lt_application.py
+++ b/app/event/tests/test_lt_application.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 
+from community.constants import WEEKDAY_ABBR, weekday_code
 from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
 from event.views.lt_application import _calc_next_lt_start_time
@@ -18,6 +19,9 @@ from tests.factories import make_community, make_event, make_event_detail
 from user_account.tests.utils import create_discord_linked_user
 
 User = get_user_model()
+
+# 説明文中の「申請者」と混同しないよう、申請内容テーブルの見出しセルで判定する
+APPLICANT_ROW_HEADER = '<th scope="row" class="bg-light">申請者</th>'
 
 def create_test_image():
     """テスト用の画像ファイルを生成する"""
@@ -566,6 +570,55 @@ class LTApplicationReviewTest(TestCase):
         self.assertEqual(self.pending_application.status, 'rejected')
         self.assertEqual(self.pending_application.event_id, original_event_id)
         self.assertEqual(self.pending_application.start_time, original_start_time)
+
+    def test_event_choice_label_shows_date_without_time(self):
+        """開催日の選択肢は日付と曜日だけ（隣の開始時刻欄と紛らわしいので時刻は出さない）"""
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        field = self.client.get(url).context['form'].fields['event']
+        label = field.label_from_instance(self.event)
+
+        self.assertEqual(
+            label,
+            f"{self.event.date.strftime('%Y年%m月%d日')}"
+            f"({WEEKDAY_ABBR[weekday_code(self.event.date)]})",
+        )
+        self.assertNotIn(self.event.start_time.strftime('%H:%M'), label)
+
+    def test_applicant_row_hidden_when_same_as_speaker(self):
+        """発表者と申請者が同じ人なら申請者行を出さない"""
+        self.pending_application.speaker = self.applicant.display_label
+        self.pending_application.save(update_fields=['speaker'])
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        response = self.client.get(url)
+
+        self.assertNotContains(response, APPLICANT_ROW_HEADER, html=True)
+
+    def test_applicant_row_shown_for_proxy_application(self):
+        """代理申請（発表者と申請者が別名）なら申請者行を出す"""
+        self.pending_application.speaker = '登壇する人'
+        self.pending_application.save(update_fields=['speaker'])
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        response = self.client.get(url)
+
+        self.assertContains(response, APPLICANT_ROW_HEADER, html=True)
+        self.assertContains(response, self.applicant.display_label)
+
+    def test_applicant_row_hidden_when_applicant_is_missing(self):
+        """申請者が紐づいていない発表では申請者行を出さない"""
+        self.pending_application.applicant = None
+        self.pending_application.save(update_fields=['applicant'])
+        self.client.force_login(self.owner)
+
+        url = reverse('event:lt_application_review', kwargs={'pk': self.pending_application.pk})
+        response = self.client.get(url)
+
+        self.assertNotContains(response, APPLICANT_ROW_HEADER, html=True)
 
     def test_event_choices_limited_to_own_open_future_events(self):
         """開催日の選択肢は自集会の受付中・未来イベントと現在割当中イベントに限る"""


### PR DESCRIPTION
## なぜこの変更が必要か

PR #614 で追加した承認画面を実際に使ってみて、表示の重複が2点見つかった。

1. **開催日ドロップダウンに時刻が入っていた**（`2026年07月27日(月) 22:00`）。すぐ隣に「開始時刻」の入力欄があり、同じ `22:00` が2箇所に並ぶ。しかもドロップダウン側は集会の開始時刻、入力欄は発表個別の開始時刻で意味が違うため、並ぶと誤読を招く
2. **「申請者」行が「発表者」行と重複して見えた**。同じ人が申請していると同じ名前が2行並ぶ

## 変更内容

- 開催日ドロップダウンの表示から時刻を外し、`2026年07月27日(月)` にした
- 「申請者」行を、発表者と別名のとき（＝代理申請）だけ表示するようにした
- 曜日ラベルの自前配列（`WEEKDAY_LABELS`）を削除し、既存の正本 `community/constants.py` の `weekday_code()` + `WEEKDAY_ABBR` に寄せた

## 意思決定

### 採用アプローチ
- **開催日から時刻を常に外す**。同じ集会が同日に別時刻で複数回開催するケースは実データで1件のみ。「同日重複時だけ時刻を付ける」分岐も検討したが、稀なケースのために表示ロジックを増やす価値がないと判断した（ユーザー確認済み）
- **申請者行は条件付き表示**。実データを確認したところ、`applicant` を持つ290件のうち**216件（74%）で発表者と申請者が別名**だった（例: 発表者 `TAK1123` / 申請者 `株式投資座談会`）。主催者が発表者の代わりに申請するケースが多く、行ごと削除すると誰が出した申請か追えなくなる

### 却下した代替案
- 申請者行を無条件で削除 → 却下: 代理申請（実データの74%）で申請元が追えなくなる
- 同日に複数回あるときだけ時刻を付ける → 却下: 対象1件のために分岐を増やす価値がない

### 副次的な改善
`applicant` が未設定の EventDetail が326件あり、これまで「申請者」行が空欄のまま表示されていた。条件に `applicant` の存在チェックを含めたので、この無意味な空行も出なくなる。

## テスト

- [x] `event` アプリの全619件パス（`docker compose exec vrc-ta-hub python manage.py test event`）
- [x] 新規テスト4件: 開催日ラベルに時刻が含まれない / 同名なら申請者行を出さない / 代理申請なら出す / `applicant` 未設定なら出さない
- [x] **各テストの検出力を確認**（変更を元に戻すと落ちることを実際に検証済み）
- [x] `manage.py check` 問題なし
- [x] ローカル実機で反映を確認（コンソールエラーなし、レイアウト崩れなし）

## Screenshot

| Before | After |
|--------|-------|
| ![Before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/24f287aebb10-05-review-final-20260806-140251.avif) | ![After](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/a9b561d531d0-07-review-cleanup-20260806-144655.avif) |

Before は開催日が `2026年07月27日(月) 22:00` で隣の開始時刻と重複し、申請内容テーブルに「発表者 testuser」と「申請者 testuser」が並んでいる。After はどちらも解消されている。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
