### PR TITLE
fix(deploy): デプロイ運用の欠陥3件を塞ぐ（本番DB操作・migrate Job・事前チェック）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,20 +60,38 @@ COMPOSE_DB_SERVICE       ?= db
 DB_PULL_VERIFY_TABLE     ?= vket_collaboration
 DB_PULL_VERIFY_MIN_ROWS  ?= 1
 
-DUMP_OPTS  := --single-transaction --routines --triggers --no-tablespaces --skip-ssl
-MYSQL_OPTS := --skip-ssl
 PROD_ENV_FILE ?= .env.production.local
 
-# .env.production.local から DB_ 変数を安全に読み込む
-PROD_DB_NAME := $(shell [ ! -f "$(PROD_ENV_FILE)" ] || grep '^DB_NAME=' "$(PROD_ENV_FILE)" | cut -d= -f2-)
-PROD_DB_USER := $(shell [ ! -f "$(PROD_ENV_FILE)" ] || grep '^DB_USER=' "$(PROD_ENV_FILE)" | cut -d= -f2-)
-PROD_DB_PASSWORD := $(shell [ ! -f "$(PROD_ENV_FILE)" ] || grep '^DB_PASSWORD=' "$(PROD_ENV_FILE)" | cut -d= -f2-)
-PROD_DB_HOST := $(shell [ ! -f "$(PROD_ENV_FILE)" ] || grep '^DB_HOST=' "$(PROD_ENV_FILE)" | cut -d= -f2-)
+# 本番 dump は RDS(MySQL 8) 向け。SSL を無効化する指定は付けない（RDS は SSL 接続を受け付ける）。
+# --set-gtid-purged=OFF は GTID を持たない Compose DB へ流し込むために必須。
+PROD_DUMP_OPTS := --single-transaction --routines --triggers --no-tablespaces --set-gtid-purged=OFF
+
+# .env.production.local の値は 1Password 参照（op://...）なので生値を読んではいけない。
+# `op run --env-file` で実値へ解決し、コマンド内でシェル変数として参照する。
+# また本番 MySQL 8 の認証プラグインにホストの MariaDB クライアントは非対応なため、
+# 本番への mysqldump / mysql は Compose の db サービス（MySQL 8 正規クライアント）経由で叩く。
+OP_RUN := op run --env-file=$(PROD_ENV_FILE) --
+# MYSQL_PWD の値は呼び出し側で `-e MYSQL_PWD="$$DB_PASSWORD"` の形に展開される
+PROD_MYSQL_EXEC := docker compose exec -T -e MYSQL_PWD
+
+define require_op
+	@command -v op >/dev/null 2>&1 || \
+		(echo "ERROR: 1Password CLI (op) not found. $(PROD_ENV_FILE) stores op:// references and requires 'op run'." >&2; exit 1)
+	@test -f "$(PROD_ENV_FILE)" || (echo "ERROR: $(PROD_ENV_FILE) not found." >&2; exit 1)
+endef
+
+# op run 配下で必須 DB 変数が解決できたかを検証する（値そのものは出力しない）
+define assert_prod_db_env
+	test -n "$$DB_NAME" -a -n "$$DB_USER" -a -n "$$DB_PASSWORD" -a -n "$$DB_HOST" || \
+		{ echo "ERROR: $(PROD_ENV_FILE) must define DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST." >&2; exit 1; }
+endef
 
 db-backup: ## 本番DBバックアップ → dumps/
+	$(require_op)
 	@mkdir -p $(DUMPS_DIR)
-	@echo "Backing up production DB ($(PROD_DB_HOST)/$(PROD_DB_NAME))..."
-	@MYSQL_PWD="$(PROD_DB_PASSWORD)" mysqldump -h "$(PROD_DB_HOST)" -u "$(PROD_DB_USER)" $(DUMP_OPTS) "$(PROD_DB_NAME)" \
+	@$(OP_RUN) sh -c '$(assert_prod_db_env); \
+		echo "Backing up production DB ($$DB_NAME)..."; \
+		$(PROD_MYSQL_EXEC)="$$DB_PASSWORD" $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME"' \
 		| gzip > $(DUMPS_DIR)/production_$(DATE).sql.gz
 	@echo "Done: $(DUMPS_DIR)/production_$(DATE).sql.gz"
 
@@ -85,11 +103,11 @@ db-backup-local: ## ローカルDBバックアップ → dumps/
 	@echo "Done: $(DUMPS_DIR)/local_$(DATE).sql.gz"
 
 db-pull: ## 本番DB → ローカルDB
-	@test -n "$(PROD_DB_NAME)" -a -n "$(PROD_DB_USER)" -a -n "$(PROD_DB_PASSWORD)" -a -n "$(PROD_DB_HOST)" || \
-		(echo "ERROR: $(PROD_ENV_FILE) must define DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST." >&2; exit 1)
+	$(require_op)
 	@mkdir -p $(DUMPS_DIR)
-	@echo "Dumping production DB ($(PROD_DB_HOST)/$(PROD_DB_NAME))..."
-	@MYSQL_PWD="$(PROD_DB_PASSWORD)" mysqldump -h "$(PROD_DB_HOST)" -u "$(PROD_DB_USER)" $(DUMP_OPTS) "$(PROD_DB_NAME)" \
+	@$(OP_RUN) sh -c '$(assert_prod_db_env); \
+		echo "Dumping production DB ($$DB_NAME)..."; \
+		$(PROD_MYSQL_EXEC)="$$DB_PASSWORD" $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME"' \
 		| gzip > $(DUMPS_DIR)/production.sql.gz
 	@echo "Restoring to Docker Compose DB service ($(COMPOSE_DB_SERVICE))..."
 	@APP_SERVICE="$(COMPOSE_APP_SERVICE)" \
@@ -105,20 +123,23 @@ db-verify-local: ## アプリコンテナ経由でローカルDB復元結果を�
 	@docker compose exec -T vrc-ta-hub python manage.py shell -c "from community.models import Community; from event.models import Event; from vket.models import VketCollaboration; print('local DB verify:', {'communities': Community.objects.count(), 'events': Event.objects.count(), 'vket_collaborations': VketCollaboration.objects.count()}); assert Community.objects.exists(); assert Event.objects.exists();"
 
 db-push: ## ローカルDB → 本番DB（確認プロンプト + 自動backup）
+	$(require_op)
 	@echo "WARNING: This will OVERWRITE the production database with local data."
-	@read -p "Type the production DB name '$(PROD_DB_NAME)' to continue: " confirm && \
-		[ "$$confirm" = "$(PROD_DB_NAME)" ] || (echo "Aborted." && exit 1)
 	@mkdir -p $(DUMPS_DIR)
-	@echo "Auto-backup: production DB..."
-	@MYSQL_PWD="$(PROD_DB_PASSWORD)" mysqldump -h "$(PROD_DB_HOST)" -u "$(PROD_DB_USER)" $(DUMP_OPTS) "$(PROD_DB_NAME)" \
-		| gzip > $(DUMPS_DIR)/production_before_push_$(DATE).sql.gz
-	@echo "Saved: $(DUMPS_DIR)/production_before_push_$(DATE).sql.gz"
 	@echo "Dumping Docker Compose local DB ($(LOCAL_DB_NAME))..."
 	@docker compose exec -T -e MYSQL_PWD="$(LOCAL_DB_AUTH)" db mysqldump -u "$(LOCAL_DB_USER)" --single-transaction --routines --triggers --no-tablespaces "$(LOCAL_DB_NAME)" \
 		| gzip > $(DUMPS_DIR)/local.sql.gz
-	@echo "Restoring to production DB ($(PROD_DB_HOST)/$(PROD_DB_NAME))..."
-	@MYSQL_PWD="$(PROD_DB_PASSWORD)" mysql -h "$(PROD_DB_HOST)" -u "$(PROD_DB_USER)" $(MYSQL_OPTS) \
-		-e "DROP DATABASE IF EXISTS \`$(PROD_DB_NAME)\`; CREATE DATABASE \`$(PROD_DB_NAME)\`;"
-	@gunzip -c $(DUMPS_DIR)/local.sql.gz \
-		| MYSQL_PWD="$(PROD_DB_PASSWORD)" mysql -h "$(PROD_DB_HOST)" -u "$(PROD_DB_USER)" $(MYSQL_OPTS) "$(PROD_DB_NAME)"
+	@$(OP_RUN) sh -c '$(assert_prod_db_env); \
+		printf "Type the production DB name (%s) to continue: " "$$DB_NAME"; \
+		read confirm </dev/tty; \
+		[ "$$confirm" = "$$DB_NAME" ] || { echo "Aborted."; exit 1; }; \
+		echo "Auto-backup: production DB..."; \
+		$(PROD_MYSQL_EXEC)="$$DB_PASSWORD" $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME" \
+			| gzip > $(DUMPS_DIR)/production_before_push_$(DATE).sql.gz; \
+		echo "Saved: $(DUMPS_DIR)/production_before_push_$(DATE).sql.gz"; \
+		echo "Restoring to production DB ($$DB_NAME)..."; \
+		$(PROD_MYSQL_EXEC)="$$DB_PASSWORD" $(COMPOSE_DB_SERVICE) mysql -h "$$DB_HOST" -u "$$DB_USER" \
+			-e "DROP DATABASE IF EXISTS \`$$DB_NAME\`; CREATE DATABASE \`$$DB_NAME\`;"; \
+		gunzip -c $(DUMPS_DIR)/local.sql.gz \
+			| $(PROD_MYSQL_EXEC)="$$DB_PASSWORD" $(COMPOSE_DB_SERVICE) mysql -h "$$DB_HOST" -u "$$DB_USER" "$$DB_NAME"'
 	@echo "Done: $(LOCAL_DB_NAME) → production"

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,10 @@ PROD_DUMP_OPTS := --single-transaction --routines --triggers --no-tablespaces --
 # また本番 MySQL 8 の認証プラグインにホストの MariaDB クライアントは非対応なため、
 # 本番への mysqldump / mysql は Compose の db サービス（MySQL 8 正規クライアント）経由で叩く。
 OP_RUN := op run --env-file=$(PROD_ENV_FILE) --
-# MYSQL_PWD の値は呼び出し側で `-e MYSQL_PWD="$$DB_PASSWORD"` の形に展開される
-PROD_MYSQL_EXEC := docker compose exec -T -e MYSQL_PWD
+# 値なしの `-e MYSQL_PWD` は呼び出し元プロセスの環境から引き継ぐ。
+# `-e MYSQL_PWD=<値>` にすると docker CLI の argv に本番パスワードが平文で乗り、
+# 実行中は同一ホストの ps から読める（op run のマスクは argv に効かない）。
+PROD_MYSQL_EXEC := MYSQL_PWD="$$DB_PASSWORD" docker compose exec -T -e MYSQL_PWD
 
 define require_op
 	@command -v op >/dev/null 2>&1 || \
@@ -86,12 +88,19 @@ define assert_prod_db_env
 		{ echo "ERROR: $(PROD_ENV_FILE) must define DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST." >&2; exit 1; }
 endef
 
+# DROP/CREATE DATABASE に埋め込む前に識別子を検証する（scripts/db_pull_restore.sh と同基準）。
+# バッククォート囲みだけでは、値に ` が混ざると SQL 文が壊れる。
+define assert_prod_db_name_is_identifier
+	case "$$DB_NAME" in *[!A-Za-z0-9_]*) \
+		echo "ERROR: DB_NAME must contain only letters, numbers, and underscores." >&2; exit 1;; esac
+endef
+
 db-backup: ## 本番DBバックアップ → dumps/
 	$(require_op)
 	@mkdir -p $(DUMPS_DIR)
 	@$(OP_RUN) sh -c '$(assert_prod_db_env); \
 		echo "Backing up production DB ($$DB_NAME)..."; \
-		$(PROD_MYSQL_EXEC)="$$DB_PASSWORD" $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME"' \
+		$(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME"' \
 		| gzip > $(DUMPS_DIR)/production_$(DATE).sql.gz
 	@echo "Done: $(DUMPS_DIR)/production_$(DATE).sql.gz"
 
@@ -107,7 +116,7 @@ db-pull: ## 本番DB → ローカルDB
 	@mkdir -p $(DUMPS_DIR)
 	@$(OP_RUN) sh -c '$(assert_prod_db_env); \
 		echo "Dumping production DB ($$DB_NAME)..."; \
-		$(PROD_MYSQL_EXEC)="$$DB_PASSWORD" $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME"' \
+		$(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME"' \
 		| gzip > $(DUMPS_DIR)/production.sql.gz
 	@echo "Restoring to Docker Compose DB service ($(COMPOSE_DB_SERVICE))..."
 	@APP_SERVICE="$(COMPOSE_APP_SERVICE)" \
@@ -129,17 +138,20 @@ db-push: ## ローカルDB → 本番DB（確認プロンプト + 自動backup�
 	@echo "Dumping Docker Compose local DB ($(LOCAL_DB_NAME))..."
 	@docker compose exec -T -e MYSQL_PWD="$(LOCAL_DB_AUTH)" db mysqldump -u "$(LOCAL_DB_USER)" --single-transaction --routines --triggers --no-tablespaces "$(LOCAL_DB_NAME)" \
 		| gzip > $(DUMPS_DIR)/local.sql.gz
-	@$(OP_RUN) sh -c '$(assert_prod_db_env); \
+	@$(OP_RUN) sh -e -c '$(assert_prod_db_env); \
+		$(assert_prod_db_name_is_identifier); \
 		printf "Type the production DB name (%s) to continue: " "$$DB_NAME"; \
 		read confirm </dev/tty; \
 		[ "$$confirm" = "$$DB_NAME" ] || { echo "Aborted."; exit 1; }; \
 		echo "Auto-backup: production DB..."; \
-		$(PROD_MYSQL_EXEC)="$$DB_PASSWORD" $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME" \
-			| gzip > $(DUMPS_DIR)/production_before_push_$(DATE).sql.gz; \
-		echo "Saved: $(DUMPS_DIR)/production_before_push_$(DATE).sql.gz"; \
+		BACKUP="$(DUMPS_DIR)/production_before_push_$(DATE).sql.gz"; \
+		$(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME" \
+			| gzip > "$$BACKUP"; \
+		gunzip -t "$$BACKUP" || { echo "ERROR: backup is missing or corrupt. Aborting before DROP." >&2; exit 1; }; \
+		echo "Saved: $$BACKUP"; \
 		echo "Restoring to production DB ($$DB_NAME)..."; \
-		$(PROD_MYSQL_EXEC)="$$DB_PASSWORD" $(COMPOSE_DB_SERVICE) mysql -h "$$DB_HOST" -u "$$DB_USER" \
+		$(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysql -h "$$DB_HOST" -u "$$DB_USER" \
 			-e "DROP DATABASE IF EXISTS \`$$DB_NAME\`; CREATE DATABASE \`$$DB_NAME\`;"; \
 		gunzip -c $(DUMPS_DIR)/local.sql.gz \
-			| $(PROD_MYSQL_EXEC)="$$DB_PASSWORD" $(COMPOSE_DB_SERVICE) mysql -h "$$DB_HOST" -u "$$DB_USER" "$$DB_NAME"'
+			| $(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysql -h "$$DB_HOST" -u "$$DB_USER" "$$DB_NAME"'
 	@echo "Done: $(LOCAL_DB_NAME) → production"

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,15 @@ define assert_prod_db_name_is_identifier
 		echo "ERROR: DB_NAME must contain only letters, numbers, and underscores." >&2; exit 1;; esac
 endef
 
+# `mysqldump | gzip` は dump が失敗しても gzip が成功するため、空でも正常な gz が残る。
+# パイプの終了状態には頼らず、生成物にテーブル定義が入っていることで成否を判定する。
+define assert_dump_is_usable
+	@gunzip -t "$(1)" 2>/dev/null || \
+		{ echo "ERROR: $(1) is corrupt or missing." >&2; rm -f "$(1)"; exit 1; }
+	@gunzip -c "$(1)" | grep -q "CREATE TABLE" || \
+		{ echo "ERROR: $(1) has no table definitions (dump likely failed)." >&2; rm -f "$(1)"; exit 1; }
+endef
+
 db-backup: ## 本番DBバックアップ → dumps/
 	$(require_op)
 	@mkdir -p $(DUMPS_DIR)
@@ -102,6 +111,7 @@ db-backup: ## 本番DBバックアップ → dumps/
 		echo "Backing up production DB ($$DB_NAME)..."; \
 		$(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME"' \
 		| gzip > $(DUMPS_DIR)/production_$(DATE).sql.gz
+	$(call assert_dump_is_usable,$(DUMPS_DIR)/production_$(DATE).sql.gz)
 	@echo "Done: $(DUMPS_DIR)/production_$(DATE).sql.gz"
 
 db-backup-local: ## ローカルDBバックアップ → dumps/
@@ -118,6 +128,7 @@ db-pull: ## 本番DB → ローカルDB
 		echo "Dumping production DB ($$DB_NAME)..."; \
 		$(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME"' \
 		| gzip > $(DUMPS_DIR)/production.sql.gz
+	$(call assert_dump_is_usable,$(DUMPS_DIR)/production.sql.gz)
 	@echo "Restoring to Docker Compose DB service ($(COMPOSE_DB_SERVICE))..."
 	@APP_SERVICE="$(COMPOSE_APP_SERVICE)" \
 		DB_SERVICE="$(COMPOSE_DB_SERVICE)" \
@@ -138,7 +149,8 @@ db-push: ## ローカルDB → 本番DB（確認プロンプト + 自動backup�
 	@echo "Dumping Docker Compose local DB ($(LOCAL_DB_NAME))..."
 	@docker compose exec -T -e MYSQL_PWD="$(LOCAL_DB_AUTH)" db mysqldump -u "$(LOCAL_DB_USER)" --single-transaction --routines --triggers --no-tablespaces "$(LOCAL_DB_NAME)" \
 		| gzip > $(DUMPS_DIR)/local.sql.gz
-	@$(OP_RUN) sh -e -c '$(assert_prod_db_env); \
+	$(call assert_dump_is_usable,$(DUMPS_DIR)/local.sql.gz)
+	@$(OP_RUN) bash -e -o pipefail -c '$(assert_prod_db_env); \
 		$(assert_prod_db_name_is_identifier); \
 		printf "Type the production DB name (%s) to continue: " "$$DB_NAME"; \
 		read confirm </dev/tty; \
@@ -147,7 +159,9 @@ db-push: ## ローカルDB → 本番DB（確認プロンプト + 自動backup�
 		BACKUP="$(DUMPS_DIR)/production_before_push_$(DATE).sql.gz"; \
 		$(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME" \
 			| gzip > "$$BACKUP"; \
-		gunzip -t "$$BACKUP" || { echo "ERROR: backup is missing or corrupt. Aborting before DROP." >&2; exit 1; }; \
+		gunzip -t "$$BACKUP" || { echo "ERROR: backup is corrupt. Aborting before DROP." >&2; exit 1; }; \
+		gunzip -c "$$BACKUP" | grep -q "CREATE TABLE" || \
+			{ echo "ERROR: backup has no table definitions. Aborting before DROP." >&2; exit 1; }; \
 		echo "Saved: $$BACKUP"; \
 		echo "Restoring to production DB ($$DB_NAME)..."; \
 		$(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysql -h "$$DB_HOST" -u "$$DB_USER" \

--- a/app/ta_hub/health.py
+++ b/app/ta_hub/health.py
@@ -6,6 +6,9 @@ zombie プロセスへの誤ルーティングを防ぐため、DB と cache の
 設計方針:
 - DB 失敗は致命的なので 503 を返す（probe で外れる）
 - cache 失敗は status を ng にしない（cache 未設定でも生存判定したい）
+- shared_cache は default alias（Cloud Run では DatabaseCache）の可用性を別に返す。
+  cache フィールドは常に LocMem の healthcheck alias を見るため、DatabaseCache の
+  テーブル未作成（migration 未適用）を検知できない。デプロイ前チェックはこちらを見る。
 """
 
 from django.core.cache import caches
@@ -27,8 +30,8 @@ def health_check(request):
     """軽量ヘルスチェック (DB + cache ping)
 
     Returns:
-        JsonResponse: ``{"status": "ok"|"ng", "db": "ok"|"ng", "cache": "ok"|"ng"}``。
-            DB がダウンしている場合のみ 503、それ以外は 200。
+        JsonResponse: ``{"status", "db", "cache", "shared_cache"}`` の各値が
+            ``"ok"|"ng"``。DB がダウンしている場合のみ 503、それ以外は 200。
     """
     checks = {"status": "ok"}
 
@@ -48,6 +51,16 @@ def health_check(request):
     except Exception:
         # cache 未設定環境でも生存判定したいので status は ng にしない
         checks["cache"] = "ng"
+
+    try:
+        # default alias は Cloud Run では DatabaseCache。probe ごとに INSERT すると
+        # Cloud SQL への書き込みが増えるので、読み取りだけで疎通を確かめる
+        # （テーブルが無ければここで例外になる）。
+        caches['default'].get(_HEALTH_CACHE_KEY)
+        checks["shared_cache"] = "ok"
+    except Exception:
+        # レート制限は落ちるがページ表示は生きうるので status は ng にしない
+        checks["shared_cache"] = "ng"
 
     status_code = 200 if checks["status"] == "ok" else 503
     return JsonResponse(checks, status=status_code)

--- a/app/ta_hub/tests/test_health.py
+++ b/app/ta_hub/tests/test_health.py
@@ -28,6 +28,22 @@ class HealthCheckTest(TestCase):
         self.assertEqual(payload['status'], 'ok')
         self.assertEqual(payload['db'], 'ok')
         self.assertEqual(payload['cache'], 'ok')
+        self.assertEqual(payload['shared_cache'], 'ok')
+
+    def test_health_marks_shared_cache_ng_when_default_cache_unavailable(self):
+        """default cache が使えないと shared_cache=ng になる
+
+        Cloud Run の default は DatabaseCache で、テーブル未作成（migration 未適用）だと
+        ここが落ちる。cache フィールドは常に LocMem を見るので検知できない。
+        """
+        with patch('ta_hub.health.caches') as mock_caches:
+            mock_caches.__getitem__.side_effect = Exception('no such table')
+            response = self.client.get('/health')
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content)
+        self.assertEqual(payload['status'], 'ok')
+        self.assertEqual(payload['shared_cache'], 'ng')
 
     def test_health_returns_503_when_db_unreachable(self):
         """DB 切断時は 503 / status=ng / db=ng を返す（probe で外す）"""

--- a/app/website/tests/test_deploy_check_config.py
+++ b/app/website/tests/test_deploy_check_config.py
@@ -26,11 +26,19 @@ class DeployCheckConfigTest(SimpleTestCase):
         ]
 
     def test_migration_check_command_is_read_only(self):
-        """未適用 migration の確認は read-only。deploy-watch が誤って適用しないこと。"""
+        """未適用 migration の確認は read-only。deploy-watch が誤って適用しないこと。
+
+        check_command 自体はスクリプトなので、スクリプト本体が showmigrations だけを
+        実行し migrate を含まないことまで見る。
+        """
         check_command = self.config['migrations']['check_command']
-        self.assertIn('showmigrations', check_command)
-        self.assertNotIn('migrate --noinput', check_command)
-        self.assertNotIn('|migrate|', check_command)
+        self.assertIn('check_pending_migrations.sh', check_command)
+
+        script = REPO_ROOT / 'scripts' / 'check_pending_migrations.sh'
+        body = script.read_text(encoding='utf-8')
+        self.assertIn('showmigrations', body)
+        # 実行対象として migrate を渡す箇所が無いこと（復元用の args 文字列は除く）
+        self.assertNotIn("--args='^|^manage.py|migrate", body)
 
     def test_migration_apply_command_creates_job_first(self):
         """Job 不在でも適用できるよう、作成スクリプトを経由する。"""
@@ -44,22 +52,36 @@ class DeployCheckConfigTest(SimpleTestCase):
         self.assertTrue(checks)
         self.assertTrue(all(check['expect_status'] == 200 for check in checks))
 
-    def test_health_check_asserts_db_and_cache(self):
-        """/health は cache 失敗でも status=ok を返すため、db と cache の値まで見る。
+    def test_health_check_asserts_shared_cache(self):
+        """/health は cache 失敗でも status=ok を返すため、各フィールドの値まで見る。
 
-        DatabaseCache のテーブル未作成（migration 未適用）を status だけでは検知できない。
+        cache フィールドは常に LocMem の healthcheck alias を見るので、
+        DatabaseCache のテーブル未作成（migration 未適用）は shared_cache でしか
+        検知できない。これが無いと、この設定ファイルを追加した意味が無くなる。
         """
         bodies = {
             check['expect_body']
             for check in self._expectations_for('critical', '/health')
         }
         self.assertIn('"db": "ok"', bodies)
-        self.assertIn('"cache": "ok"', bodies)
+        self.assertIn('"shared_cache": "ok"', bodies)
         self.assertIn('"status": "ok"', bodies)
 
-    def test_important_checks_cover_login_and_listings(self):
+    def test_login_page_is_critical(self):
+        """ログイン画面は DatabaseCache に依存するので即時モードでも検証する
+
+        important は --immediate でスキップされる。緊急デプロイでこそ
+        migration 未適用を検知したいので critical に置く。
+        """
+        critical_urls = [check['url'] for check in self._checks('critical')]
+        self.assertTrue(
+            any(url.endswith('/account/login/') for url in critical_urls),
+            '/account/login/ should be a critical check',
+        )
+
+    def test_important_checks_cover_listings(self):
         important_urls = [check['url'] for check in self._checks('important')]
-        for path in ('/account/login/', '/community/list/', '/event/detail/history/'):
+        for path in ('/community/list/', '/event/detail/history/'):
             self.assertTrue(
                 any(url.endswith(path) for url in important_urls),
                 f'{path} should be an important check',

--- a/app/website/tests/test_deploy_check_config.py
+++ b/app/website/tests/test_deploy_check_config.py
@@ -1,0 +1,78 @@
+"""docs/deploy-check.toml（deploy-watch が読むデプロイ前チェック定義）のテスト。"""
+
+import tomllib
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEPLOY_CHECK_PATH = REPO_ROOT / 'docs' / 'deploy-check.toml'
+
+
+class DeployCheckConfigTest(SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.config = tomllib.loads(DEPLOY_CHECK_PATH.read_text(encoding='utf-8'))
+
+    def _checks(self, level):
+        return self.config['checks'][level]
+
+    def _expectations_for(self, level, path_suffix):
+        return [
+            check for check in self._checks(level)
+            if check['url'].endswith(path_suffix)
+        ]
+
+    def test_migration_check_command_is_read_only(self):
+        """未適用 migration の確認は read-only。deploy-watch が誤って適用しないこと。"""
+        check_command = self.config['migrations']['check_command']
+        self.assertIn('showmigrations', check_command)
+        self.assertNotIn('migrate --noinput', check_command)
+        self.assertNotIn('|migrate|', check_command)
+
+    def test_migration_apply_command_creates_job_first(self):
+        """Job 不在でも適用できるよう、作成スクリプトを経由する。"""
+        apply_command = self.config['migrations']['apply_command']
+        self.assertIn('scripts/create_migrate_job.sh', apply_command)
+        self.assertIn('gcloud run jobs execute vrc-ta-hub-migrate', apply_command)
+
+    def test_top_page_is_critical(self):
+        """トップページ 500（今回の事故）を critical で検知する。"""
+        checks = self._expectations_for('critical', 'vrc-ta-hub.com/')
+        self.assertTrue(checks)
+        self.assertTrue(all(check['expect_status'] == 200 for check in checks))
+
+    def test_health_check_asserts_db_and_cache(self):
+        """/health は cache 失敗でも status=ok を返すため、db と cache の値まで見る。
+
+        DatabaseCache のテーブル未作成（migration 未適用）を status だけでは検知できない。
+        """
+        bodies = {
+            check['expect_body']
+            for check in self._expectations_for('critical', '/health')
+        }
+        self.assertIn('"db": "ok"', bodies)
+        self.assertIn('"cache": "ok"', bodies)
+        self.assertIn('"status": "ok"', bodies)
+
+    def test_important_checks_cover_login_and_listings(self):
+        important_urls = [check['url'] for check in self._checks('important')]
+        for path in ('/account/login/', '/community/list/', '/event/detail/history/'):
+            self.assertTrue(
+                any(url.endswith(path) for url in important_urls),
+                f'{path} should be an important check',
+            )
+        self.assertTrue(
+            all(check['expect_status'] == 200 for check in self._checks('important'))
+        )
+
+    def test_check_urls_are_absolute_production_urls(self):
+        """deploy-watch は絶対 URL から path を取り出し canary タグ URL へ差し替える。"""
+        for level in ('critical', 'important'):
+            for check in self._checks(level):
+                self.assertTrue(
+                    check['url'].startswith('https://vrc-ta-hub.com/'),
+                    f"{check['name']}: {check['url']}",
+                )

--- a/docs/deploy-check.toml
+++ b/docs/deploy-check.toml
@@ -25,13 +25,14 @@ complete_checklist = [
 # Cloud Build は migration を自動実行しない（判断記録: docs/research/issue-464-cloud-run-job-migration.md）。
 # 未適用のまま新リビジョンへトラフィックを流すと 500 になるため、切替前に必ずこの確認を通す。
 #
-# check_command は read-only。Cloud Run Job で showmigrations --plan を実行し、
-# 出力は Job のログに出るので check_log_command で読む（`[ ]` 行が未適用）。
+# check_command は read-only（showmigrations --plan）。実行〜ログ読み取り〜判定まで
+# 1コマンドで完結させる。未適用があれば exit 1、ログが取れなければ exit 2 で落とす
+# （取り込み遅延を「未適用ゼロ」と誤認すると今回の事故を素通りさせるため）。
 # Job が存在しない場合は先に ./scripts/create_migrate_job.sh で作成する。
-check_command = "gcloud run jobs execute vrc-ta-hub-migrate --region=asia-northeast1 --project=vrc-ta-hub --wait --args='^|^manage.py|showmigrations|--plan'"
-check_log_command = "gcloud logging read 'resource.type=\"cloud_run_job\" AND resource.labels.job_name=\"vrc-ta-hub-migrate\"' --project=vrc-ta-hub --limit=300 --freshness=10m --format='value(textPayload)' | grep -F '[ ]'"
-# 全アプリ適用（Job のデフォルト引数）。個別に当てる場合は
-# --args='^|^manage.py|migrate|user_account|0016|--noinput' のように実行時上書きする。
+check_command = "./scripts/check_pending_migrations.sh"
+# 全アプリ適用（Job のデフォルト引数）。個別に当てる場合は gcloud run jobs update で
+# --args を差し替えてから execute する（execute --args による実行時上書きは、この環境では
+# API が overrides を受け付けず失敗する）。
 apply_command = "./scripts/create_migrate_job.sh && gcloud run jobs execute vrc-ta-hub-migrate --region=asia-northeast1 --project=vrc-ta-hub --wait"
 
 [[checks.critical]]
@@ -42,13 +43,21 @@ expect_status = 200
 expect_body = "VRChat技術・学術系イベントHub"
 
 # /health は cache 失敗でも status=ok を返す設計（app/ta_hub/health.py）。
-# DatabaseCache のテーブル未作成を status だけでは検知できないため cache まで見る。
 [[checks.critical]]
 name = "ヘルスチェック（DB）"
 url = "https://vrc-ta-hub.com/health"
 method = "GET"
 expect_status = 200
 expect_body = "\"db\": \"ok\""
+
+# migration 未適用（DatabaseCache のテーブル不在）はここでしか検知できない。
+# cache フィールドは常に LocMem の healthcheck alias を見るため、テーブルが無くても ok を返す。
+[[checks.critical]]
+name = "ヘルスチェック（共有キャッシュ）"
+url = "https://vrc-ta-hub.com/health"
+method = "GET"
+expect_status = 200
+expect_body = "\"shared_cache\": \"ok\""
 
 [[checks.critical]]
 name = "ヘルスチェック（cache）"
@@ -57,21 +66,20 @@ method = "GET"
 expect_status = 200
 expect_body = "\"cache\": \"ok\""
 
+# DatabaseCache に実際に依存するため、即時モード（critical のみ実行）でも検知したい。
+[[checks.critical]]
+name = "ログイン画面"
+url = "https://vrc-ta-hub.com/account/login/"
+method = "GET"
+expect_status = 200
+expect_body = "csrfmiddlewaretoken"
+
 [[checks.critical]]
 name = "ヘルスチェック（総合ステータス）"
 url = "https://vrc-ta-hub.com/health"
 method = "GET"
 expect_status = 200
 expect_body = "\"status\": \"ok\""
-
-# ログイン画面は DatabaseCache（login_rate_limit_cache）に依存するため、
-# migration 未適用の検知に効く。
-[[checks.important]]
-name = "ログイン画面"
-url = "https://vrc-ta-hub.com/account/login/"
-method = "GET"
-expect_status = 200
-expect_body = "csrfmiddlewaretoken"
 
 [[checks.important]]
 name = "集会一覧"

--- a/docs/deploy-check.toml
+++ b/docs/deploy-check.toml
@@ -1,0 +1,124 @@
+# deploy-watch project checklist schema (v1)
+# - `complete_checklist`: 監視完了時に満たすべき project-level 条件
+# - `[migrations]`: デプロイ前の未適用 migration 確認・適用コマンド
+# - `[[checks.critical]]`: 全ステージ（即時モード含む）で実行する curl アサーション
+# - `[[checks.important]]`: Stage 2 以降で実行する curl アサーション
+# - `[[log_checks]]`: Cloud Logging で確認する project-level 指標
+# - `[[critical_paths]]`: 重要機能の棚卸し
+#
+# URL は本番の絶対 URL で書く。deploy-watch は新リビジョン検証時に host を
+# canary タグ URL へ差し替えて叩くため、canary 用の URL を別途書く必要はない。
+schema_version = 1
+title = "vrc-ta-hub deploy checklist"
+service = "vrc-ta-hub"
+source_of_truth = true
+
+complete_checklist = [
+  "未適用 migration がゼロであることをトラフィック切替前に確認した",
+  "Critical の curl アサーションを各ステージで実行した",
+  "Important の curl アサーションを Stage 2 以降で実行した",
+  "/health の db と cache がどちらも ok であることを確認した",
+  "5xx が増加していないことを確認した",
+]
+
+[migrations]
+# Cloud Build は migration を自動実行しない（判断記録: docs/research/issue-464-cloud-run-job-migration.md）。
+# 未適用のまま新リビジョンへトラフィックを流すと 500 になるため、切替前に必ずこの確認を通す。
+#
+# check_command は read-only。Cloud Run Job で showmigrations --plan を実行し、
+# 出力は Job のログに出るので check_log_command で読む（`[ ]` 行が未適用）。
+# Job が存在しない場合は先に ./scripts/create_migrate_job.sh で作成する。
+check_command = "gcloud run jobs execute vrc-ta-hub-migrate --region=asia-northeast1 --project=vrc-ta-hub --wait --args='^|^manage.py|showmigrations|--plan'"
+check_log_command = "gcloud logging read 'resource.type=\"cloud_run_job\" AND resource.labels.job_name=\"vrc-ta-hub-migrate\"' --project=vrc-ta-hub --limit=300 --freshness=10m --format='value(textPayload)' | grep -F '[ ]'"
+# 全アプリ適用（Job のデフォルト引数）。個別に当てる場合は
+# --args='^|^manage.py|migrate|user_account|0016|--noinput' のように実行時上書きする。
+apply_command = "./scripts/create_migrate_job.sh && gcloud run jobs execute vrc-ta-hub-migrate --region=asia-northeast1 --project=vrc-ta-hub --wait"
+
+[[checks.critical]]
+name = "トップページ"
+url = "https://vrc-ta-hub.com/"
+method = "GET"
+expect_status = 200
+expect_body = "VRChat技術・学術系イベントHub"
+
+# /health は cache 失敗でも status=ok を返す設計（app/ta_hub/health.py）。
+# DatabaseCache のテーブル未作成を status だけでは検知できないため cache まで見る。
+[[checks.critical]]
+name = "ヘルスチェック（DB）"
+url = "https://vrc-ta-hub.com/health"
+method = "GET"
+expect_status = 200
+expect_body = "\"db\": \"ok\""
+
+[[checks.critical]]
+name = "ヘルスチェック（cache）"
+url = "https://vrc-ta-hub.com/health"
+method = "GET"
+expect_status = 200
+expect_body = "\"cache\": \"ok\""
+
+[[checks.critical]]
+name = "ヘルスチェック（総合ステータス）"
+url = "https://vrc-ta-hub.com/health"
+method = "GET"
+expect_status = 200
+expect_body = "\"status\": \"ok\""
+
+# ログイン画面は DatabaseCache（login_rate_limit_cache）に依存するため、
+# migration 未適用の検知に効く。
+[[checks.important]]
+name = "ログイン画面"
+url = "https://vrc-ta-hub.com/account/login/"
+method = "GET"
+expect_status = 200
+expect_body = "csrfmiddlewaretoken"
+
+[[checks.important]]
+name = "集会一覧"
+url = "https://vrc-ta-hub.com/community/list/"
+method = "GET"
+expect_status = 200
+expect_body = "技術学術系集会一覧"
+
+[[checks.important]]
+name = "発表一覧"
+url = "https://vrc-ta-hub.com/event/detail/history/"
+method = "GET"
+expect_status = 200
+expect_body = "イベント発表履歴"
+
+[[log_checks]]
+name = "5xx エラー"
+filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"vrc-ta-hub\" AND httpRequest.status>=500"
+description = "トラフィック切替前後で 5xx が増えていないことを確認する"
+
+# migration 未適用で DatabaseCache のテーブルが無いと発生する。
+[[log_checks]]
+name = "cache テーブル不在"
+filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"vrc-ta-hub\" AND textPayload=~\"login_rate_limit_cache\""
+description = "DatabaseCache のテーブル未作成（migration 未適用）を検知する"
+
+[[critical_paths]]
+priority = "P0"
+feature = "トップページ /"
+impact = "サイト全体が閲覧不可"
+
+[[critical_paths]]
+priority = "P0"
+feature = "ヘルスチェック /health"
+impact = "Cloud Run がインスタンスを異常判定"
+
+[[critical_paths]]
+priority = "P0"
+feature = "ログイン /account/login/"
+impact = "主催者が集会・発表を管理できない"
+
+[[critical_paths]]
+priority = "P1"
+feature = "集会一覧 /community/list/"
+impact = "集会情報の集約という主目的が果たせない"
+
+[[critical_paths]]
+priority = "P1"
+feature = "発表一覧 /event/detail/history/"
+impact = "発表アーカイブへ到達できない"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,16 +38,20 @@ Jobが存在しない場合は先に作成する。稼働中のCloud Runサー�
 gcloud run jobs execute vrc-ta-hub-migrate \
   --region=asia-northeast1 --project=vrc-ta-hub --wait
 
-# 個別のmigrationだけ当てる場合は実行時に引数を上書きする。
-# 区切りは ^|^ を使う（既定のカンマ区切りだと "manage.py migrate" が壊れる）。
-gcloud run jobs execute vrc-ta-hub-migrate \
-  --region=asia-northeast1 --project=vrc-ta-hub --wait \
+# 個別のmigrationだけ当てる場合はJob定義の引数を差し替えてから実行し、必ず戻す。
+# execute --args による実行時上書きは、この環境ではAPIがoverridesを受け付けず失敗する
+# （Unknown name "priorityTier"）。区切りは ^|^ を使う（既定のカンマ区切りだと壊れる）。
+gcloud run jobs update vrc-ta-hub-migrate \
+  --region=asia-northeast1 --project=vrc-ta-hub \
   --args='^|^manage.py|migrate|user_account|0016|--noinput'
-
-# 未適用の一覧（read-only）。出力はJobのログに出る
 gcloud run jobs execute vrc-ta-hub-migrate \
-  --region=asia-northeast1 --project=vrc-ta-hub --wait \
-  --args='^|^manage.py|showmigrations|--plan'
+  --region=asia-northeast1 --project=vrc-ta-hub --wait
+gcloud run jobs update vrc-ta-hub-migrate \
+  --region=asia-northeast1 --project=vrc-ta-hub \
+  --args='^|^manage.py|migrate|--noinput'
+
+# 未適用の一覧（read-only）。引数の差し替え・復元・ログ判定まで面倒を見る
+./scripts/check_pending_migrations.sh
 ```
 
 デプロイ前チェックの正本は [deploy-check.toml](deploy-check.toml)（deploy-watchが読む）。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,18 +18,53 @@ Google Cloud側のBuild Trigger設定で限定する。GitHub Actionsの`safe-to
 GitHub Actionsの隔離PRゲートは[テスト方針](testing.md#github-actions-の隔離pr承認ゲート)を参照。
 必要なTrigger filterを確認できない環境では、自動deployを有効化しない。
 
-## DatabaseCache migrationの先行適用
+## migration適用用のCloud Run Job
 
-Cloud BuildはDjango migrationを自動実行しない。Cloud Runではログイン失敗回数と
-DRF throttleを複数インスタンス間で共有するため、default cacheが
-`login_rate_limit_cache` テーブルを使う。新revisionにトラフィックを入れる前に
-`user_account.0016_login_rate_limit_cache` を必ず適用する。
+Cloud BuildはDjango migrationを自動実行しない（判断記録:
+[issue-464](research/issue-464-cloud-run-job-migration.md)）。本番migrationは
+Cloud Run Job `vrc-ta-hub-migrate` を人間の判断で実行して適用する。
+
+Jobが存在しない場合は先に作成する。稼働中のCloud Runサービスからイメージ・
+環境変数・シークレット・サービスアカウントを引き継ぐ冪等スクリプトを使う。
 
 ```bash
-gcloud run jobs execute vrc-ta-hub-migrate \
-  --region=asia-northeast1 \
-  --args="migrate,user_account,0016"
+./scripts/create_migrate_job.sh
 ```
+
+適用（全アプリ）と適用状況の確認:
+
+```bash
+# 全アプリのmigrateを適用（Jobのデフォルト引数）
+gcloud run jobs execute vrc-ta-hub-migrate \
+  --region=asia-northeast1 --project=vrc-ta-hub --wait
+
+# 個別のmigrationだけ当てる場合は実行時に引数を上書きする。
+# 区切りは ^|^ を使う（既定のカンマ区切りだと "manage.py migrate" が壊れる）。
+gcloud run jobs execute vrc-ta-hub-migrate \
+  --region=asia-northeast1 --project=vrc-ta-hub --wait \
+  --args='^|^manage.py|migrate|user_account|0016|--noinput'
+
+# 未適用の一覧（read-only）。出力はJobのログに出る
+gcloud run jobs execute vrc-ta-hub-migrate \
+  --region=asia-northeast1 --project=vrc-ta-hub --wait \
+  --args='^|^manage.py|showmigrations|--plan'
+```
+
+デプロイ前チェックの正本は [deploy-check.toml](deploy-check.toml)（deploy-watchが読む）。
+`[migrations]` に上記コマンドを定義してあるため、トラフィック切替前に未適用migrationが
+無いことを必ず確認する。
+
+`user_account.0015_backfill_verified_email_addresses` は所有権が競合するデータ
+（別ユーザーが所有する `EmailAddress` 等）があると監査で停止する。停止した場合は
+所有者を推測して修正せず、[migration-rollback.md](migration-rollback.md#user_account-0015-の適用前監査)
+の監査コマンドで対象を確認してから再実行する。
+
+### DatabaseCache migrationの先行適用
+
+Cloud Runではログイン失敗回数とDRF throttleを複数インスタンス間で共有するため、
+default cacheが `login_rate_limit_cache` テーブルを使う。新revisionにトラフィックを
+入れる前に `user_account.0016_login_rate_limit_cache` を必ず適用する。未適用のまま
+トラフィックを流すと、cacheテーブル不在でトップページが500になる。
 
 実行ログで成功を確認し、`showmigrations user_account`で `0016` が適用済みに
 なってからdeploy・トラフィック切り替えへ進む。新revisionが動作中にこの

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ VRC技術学術ハブの開発、運用、調査メモ、利用ガイドをま�
 ## 開発・運用の基本
 
 - [セットアップ](setup.md)
-- [デプロイ](deployment.md) — [ヘルスチェック](deployment.md#health)
+- [デプロイ](deployment.md) — [ヘルスチェック](deployment.md#health) / [デプロイ前チェック定義](deploy-check.toml)
 - [テスト方針と共有 factory ヘルパー](testing.md)
 - [mypy + django-stubs 段階導入ガイド](mypy.md)
 - [関数リファレンス](functions.md)

--- a/scripts/check_pending_migrations.sh
+++ b/scripts/check_pending_migrations.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# 本番DBの未適用 migration を一覧する（read-only）。
+#
+# Cloud Run Job で showmigrations --plan を実行し、その実行のログだけを読んで
+# `[ ]` 行（未適用）を出す。ログが1行も取れない場合は「未適用ゼロ」ではなく
+# エラーで落とす。取り込み遅延を「問題なし」と誤認すると、未適用のまま
+# トラフィックを流す事故（DatabaseCache のテーブル不在で全ページ 500）に直結する。
+#
+# 出力:
+#   未適用あり -> 該当行を stdout に出して exit 1
+#   未適用なし -> "no pending migrations" を出して exit 0
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-vrc-ta-hub}"
+REGION="${REGION:-asia-northeast1}"
+JOB_NAME="${JOB_NAME:-vrc-ta-hub-migrate}"
+# Cloud Logging は書き込み直後に読めないことがあるため、取得できるまで待つ
+LOG_RETRIES="${LOG_RETRIES:-10}"
+LOG_RETRY_INTERVAL_SEC="${LOG_RETRY_INTERVAL_SEC:-6}"
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 2
+}
+
+command -v gcloud >/dev/null 2>&1 || die "gcloud CLI not found."
+
+gcloud run jobs describe "$JOB_NAME" --project="$PROJECT_ID" --region="$REGION" >/dev/null 2>&1 \
+  || die "Cloud Run job $JOB_NAME not found. Create it with ./scripts/create_migrate_job.sh"
+
+# `gcloud run jobs execute --args` による実行時上書きは、この環境では API 側が
+# overrides を受け付けない（Unknown name "priorityTier"）。Job 定義を一時的に
+# showmigrations へ差し替えて実行し、終了時に必ず元へ戻す。
+ORIGINAL_ARGS="$(
+  gcloud run jobs describe "$JOB_NAME" \
+    --project="$PROJECT_ID" \
+    --region="$REGION" \
+    --format='value[delimiter="|"](spec.template.spec.template.spec.containers[0].args)'
+)"
+[[ -n "$ORIGINAL_ARGS" ]] || die "Could not read current args of $JOB_NAME."
+
+restore_args() {
+  gcloud run jobs update "$JOB_NAME" \
+    --project="$PROJECT_ID" \
+    --region="$REGION" \
+    --args="^|^${ORIGINAL_ARGS}" >/dev/null 2>&1 \
+    || printf 'WARNING: failed to restore args of %s to "%s"\n' "$JOB_NAME" "$ORIGINAL_ARGS" >&2
+}
+trap restore_args EXIT
+
+gcloud run jobs update "$JOB_NAME" \
+  --project="$PROJECT_ID" \
+  --region="$REGION" \
+  --args='^|^manage.py|showmigrations|--plan' >/dev/null 2>&1 \
+  || die "Failed to set showmigrations args on $JOB_NAME."
+
+gcloud run jobs execute "$JOB_NAME" \
+  --project="$PROJECT_ID" \
+  --region="$REGION" \
+  --wait >/dev/null 2>&1 \
+  || die "Failed to execute $JOB_NAME."
+
+EXECUTION="$(
+  gcloud run jobs executions list \
+    --job="$JOB_NAME" \
+    --project="$PROJECT_ID" \
+    --region="$REGION" \
+    --limit=1 \
+    --format='value(name)'
+)"
+[[ -n "$EXECUTION" ]] || die "Could not determine the execution name for $JOB_NAME."
+
+LOG_LINES=""
+for _ in $(seq 1 "$LOG_RETRIES"); do
+  LOG_LINES="$(
+    gcloud logging read \
+      "labels.\"run.googleapis.com/execution_name\"=\"$EXECUTION\"" \
+      --project="$PROJECT_ID" \
+      --limit=500 \
+      --format='value(textPayload)' 2>/dev/null || true
+  )"
+  # showmigrations --plan は必ず [X] か [ ] の行を出す。1行も無ければ未取得とみなす
+  if printf '%s' "$LOG_LINES" | grep -qE '^\[[X ]\]'; then
+    break
+  fi
+  LOG_LINES=""
+  sleep "$LOG_RETRY_INTERVAL_SEC"
+done
+
+[[ -n "$LOG_LINES" ]] \
+  || die "No migration plan found in logs for $EXECUTION. Treating this as unknown, not as zero pending."
+
+PENDING="$(printf '%s\n' "$LOG_LINES" | grep -E '^\[ \]' || true)"
+if [[ -n "$PENDING" ]]; then
+  printf 'pending migrations:\n%s\n' "$PENDING"
+  exit 1
+fi
+
+printf 'no pending migrations\n'

--- a/scripts/create_migrate_job.sh
+++ b/scripts/create_migrate_job.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Cloud Run Job `vrc-ta-hub-migrate` の作成/更新スクリプト（冪等）。
+#
+# Cloud Build は Django migration を自動実行しない方針（docs/research/issue-464-cloud-run-job-migration.md）。
+# 本番 migration はこの Job を人間の判断で実行して適用する。
+#
+# 稼働中の Cloud Run サービスからイメージ・環境変数・シークレット・SA を引き継ぐため、
+# サービス側の設定を変えても Job 定義がずれない（値をこのファイルにハードコードしない）。
+#
+# 使い方:
+#   ./scripts/create_migrate_job.sh                 # 稼働中リビジョンのイメージで作成/更新
+#   IMAGE=<explicit image> ./scripts/create_migrate_job.sh
+#   gcloud run jobs execute vrc-ta-hub-migrate --region=asia-northeast1 --wait
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-vrc-ta-hub}"
+REGION="${REGION:-asia-northeast1}"
+SERVICE_NAME="${SERVICE_NAME:-vrc-ta-hub}"
+JOB_NAME="${JOB_NAME:-vrc-ta-hub-migrate}"
+
+# Job のデフォルト引数は「全アプリの migrate」。個別 migration を当てる時は
+# `gcloud run jobs execute ... --args=...` で実行時に上書きする。
+# 区切りに ^|^ を使うのは、既定のカンマ区切りだと "manage.py migrate" のような
+# カンマ非依存の引数列が壊れる（manage.py,migrate が別扱いされない）ため。
+DEFAULT_ARGS='^|^manage.py|migrate|--noinput'
+
+# migration の多重実行を防ぐ（リトライで同じ migration が並走しないこと優先）
+MAX_RETRIES=0
+TASK_TIMEOUT="10m"
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v gcloud >/dev/null 2>&1 || die "gcloud CLI not found."
+
+describe_service() {
+  gcloud run services describe "$SERVICE_NAME" \
+    --project="$PROJECT_ID" \
+    --region="$REGION" \
+    --format="$1"
+}
+
+if [[ -z "${IMAGE:-}" ]]; then
+  IMAGE="$(describe_service 'value(spec.template.spec.containers[0].image)')" \
+    || die "Could not read image from Cloud Run service $SERVICE_NAME."
+fi
+[[ -n "$IMAGE" ]] || die "Cloud Run service $SERVICE_NAME has no container image."
+
+SERVICE_ACCOUNT="$(describe_service 'value(spec.template.spec.serviceAccountName)')"
+
+# 環境変数の値をログ・プロセス引数に出さないため、--env-vars-file に一時ファイルで渡す。
+# gcloud の出力もファイル経由にする。`python3 -` はスクリプト本体を stdin から読むため、
+# ヒアドキュメントとパイプ入力が衝突して JSON が届かない。
+ENV_VARS_FILE="$(mktemp)"
+SERVICE_ENV_FILE="$(mktemp)"
+trap 'rm -f "$ENV_VARS_FILE" "$SERVICE_ENV_FILE"' EXIT
+chmod 600 "$ENV_VARS_FILE" "$SERVICE_ENV_FILE"
+
+describe_service 'json(spec.template.spec.containers[0].env)' > "$SERVICE_ENV_FILE" \
+  || die "Could not read env from Cloud Run service $SERVICE_NAME."
+
+# env は plain 値と secret 参照が混在する。plain は値を含むので --env-vars-file（一時ファイル）へ、
+# secret 参照は値を含まないので "ENV=SECRET:VERSION" の文字列として stdout へ出す。
+SET_SECRETS="$(
+  ENV_VARS_FILE="$ENV_VARS_FILE" SERVICE_ENV_FILE="$SERVICE_ENV_FILE" python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["SERVICE_ENV_FILE"], encoding="utf-8") as src:
+    doc = json.load(src) or {}
+containers = doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+env = (containers[0].get("env") if containers else None) or []
+
+plain = []
+secrets = []
+for entry in env:
+    name = entry["name"]
+    ref = (entry.get("valueFrom") or {}).get("secretKeyRef")
+    if ref:
+        secrets.append("{}={}:{}".format(name, ref["name"], ref.get("key", "latest")))
+    elif "value" in entry:
+        # gcloud の env-vars-file は YAML。値の解釈ゆれを避けるため JSON 文字列としてクォートする
+        # （JSON は YAML 1.2 のサブセットなので安全に読める）。
+        plain.append("{}: {}".format(json.dumps(name), json.dumps(entry["value"])))
+
+with open(os.environ["ENV_VARS_FILE"], "w", encoding="utf-8") as f:
+    f.write("\n".join(plain) + "\n")
+
+print(",".join(secrets))
+PY
+)"
+
+if gcloud run jobs describe "$JOB_NAME" --project="$PROJECT_ID" --region="$REGION" >/dev/null 2>&1; then
+  ACTION="update"
+else
+  ACTION="create"
+fi
+
+# イメージの CMD は supervisord（Dockerfile 参照）なので --command で python を明示する。
+GCLOUD_ARGS=(
+  run jobs "$ACTION" "$JOB_NAME"
+  --project="$PROJECT_ID"
+  --region="$REGION"
+  --image="$IMAGE"
+  --command=python
+  --args="$DEFAULT_ARGS"
+  --tasks=1
+  --max-retries="$MAX_RETRIES"
+  --task-timeout="$TASK_TIMEOUT"
+  --env-vars-file="$ENV_VARS_FILE"
+)
+
+if [[ -n "$SET_SECRETS" ]]; then
+  GCLOUD_ARGS+=(--set-secrets="$SET_SECRETS")
+fi
+if [[ -n "$SERVICE_ACCOUNT" ]]; then
+  GCLOUD_ARGS+=(--service-account="$SERVICE_ACCOUNT")
+fi
+
+printf '%s Cloud Run Job %s (image: %s)\n' "$ACTION" "$JOB_NAME" "$IMAGE"
+gcloud "${GCLOUD_ARGS[@]}"
+
+printf 'Done. Execute with: gcloud run jobs execute %s --region=%s --project=%s --wait\n' \
+  "$JOB_NAME" "$REGION" "$PROJECT_ID"

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -23,3 +23,8 @@ Django関係のスクリプトはカスタムコマンドとして、各アプ�
 
 - `scripts/db_pull_restore.sh`: `make db-pull` が取得した本番ダンプを Docker Compose の `db` サービスへ復元し、アプリコンテナ経由で代表テーブル件数を検証します。
 - `scripts/tests/test_db_pull_restore.sh`: Docker Compose 呼び出しをモックして、復元先サービス固定・`DB_HOST` 不一致検知・代表テーブル件数検証を確認します。
+
+## デプロイ運用
+
+- `scripts/create_migrate_job.sh`: Cloud Run Job `vrc-ta-hub-migrate` を作成/更新（冪等）。稼働中サービスからイメージ・環境変数・シークレット・SA を引き継ぎます。
+- `scripts/tests/test_deploy_ops_config.sh`: `make -n` の展開結果で本番DBターゲットの `op run` / Compose 経由を検証し、migrate Job スクリプトの必須オプションを静的検証します。

--- a/scripts/tests/test_deploy_ops_config.sh
+++ b/scripts/tests/test_deploy_ops_config.sh
@@ -61,10 +61,18 @@ for target in db-backup db-pull db-push; do
   # op run 経由でなければ op:// 参照がホスト名として渡り接続に失敗する
   assert_expansion_contains "$target" "op run --env-file=.env.production.local --"
   # ホストの MariaDB クライアントは本番 MySQL 8 の認証プラグインに非対応
-  assert_expansion_contains "$target" 'docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" db'
+  assert_expansion_contains "$target" 'docker compose exec -T -e MYSQL_PWD db'
+  # 値付き -e は docker CLI の argv に本番パスワードを平文で載せる（ps から読める）
+  assert_expansion_not_contains "$target" '-e MYSQL_PWD="$DB_PASSWORD"'
   # op が無い環境では分かりやすく落とす
   assert_expansion_contains "$target" "command -v op"
 done
+
+# 本番DBを DROP する前に識別子検証とバックアップ健全性チェックを通す
+assert_expansion_contains db-push "gunzip -t"
+assert_expansion_contains db-push "must contain only letters, numbers, and underscores"
+# 内側 sh に -e が無いと、バックアップ失敗後も DROP DATABASE が続行する
+assert_expansion_contains db-push "sh -e -c"
 
 # ローカルへ流し込むため GTID を落とす
 assert_expansion_contains db-pull "--set-gtid-purged=OFF"

--- a/scripts/tests/test_deploy_ops_config.sh
+++ b/scripts/tests/test_deploy_ops_config.sh
@@ -71,8 +71,14 @@ done
 # 本番DBを DROP する前に識別子検証とバックアップ健全性チェックを通す
 assert_expansion_contains db-push "gunzip -t"
 assert_expansion_contains db-push "must contain only letters, numbers, and underscores"
-# 内側 sh に -e が無いと、バックアップ失敗後も DROP DATABASE が続行する
-assert_expansion_contains db-push "sh -e -c"
+# 内側シェルに -e / pipefail が無いと、バックアップ失敗後も DROP DATABASE が続行する
+assert_expansion_contains db-push "bash -e -o pipefail -c"
+
+# `mysqldump | gzip` は dump が失敗しても gzip 側が成功するため、パイプの終了状態では
+# 空バックアップを検知できない。生成物にテーブル定義があることまで確認する。
+for target in db-backup db-pull db-push; do
+  assert_expansion_contains "$target" "has no table definitions"
+done
 
 # ローカルへ流し込むため GTID を落とす
 assert_expansion_contains db-pull "--set-gtid-purged=OFF"

--- a/scripts/tests/test_deploy_ops_config.sh
+++ b/scripts/tests/test_deploy_ops_config.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# 本番デプロイ運用の定義（Makefile の本番DBターゲット / migrate Job スクリプト）の静的検証。
+# 実際に本番DB・GCP へ接続する検証は行わない。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+MAKEFILE="$REPO_ROOT/Makefile"
+MIGRATE_JOB_SCRIPT="$REPO_ROOT/scripts/create_migrate_job.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1" pattern="$2"
+  grep -Fq -- "$pattern" "$file" || fail "Expected '$pattern' in $(basename "$file")"
+}
+
+assert_file_not_contains() {
+  local file="$1" pattern="$2"
+  if grep -Fq -- "$pattern" "$file"; then
+    fail "Did not expect '$pattern' in $(basename "$file")"
+  fi
+}
+
+# Make の展開結果（実際に走るコマンド列）で検証する。
+# 変数定義の見た目ではなく、ターゲット実行時に何が起きるかが振る舞い。
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+expand_target() {
+  local target="$1"
+  local out="$TMP_DIR/$target.expanded"
+
+  if [[ ! -f "$out" ]]; then
+    make -C "$REPO_ROOT" -n "$target" > "$out" 2>/dev/null \
+      || fail "make -n $target failed"
+  fi
+  printf '%s\n' "$out"
+}
+
+assert_expansion_contains() {
+  local target="$1" pattern="$2"
+  grep -Fq -- "$pattern" "$(expand_target "$target")" \
+    || fail "make -n $target should contain '$pattern'"
+}
+
+assert_expansion_not_contains() {
+  local target="$1" pattern="$2"
+  if grep -Fq -- "$pattern" "$(expand_target "$target")"; then
+    fail "make -n $target should not contain '$pattern'"
+  fi
+}
+
+# --- 課題1: 本番DBターゲットが 1Password 参照を解決し、Compose の db 経由で叩く ---
+
+for target in db-backup db-pull db-push; do
+  # op run 経由でなければ op:// 参照がホスト名として渡り接続に失敗する
+  assert_expansion_contains "$target" "op run --env-file=.env.production.local --"
+  # ホストの MariaDB クライアントは本番 MySQL 8 の認証プラグインに非対応
+  assert_expansion_contains "$target" 'docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" db'
+  # op が無い環境では分かりやすく落とす
+  assert_expansion_contains "$target" "command -v op"
+done
+
+# ローカルへ流し込むため GTID を落とす
+assert_expansion_contains db-pull "--set-gtid-purged=OFF"
+
+# 本番接続で SSL を無効化しない（RDS は SSL 接続を受け付ける）
+assert_expansion_not_contains db-pull "--skip-ssl"
+assert_expansion_not_contains db-backup "--skip-ssl"
+
+# 生値の先読み（op:// がそのまま渡る原因）が残っていないこと
+for var in DB_HOST DB_USER DB_PASSWORD DB_NAME; do
+  assert_file_not_contains "$MAKEFILE" "grep '^${var}=' \"\$(PROD_ENV_FILE)\""
+done
+
+# 依存関係の維持
+assert_file_contains "$MAKEFILE" "db-restore-production-local: db-backup-local db-pull"
+
+# ローカル向けターゲットの挙動は変えない
+assert_expansion_not_contains db-backup-local "op run"
+
+# --- 課題2: migrate Job 作成スクリプト ---
+
+[[ -x "$MIGRATE_JOB_SCRIPT" ]] || fail "create_migrate_job.sh must be executable"
+bash -n "$MIGRATE_JOB_SCRIPT" || fail "create_migrate_job.sh has a syntax error"
+
+# 稼働中サービスから引き継ぐ（ハードコードしない）
+assert_file_contains "$MIGRATE_JOB_SCRIPT" "gcloud run services describe"
+assert_file_contains "$MIGRATE_JOB_SCRIPT" "--service-account="
+assert_file_contains "$MIGRATE_JOB_SCRIPT" "--set-secrets="
+
+# 冪等（あれば update / なければ create）
+assert_file_contains "$MIGRATE_JOB_SCRIPT" "gcloud run jobs describe"
+assert_file_contains "$MIGRATE_JOB_SCRIPT" 'ACTION="update"'
+assert_file_contains "$MIGRATE_JOB_SCRIPT" 'ACTION="create"'
+
+# 既定のカンマ区切りだと manage.py migrate が壊れるため ^|^ を使う
+assert_file_contains "$MIGRATE_JOB_SCRIPT" '^|^manage.py|migrate|--noinput'
+# イメージの CMD は supervisord なので python を明示する
+assert_file_contains "$MIGRATE_JOB_SCRIPT" "--command=python"
+
+# migration の多重実行を防ぐ
+assert_file_contains "$MIGRATE_JOB_SCRIPT" "--max-retries="
+assert_file_contains "$MIGRATE_JOB_SCRIPT" 'TASK_TIMEOUT="10m"'
+
+# 環境変数の値は一時ファイル経由で渡し、確実に削除する
+# （trap の書き方には依存させない。ENV_VARS_FILE が EXIT trap で消えることだけを見る）
+assert_file_contains "$MIGRATE_JOB_SCRIPT" "--env-vars-file="
+if ! grep -E '^trap .*rm -f .*\$ENV_VARS_FILE.* EXIT$' "$MIGRATE_JOB_SCRIPT" >/dev/null; then
+  printf 'FAIL: ENV_VARS_FILE must be removed by an EXIT trap in %s\n' "$MIGRATE_JOB_SCRIPT" >&2
+  exit 1
+fi
+# 値を標準出力・ログに出さない
+assert_file_not_contains "$MIGRATE_JOB_SCRIPT" "--set-env-vars"
+assert_file_not_contains "$MIGRATE_JOB_SCRIPT" 'echo "$ENV_VARS_FILE"'
+
+assert_file_contains "$MIGRATE_JOB_SCRIPT" 'REGION="${REGION:-asia-northeast1}"'
+assert_file_contains "$MIGRATE_JOB_SCRIPT" 'PROJECT_ID="${PROJECT_ID:-vrc-ta-hub}"'
+
+printf 'PASS: deploy ops config (Makefile / create_migrate_job.sh)\n'


### PR DESCRIPTION
## なぜこの変更が必要か

本番デプロイで**トップページが 500 になる事故**が起きた。PR #612 が Cloud Run のキャッシュを DatabaseCache に切り替えたのに、受け皿となる `login_rate_limit_cache` テーブルを作る migration が本番未適用で、キャッシュを触るページが全て落ちていた。

復旧の過程で、運用の仕組みに3つの欠陥が見つかった。いずれも「次も同じ事故が起きる」性質のものなので塞ぐ。

1. **`make db-pull` 等が動かない** — `.env.production.local` の値は 1Password 参照（`op://...`）なのに Makefile は grep で生値を読んでおり、`Unknown MySQL server host 'op://...'` で失敗していた。さらにホストの MariaDB クライアントは本番 MySQL 8 の認証プラグインに非対応
2. **`vrc-ta-hub-migrate` Job が実在しなかった** — `docs/deployment.md` に手順は書かれていたが、`gcloud run jobs list` は空だった
3. **未適用 migration があってもデプロイできてしまう** — 事故の根本原因。切替前に検知する仕組みがなかった

## 変更内容

- **Makefile**: 本番DB系ターゲット（`db-backup` / `db-pull` / `db-push`）を `op run --env-file` 経由にし、本番への mysqldump/mysql を Compose の `db` サービス（MySQL 8 正規クライアント）経由に変更
- **`scripts/create_migrate_job.sh`**: migrate Job を稼働中サービスの設定を引き継いで作成/更新する冪等なスクリプト
- **`scripts/check_pending_migrations.sh`**: 未適用 migration を検知（read-only）。ログが取れない場合は「ゼロ」ではなくエラーで落とす
- **`docs/deploy-check.toml`**: deploy-watch が読むデプロイ前チェックリスト
- **`app/ta_hub/health.py`**: `/health` に `shared_cache` を追加（後述）

## 意思決定

### `/health` に shared_cache を足した理由

これが本 PR の核心。当初 deploy-check.toml で `"cache": "ok"` をアサートしていたが、**それでは今回の事故を検知できない**ことが判明した。

`/health` の `cache` は `caches['healthcheck']`（環境を問わず常に LocMemCache）を見ており、500 の原因だった `default`（Cloud Run では DatabaseCache）を一切触らない。実際に検証した:

```
テーブルを消した状態:
  /health  -> {"status": "ok", "db": "ok", "cache": "ok"}   ← 全部 ok
  トップ   -> ProgrammingError で 500
```

そこで `default` alias の可用性を `shared_cache` として別に返すようにした。probe ごとに Cloud SQL へ INSERT しないよう読み取りだけで確認している。

```
テーブルを消した状態（修正後）:
  /health  -> {..., "cache": "ok", "shared_cache": "ng"}   ← 検知できる
```

### ログイン画面を important → critical に昇格

deploy-watch の `--immediate`（即時モード）は critical のみ実行する。ログイン画面は DatabaseCache に依存するため migration 未適用の検知に効くが、important のままだと**緊急デプロイでこそ検知したい項目が落ちる**配置だった。

### 却下した代替案

- `/health` の cache 失敗で status を ng にする → 却下: cache 未設定環境でも生存判定したいという既存の設計意図を壊す
- `check_command` に execute と ログ読みを2コマンドで書く → 却下: deploy-watch は `check_command` の出力しか見ないため、ログ側の判定が無視されて偽陰性になる

### トレードオフ

`gcloud run jobs execute --args` による実行時上書きは、この環境では API が overrides を受け付けず失敗する（`Unknown name "priorityTier"`）。そのため `check_pending_migrations.sh` は Job 定義を一時的に差し替えて実行し、EXIT trap で必ず復元する方式にした。Job 定義を触る点は美しくないが、実際に動く唯一の経路。

### 技術的負債

- **`scripts/read_deploy_check.py` が未整備**: deploy-watch skill はこのリーダー経由で toml を読む想定だが、本リポには無い（ondoku3 等には存在）。現状は AI が生 toml を読む運用になる
- **`scripts/tests/*.sh` が CI 未接続**: 既存の `test_db_pull_restore.sh` も含め、CI から実行されていない。手元では PASS するが回帰を守れない
- `deploy-check.toml` の `critical_paths` と `checks` が機械的に紐づいていない（`id` / `check_id` が無い）

## テスト

- [x] `event` 含む全2244件中、失敗は `test_nginx_preserves_cloud_run_forwarded_for_chain` の1件のみ。これはコンテナ内に残った古いリポジトリのコピー（`docs/tmp/issue-575-repo/`、gitignore対象）をテストが拾うローカル環境固有のノイズで、本 PR とは無関係（CI では緑）
- [x] `manage.py check` 問題なし
- [x] `scripts/tests/test_deploy_ops_config.sh` / `test_db_pull_restore.sh` とも PASS
- [x] **実地検証**: `op run` 経由で本番DBへ読み取り接続して `CONNECT_OK` を確認（従来はここで失敗していた）
- [x] **実地検証**: `create_migrate_job.sh` を実行して Job を更新し、`No migrations to apply` まで到達
- [x] **実地検証**: `check_pending_migrations.sh` が `no pending migrations` を返し、ログ取得失敗時は exit 2 で落ち、Job 定義が復元されることを確認
- [x] **実地検証**: `shared_cache` がテーブル不在で `ng`、復元で `ok` に戻ることを本番相当データで確認
- [x] deploy-check.toml のアサーション文字列が本番で実際にマッチすることを確認（`shared_cache` のみ本 PR デプロイ後に有効）

## 注意

`docs/deploy-check.toml` の `"shared_cache": "ok"` アサーションは、**本 PR がデプロイされるまで本番では失敗する**（現在の本番 `/health` は `shared_cache` を返さない）。デプロイ順序に注意。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
