### PR TITLE
feat(scripts): deploy-check.toml の読み取り層を追加し、契約テストを CI に接続する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,15 @@ jobs:
           uv pip install --system ruff==0.11.6
           ruff check app/
 
+      # Makefile / 運用スクリプトの契約テスト。make -n の展開結果を検査するだけで
+      # docker / op / gcloud は起動しないため、この軽量ジョブで回せる。
+      - name: Run script contract tests
+        run: |
+          bash scripts/tests/test_deploy_ops_config.sh
+          bash scripts/tests/test_db_pull_restore.sh
+          bash scripts/tests/test_run_tests.sh
+          python -m unittest scripts.tests.test_run_live_smoke
+
   test:
     needs: [isolation-gate, lint]
     runs-on: ubuntu-latest

--- a/app/website/tests/test_deploy_check_config.py
+++ b/app/website/tests/test_deploy_check_config.py
@@ -1,5 +1,6 @@
 """docs/deploy-check.toml（deploy-watch が読むデプロイ前チェック定義）のテスト。"""
 
+import importlib.util
 import tomllib
 from pathlib import Path
 
@@ -98,3 +99,80 @@ class DeployCheckConfigTest(SimpleTestCase):
                     check['url'].startswith('https://vrc-ta-hub.com/'),
                     f"{check['name']}: {check['url']}",
                 )
+
+
+class ReadDeployCheckTest(SimpleTestCase):
+    """scripts/read_deploy_check.py（deploy-watch が読む要約層）のテスト。"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        script_path = REPO_ROOT / 'scripts' / 'read_deploy_check.py'
+        spec = importlib.util.spec_from_file_location('read_deploy_check', script_path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f'could not load {script_path}')
+        cls.reader = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.reader)
+        cls.config = tomllib.loads(DEPLOY_CHECK_PATH.read_text(encoding='utf-8'))
+
+    def test_actual_config_passes_validation(self):
+        """実際の deploy-check.toml が検証を通る（スキーマ違反の早期検知）。"""
+        summary = self.reader.build_summary(self.config, base_dir=REPO_ROOT)
+
+        self.assertEqual(summary['service'], 'vrc-ta-hub')
+        self.assertTrue(summary['selected_checks']['critical'])
+
+    def test_summary_includes_migrations(self):
+        """migrations は要約に含める。読み捨てるとこの設定ファイルの主目的が失われる。"""
+        summary = self.reader.build_summary(self.config, base_dir=REPO_ROOT)
+
+        self.assertIn('migrations', summary)
+        self.assertIn('check_pending_migrations.sh', summary['migrations']['check_command'])
+        self.assertTrue(summary['migrations']['apply_command'])
+
+    def test_migrations_section_is_required(self):
+        config = {key: value for key, value in self.config.items() if key != 'migrations'}
+
+        with self.assertRaises(ValueError):
+            self.reader.build_summary(config)
+
+    def test_check_command_running_migrate_is_rejected(self):
+        """確認のつもりで適用してしまう定義を実行前に落とす。"""
+        config = dict(self.config)
+        config['migrations'] = dict(
+            self.config['migrations'],
+            check_command='gcloud run jobs execute x --args=manage.py,migrate,--noinput',
+        )
+
+        with self.assertRaises(ValueError):
+            self.reader.build_summary(config)
+
+    def test_showmigrations_is_not_rejected(self):
+        """read-only な showmigrations を migrate と誤検知しない。"""
+        config = dict(self.config)
+        config['migrations'] = dict(
+            self.config['migrations'],
+            check_command="gcloud run jobs execute x --args='^|^manage.py|showmigrations|--plan'",
+        )
+
+        summary = self.reader.build_summary(config)
+
+        self.assertIn('showmigrations', summary['migrations']['check_command'])
+
+    def test_missing_referenced_script_is_rejected(self):
+        config = dict(self.config)
+        config['migrations'] = dict(
+            self.config['migrations'], check_command='./scripts/nonexistent.sh'
+        )
+
+        with self.assertRaises(ValueError):
+            self.reader.build_summary(config, base_dir=REPO_ROOT)
+
+    def test_render_text_shows_migrations(self):
+        """テキスト出力にも migrations を出す（AI・人間が目視する経路）。"""
+        summary = self.reader.build_summary(self.config, base_dir=REPO_ROOT)
+
+        rendered = self.reader.render_text(summary)
+
+        self.assertIn('migrations:', rendered)
+        self.assertIn('check_pending_migrations.sh', rendered)

--- a/app/website/tests/test_deploy_check_config.py
+++ b/app/website/tests/test_deploy_check_config.py
@@ -189,6 +189,18 @@ class ReadDeployCheckTest(SimpleTestCase):
         with self.assertRaises(ValueError):
             self.reader.build_summary(config, base_dir=REPO_ROOT)
 
+    def test_malformed_check_entry_is_rejected(self):
+        """スキーマ違反のチェック定義を黙って捨てない。
+
+        捨てると `critical: 0 checks` で成功終了し、本番確認を実行しないまま
+        デプロイが進む。
+        """
+        config = dict(self.config)
+        config['checks'] = dict(self.config['checks'], critical=['https://vrc-ta-hub.com/'])
+
+        with self.assertRaises(ValueError):
+            self.reader.build_summary(config)
+
     def test_script_outside_repository_is_rejected(self):
         """リポジトリ外を指す参照は、実在しても検証の対象外なので落とす。"""
         config = dict(self.config)

--- a/app/website/tests/test_deploy_check_config.py
+++ b/app/website/tests/test_deploy_check_config.py
@@ -168,6 +168,16 @@ class ReadDeployCheckTest(SimpleTestCase):
         with self.assertRaises(ValueError):
             self.reader.build_summary(config, base_dir=REPO_ROOT)
 
+    def test_script_outside_repository_is_rejected(self):
+        """リポジトリ外を指す参照は、実在しても検証の対象外なので落とす。"""
+        config = dict(self.config)
+        config['migrations'] = dict(
+            self.config['migrations'], check_command='./scripts/../../../tmp/evil.sh'
+        )
+
+        with self.assertRaises(ValueError):
+            self.reader.build_summary(config, base_dir=REPO_ROOT)
+
     def test_render_text_shows_migrations(self):
         """テキスト出力にも migrations を出す（AI・人間が目視する経路）。"""
         summary = self.reader.build_summary(self.config, base_dir=REPO_ROOT)

--- a/app/website/tests/test_deploy_check_config.py
+++ b/app/website/tests/test_deploy_check_config.py
@@ -136,28 +136,49 @@ class ReadDeployCheckTest(SimpleTestCase):
         with self.assertRaises(ValueError):
             self.reader.build_summary(config)
 
-    def test_check_command_running_migrate_is_rejected(self):
-        """確認のつもりで適用してしまう定義を実行前に落とす。"""
+    def _with_check_command(self, command):
         config = dict(self.config)
-        config['migrations'] = dict(
-            self.config['migrations'],
-            check_command='gcloud run jobs execute x --args=manage.py,migrate,--noinput',
+        config['migrations'] = dict(self.config['migrations'], check_command=command)
+        return config
+
+    def test_check_command_running_migrate_is_rejected(self):
+        """確認のつもりで適用してしまう定義を実行前に落とす。
+
+        シェルの区切りは `;` `&&` `(` など多様で、許可する区切りを列挙する方式では
+        取りこぼす。区切りに依存せず検知できることを確かめる。
+        """
+        for command in (
+            'python manage.py migrate',
+            './scripts/check_pending_migrations.sh;python manage.py migrate',
+            './scripts/check_pending_migrations.sh && python manage.py migrate',
+            '(cd app && python manage.py migrate)',
+            "gcloud run jobs update x --args='^|^manage.py|migrate|--noinput'",
+        ):
+            with self.subTest(command=command):
+                with self.assertRaises(ValueError):
+                    self.reader.build_summary(self._with_check_command(command))
+
+    def test_check_command_executing_job_is_rejected(self):
+        """Job 名が -migrate で終わる形は migrate 検知をすり抜けるため別に落とす。"""
+        command = (
+            'gcloud run jobs execute vrc-ta-hub-migrate '
+            '--region=asia-northeast1 --project=vrc-ta-hub --wait'
         )
 
         with self.assertRaises(ValueError):
-            self.reader.build_summary(config)
+            self.reader.build_summary(self._with_check_command(command))
 
-    def test_showmigrations_is_not_rejected(self):
-        """read-only な showmigrations を migrate と誤検知しない。"""
-        config = dict(self.config)
-        config['migrations'] = dict(
-            self.config['migrations'],
-            check_command="gcloud run jobs execute x --args='^|^manage.py|showmigrations|--plan'",
-        )
+    def test_read_only_commands_are_not_rejected(self):
+        """read-only なコマンドを migrate と誤検知しない。"""
+        for command in (
+            './scripts/check_pending_migrations.sh',
+            'python manage.py showmigrations --plan',
+            'python manage.py sqlmigrate user_account 0016',
+        ):
+            with self.subTest(command=command):
+                summary = self.reader.build_summary(self._with_check_command(command))
 
-        summary = self.reader.build_summary(config)
-
-        self.assertIn('showmigrations', summary['migrations']['check_command'])
+                self.assertEqual(summary['migrations']['check_command'], command)
 
     def test_missing_referenced_script_is_rejected(self):
         config = dict(self.config)

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -27,4 +27,6 @@ Django関係のスクリプトはカスタムコマンドとして、各アプ�
 ## デプロイ運用
 
 - `scripts/create_migrate_job.sh`: Cloud Run Job `vrc-ta-hub-migrate` を作成/更新（冪等）。稼働中サービスからイメージ・環境変数・シークレット・SA を引き継ぎます。
+- `scripts/check_pending_migrations.sh`: 本番の未適用 migration を一覧（read-only）。未適用ありで exit 1、ログが取れなければ exit 2 で落とします。
+- `scripts/read_deploy_check.py`: `docs/deploy-check.toml` を検証して要約を出力（deploy-watch が読む層）。`[migrations]` の必須項目と `check_command` の read-only 性を実行前に確認します。
 - `scripts/tests/test_deploy_ops_config.sh`: `make -n` の展開結果で本番DBターゲットの `op run` / Compose 経由を検証し、migrate Job スクリプトの必須オプションを静的検証します。

--- a/scripts/read_deploy_check.py
+++ b/scripts/read_deploy_check.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Read deploy-check.toml and print a normalized summary.
+
+deploy-watch skill が生 TOML を目視で解釈するのを避け、スキーマ違反を実行前に
+落とすための読み取り層。
+
+vrc-ta-hub 固有の要件として `[migrations]` を必ず要約に含める。未適用 migration の
+確認はこのプロジェクトのデプロイ事故（DatabaseCache のテーブル未作成で全ページ 500）を
+防ぐ中心的な手段なので、読み捨てると設定ファイルを置く意味が無くなる。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+CHECK_SECTIONS = ("critical", "important", "conditional", "internal", "static_integrity")
+
+# log-based metric 名は gcloud の識別子制約に合わせる
+METRIC_NAME_RE = re.compile(r"[A-Za-z0-9_]{1,100}")
+# log_check 名は gcloud のフラグ引数へ渡るため、引用符・バックスラッシュ・制御文字を拒否する
+# （バックスラッシュを許すとエスケープで引用符を持ち込めてしまう）
+LOG_CHECK_NAME_RE = re.compile(r"[^\"'`\\\x00-\x1f\x7f]{1,200}")
+
+# check_command は read-only でなければならない。deploy-watch は切替前にこれを実行するため、
+# migrate が混ざると「確認のつもりで適用してしまう」事故になる。
+# 区切りにカンマ・= も含めるのは、gcloud の --args=manage.py,migrate,--noinput 形式を
+# 見落とさないため。create_migrate_job.sh のようにファイル名へ含まれる場合は検知しない。
+MIGRATE_TOKEN_RE = re.compile(r"""(?:^|[\s|/'",=])migrate(?:$|[\s|'",])""")
+
+
+def _ensure_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as fh:
+        data = tomllib.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError("TOML root must be a table")
+    return data
+
+
+def _matches_watch_path(check: dict[str, Any], watch_path: str | None) -> bool:
+    patterns = [str(value) for value in _ensure_list(check.get("watch_path_contains"))]
+    if not patterns:
+        return True
+    if not watch_path:
+        return False
+    return any(pattern in watch_path for pattern in patterns)
+
+
+def _matches_service(check: dict[str, Any], service_name: str | None) -> bool:
+    allowed = [str(value) for value in _ensure_list(check.get("only_when_service_in"))]
+    if not allowed:
+        return True
+    if not service_name:
+        return False
+    return service_name in allowed
+
+
+def _normalize_checks(config: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    checks = config.get("checks") or {}
+    if not isinstance(checks, dict):
+        return {section: [] for section in CHECK_SECTIONS}
+
+    normalized: dict[str, list[dict[str, Any]]] = {}
+    for section in CHECK_SECTIONS:
+        items = checks.get(section) or []
+        if isinstance(items, dict):
+            items = [items]
+        normalized[section] = [item for item in items if isinstance(item, dict)]
+    return normalized
+
+
+def _select_checks(
+    checks: dict[str, list[dict[str, Any]]],
+    watch_path: str | None,
+    service_name: str | None,
+) -> dict[str, list[dict[str, Any]]]:
+    selected: dict[str, list[dict[str, Any]]] = {}
+    for section, items in checks.items():
+        selected[section] = [
+            item
+            for item in items
+            if _matches_watch_path(item, watch_path) and _matches_service(item, service_name)
+        ]
+    return selected
+
+
+def resolve_migrations(config: dict[str, Any], base_dir: Path | None = None) -> dict[str, Any]:
+    """Validate and return the [migrations] contract.
+
+    未適用 migration の確認手段が欠けたり、確認のつもりで適用してしまう定義を
+    実行前に落とす。base_dir を渡すと、参照するスクリプトの実在も確認する。
+    """
+    migrations = config.get("migrations")
+    if not isinstance(migrations, dict):
+        raise ValueError("migrations must be a table")
+
+    for key in ("check_command", "apply_command"):
+        value = migrations.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"migrations.{key} is required and must be a non-empty string")
+
+    check_command = str(migrations["check_command"])
+    if MIGRATE_TOKEN_RE.search(check_command):
+        raise ValueError(
+            "migrations.check_command must be read-only, but it runs migrate: "
+            f"{check_command!r}"
+        )
+
+    if base_dir is not None:
+        for script in _referenced_scripts(check_command):
+            if not (base_dir / script).exists():
+                raise ValueError(f"migrations.check_command references a missing script: {script}")
+
+    return dict(migrations)
+
+
+def _referenced_scripts(command: str) -> list[str]:
+    """コマンド文字列から ./scripts/*.sh 形式の参照を拾う。"""
+    return re.findall(r"\./(scripts/[\w./-]+\.sh)", command)
+
+
+def resolve_absence_alerts(config: dict[str, Any]) -> list[dict[str, Any]]:
+    """Resolve absence_alerts by expanding their referenced log_checks filter.
+
+    Fail fast when a referenced log_check name does not exist: silently
+    degrading to an empty filter would turn a monitoring gap into a green run.
+    """
+    alerts = _ensure_list(config.get("absence_alerts"))
+    log_checks = [item for item in _ensure_list(config.get("log_checks")) if isinstance(item, dict)]
+    by_name = {str(item.get("name")): item for item in log_checks if item.get("name")}
+
+    resolved: list[dict[str, Any]] = []
+    for alert in alerts:
+        if not isinstance(alert, dict):
+            raise ValueError("absence_alerts entries must be tables")
+        name = alert.get("log_check")
+        if not name:
+            raise ValueError("absence_alerts entry requires log_check")
+        if not LOG_CHECK_NAME_RE.fullmatch(str(name)):
+            raise ValueError(f"absence_alerts log_check name has invalid characters: {name!r}")
+        source = by_name.get(str(name))
+        if source is None:
+            raise ValueError(f"absence_alerts references unknown log_check: {name}")
+        log_filter = source.get("filter")
+        if not log_filter:
+            raise ValueError(f"log_check {name} has no filter to expand")
+        metric_name = alert.get("metric_name")
+        if not metric_name:
+            raise ValueError(f"absence_alerts for {name} requires metric_name")
+        if not METRIC_NAME_RE.fullmatch(str(metric_name)):
+            raise ValueError(
+                f"absence_alerts metric_name must match {METRIC_NAME_RE.pattern}: {metric_name!r}"
+            )
+        duration = alert.get("absence_duration_s")
+        # bool は int のサブクラスなので type() で厳密に判定する
+        if type(duration) is not int or duration <= 0:
+            raise ValueError(
+                f"absence_alerts for {name} requires positive integer absence_duration_s"
+            )
+        resolved.append(
+            {
+                **alert,
+                "filter": log_filter,
+                "log_check_kind": source.get("kind"),
+                "log_check_description": source.get("description"),
+            }
+        )
+    return resolved
+
+
+def build_summary(
+    config: dict[str, Any],
+    watch_path: str | None = None,
+    service_name: str | None = None,
+    base_dir: Path | None = None,
+) -> dict[str, Any]:
+    checks = _normalize_checks(config)
+    selected_checks = _select_checks(checks, watch_path, service_name)
+    return {
+        "schema_version": config.get("schema_version"),
+        "title": config.get("title"),
+        "service": config.get("service"),
+        "source_of_truth": config.get("source_of_truth", False),
+        "complete_checklist": _ensure_list(config.get("complete_checklist")),
+        "migrations": resolve_migrations(config, base_dir),
+        "checks": checks,
+        "selected_checks": selected_checks,
+        "log_checks": _ensure_list(config.get("log_checks")),
+        "absence_alerts": resolve_absence_alerts(config),
+        "critical_paths": _ensure_list(config.get("critical_paths")),
+        "watch_path": watch_path,
+        "service_name": service_name,
+    }
+
+
+def _format_check(check: dict[str, Any]) -> str:
+    identifier = check.get("id") or check.get("name") or "(unnamed)"
+    name = check.get("name")
+    # static_integrity は起点がページなので url ではなく page_url を持つ
+    url = check.get("url") or check.get("page_url")
+    parts = [str(identifier)]
+    if name and str(name) != str(identifier):
+        parts.append(str(name))
+    if url:
+        parts.append(f"[{url}]")
+    return " ".join(parts)
+
+
+def render_text(summary: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append(f"title: {summary.get('title') or '-'}")
+    lines.append(f"service: {summary.get('service') or '-'}")
+    lines.append(f"schema_version: {summary.get('schema_version') or '-'}")
+    lines.append(f"source_of_truth: {summary.get('source_of_truth')}")
+
+    migrations = summary.get("migrations") or {}
+    lines.append("migrations:")
+    for key in ("check_command", "apply_command"):
+        lines.append(f"  - {key} = {migrations.get(key)}")
+
+    checklist = summary.get("complete_checklist") or []
+    lines.append(f"complete_checklist: {len(checklist)} items")
+    for item in checklist:
+        lines.append(f"  - {item}")
+
+    checks = summary.get("selected_checks") or {}
+    for section in CHECK_SECTIONS:
+        items = checks.get(section) or []
+        lines.append(f"{section}: {len(items)} checks")
+        for item in items:
+            lines.append(f"  - {_format_check(item)}")
+
+    log_checks = summary.get("log_checks") or []
+    lines.append(f"log_checks: {len(log_checks)} entries")
+    for item in log_checks:
+        if isinstance(item, dict):
+            kind = item.get("kind", "log")
+            lines.append(f"  - {item.get('name', '(unnamed)')} [{kind}]")
+
+    absence_alerts = summary.get("absence_alerts") or []
+    lines.append(f"absence_alerts: {len(absence_alerts)} entries")
+    for item in absence_alerts:
+        if isinstance(item, dict):
+            duration = item.get("absence_duration_s")
+            lines.append(f"  - {item.get('metric_name')} <- {item.get('log_check')} ({duration}s)")
+
+    critical_paths = summary.get("critical_paths") or []
+    lines.append(f"critical_paths: {len(critical_paths)} entries")
+    for item in critical_paths:
+        if isinstance(item, dict):
+            priority = item.get("priority", "?")
+            feature = item.get("feature", "(unnamed)")
+            lines.append(f"  - {priority} {feature}")
+
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="docs/deploy-check.toml",
+        help="Path to deploy-check TOML (default: docs/deploy-check.toml)",
+    )
+    parser.add_argument(
+        "--watch-path",
+        help="Filter conditional checks by WATCH_PATH",
+    )
+    parser.add_argument(
+        "--service-name",
+        help="Filter service-specific checks by service name",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    path = Path(args.path)
+    config = _load_toml(path)
+    # スクリプト参照はリポジトリルート基準で解決する
+    summary = build_summary(
+        config,
+        watch_path=args.watch_path,
+        service_name=args.service_name,
+        base_dir=path.resolve().parent.parent,
+    )
+
+    if args.format == "json":
+        print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(render_text(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except FileNotFoundError as exc:
+        print(f"deploy-check file not found: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    except tomllib.TOMLDecodeError as exc:
+        print(f"failed to parse deploy-check TOML: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    except ValueError as exc:
+        print(f"invalid deploy-check contract: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/read_deploy_check.py
+++ b/scripts/read_deploy_check.py
@@ -73,14 +73,23 @@ def _matches_service(check: dict[str, Any], service_name: str | None) -> bool:
 def _normalize_checks(config: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
     checks = config.get("checks") or {}
     if not isinstance(checks, dict):
-        return {section: [] for section in CHECK_SECTIONS}
+        raise ValueError("checks must be a table")
 
     normalized: dict[str, list[dict[str, Any]]] = {}
     for section in CHECK_SECTIONS:
         items = checks.get(section) or []
         if isinstance(items, dict):
             items = [items]
-        normalized[section] = [item for item in items if isinstance(item, dict)]
+        if not isinstance(items, list):
+            raise ValueError(f"checks.{section} must be an array of tables")
+        # スキーマ違反の要素を黙って捨てると `critical: 0 checks` で成功終了し、
+        # 本番確認を実行しないままデプロイが進む。設定ミスとして落とす。
+        for item in items:
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"checks.{section} entries must be tables, got {type(item).__name__}"
+                )
+        normalized[section] = list(items)
     return normalized
 
 

--- a/scripts/read_deploy_check.py
+++ b/scripts/read_deploy_check.py
@@ -121,8 +121,16 @@ def resolve_migrations(config: dict[str, Any], base_dir: Path | None = None) -> 
         )
 
     if base_dir is not None:
+        root = base_dir.resolve()
         for script in _referenced_scripts(check_command):
-            if not (base_dir / script).exists():
+            target = (root / script).resolve()
+            # `./scripts/../../x.sh` のようにリポジトリ外を指す参照は、
+            # 実在してもこの検証の対象外なので設定ミスとして落とす。
+            if not target.is_relative_to(root):
+                raise ValueError(
+                    f"migrations.check_command references a script outside the repository: {script}"
+                )
+            if not target.exists():
                 raise ValueError(f"migrations.check_command references a missing script: {script}")
 
     return dict(migrations)
@@ -298,12 +306,13 @@ def main() -> int:
     args = parse_args()
     path = Path(args.path)
     config = _load_toml(path)
-    # スクリプト参照はリポジトリルート基準で解決する
+    # スクリプト参照はリポジトリルート基準で解決する。toml のパスから逆算すると
+    # 別ディレクトリの toml を渡したときに基準がずれるため、このファイルの位置を使う。
     summary = build_summary(
         config,
         watch_path=args.watch_path,
         service_name=args.service_name,
-        base_dir=path.resolve().parent.parent,
+        base_dir=Path(__file__).resolve().parent.parent,
     )
 
     if args.format == "json":

--- a/scripts/read_deploy_check.py
+++ b/scripts/read_deploy_check.py
@@ -30,9 +30,10 @@ LOG_CHECK_NAME_RE = re.compile(r"[^\"'`\\\x00-\x1f\x7f]{1,200}")
 
 # check_command は read-only でなければならない。deploy-watch は切替前にこれを実行するため、
 # migrate が混ざると「確認のつもりで適用してしまう」事故になる。
-# 区切りにカンマ・= も含めるのは、gcloud の --args=manage.py,migrate,--noinput 形式を
-# 見落とさないため。create_migrate_job.sh のようにファイル名へ含まれる場合は検知しない。
-MIGRATE_TOKEN_RE = re.compile(r"""(?:^|[\s|/'",=])migrate(?:$|[\s|'",])""")
+# 許可する区切りを列挙する方式は `;migrate` `&&migrate` `(migrate)` を取りこぼすため、
+# 「前後が識別子の一部でない」ことだけを条件にする。これで showmigrations / sqlmigrate や
+# create_migrate_job.sh のようにファイル名へ含まれる場合は検知しない。
+MIGRATE_TOKEN_RE = re.compile(r"(?<![\w./-])migrate(?![\w-])")
 
 
 def _ensure_list(value: Any) -> list[Any]:
@@ -118,6 +119,13 @@ def resolve_migrations(config: dict[str, Any], base_dir: Path | None = None) -> 
         raise ValueError(
             "migrations.check_command must be read-only, but it runs migrate: "
             f"{check_command!r}"
+        )
+    # Job 名が `-migrate` で終わる（apply_command をコピペした形）と上の検知をすり抜ける。
+    # 確認は showmigrations を実行するスクリプト経由に限る、という契約を明示する。
+    if "jobs execute" in check_command:
+        raise ValueError(
+            "migrations.check_command must not execute a Cloud Run job directly; "
+            f"use a read-only script instead: {check_command!r}"
         )
 
     if base_dir is not None:


### PR DESCRIPTION
## なぜこの変更が必要か

PR #616 で本番デプロイ事故（未適用 migration により全ページ 500）の再発防止策を入れた際、技術的負債を2件残していた。それを解消する。

1. **`scripts/read_deploy_check.py` が無い** — deploy-watch skill は「このスクリプトで `deploy-check.toml` の要約を得る」と定めているが本リポに存在せず、AI が生 TOML を目視で解釈していた。スキーマ違反を実行前に落とす層が丸ごと欠けている
2. **`scripts/tests/*.sh` が CI 未接続** — 4本あるのに `.github/workflows/ci.yml` から実行されず、「テストがあるのに回帰を守れない」状態だった

## 変更内容

- **`scripts/read_deploy_check.py`（新規）**: `docs/deploy-check.toml` を検証して要約を出力。標準ライブラリのみ（`tomllib` 等）
- **`.github/workflows/ci.yml`**: lint job で `scripts/tests/` の4本を実行
- **`app/website/tests/test_deploy_check_config.py`**: reader のテストを追加（`ReadDeployCheckTest`）

## 意思決定

### 移植元に mojiokoshi 版を選んだ理由

既存実装は ondoku3（515行）と mojiokoshi（337行）にある。**ondoku3 版は汎用パーサではなく専用のコントラクト検証器**で、`service == "ondoku3"` がハードコードされている。そのまま持ってくると `invalid deploy-check contract: service must be 'ondoku3'` で即死する。vrc-ta-hub の toml は mojiokoshi 版に近い構造（`id` なし・`expect_body` 単数）なので、そちらをベースにプロジェクト固有の定期実行スコープ制御を削った。

### `[migrations]` の検証を足した理由（ここが本題）

**既存2プロジェクトの reader はどちらも `[migrations]` を読み捨てる。** vrc-ta-hub にとってこのセクションは事故の再発防止そのものなので、読めないなら reader を置く意味が薄い。要約に含めたうえで次を検証する:

- `check_command` / `apply_command` が存在すること
- `check_command` が read-only であること（migrate を実行する定義を落とす）
- 参照するスクリプトがリポジトリ内に実在すること

### CI は lint job に相乗り

`make -n` の展開結果を文字列検査するだけで docker / op / gcloud を起動しないため、Docker 不要で数十秒の lint job に載せた。専用ジョブを切ると checkout と Python setup のオーバーヘッドが丸々増えるだけになる。docker 不在の環境でも `make -n` が正常に展開されることは確認済み。

### 技術的負債

- `_referenced_scripts` は `./scripts/x.sh` 形式のみ拾い、`bash scripts/x.sh` や絶対パス指定は実在確認をスキップする（fail-open）。ただし漏れても `check_command` 実行時に "No such file" で落ちるため深刻度は低い
- `ruff check` のスコープが `app/` なので `scripts/read_deploy_check.py` は lint 対象外。広げると既存の `scripts/*.py` が引っかかる可能性があり別 PR 向き
- `id` / `check_id` 体系（ondoku3 相当の参照整合性検証）は未導入。toml 側の改修が必要で、`critical_paths` の一部が important にしか対応チェックを持たない設計判断も伴う

## テスト

- [x] `ReadDeployCheckTest` 9件を追加。実際の toml が通ること、migrations の欠落・migrate 混入・Job 直接実行・参照スクリプト不在・リポジトリ外参照が落ちること
- [x] `website` の145件中、失敗は `test_nginx_preserves_cloud_run_forwarded_for_chain` の1件のみ。コンテナ内に残った古いリポジトリのコピー（`docs/tmp/issue-575-repo/`、gitignore対象）をテストが拾うローカル固有のノイズで、CI では緑
- [x] `ruff check app/` パス
- [x] shell テスト4本ともローカルで PASS
- [x] **実地検証**: CLI で実際の toml を読ませ、`migrations` が要約に出ることを確認。`apply_command` をコピペした形が落ちることも確認

## レビューで直した点

コードレビューとセキュリティレビューの双方から、**`MIGRATE_TOKEN_RE` が区切り文字を取りこぼす**指摘を受けた。許可する区切りを列挙する方式だったため、シェルで最もありふれた `;migrate` `&&migrate` `(migrate)` と末尾改行が素通りしていた（実測で確認）。

「前後が識別子の一部でない」ことだけを条件にする否定先読みへ反転し、区切りに依存せず検知できるようにした。あわせて Job 名が `-migrate` で終わる形（`apply_command` のコピペ）がハイフン区切りで検知をすり抜ける件に対し、`check_command` での Job 直接実行を別途拒否している。

パストラバーサル（`./scripts/../../x.sh`）でリポジトリ外を参照できる点も、実在確認の基準がずれる不具合とあわせて修正した。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
