### PR TITLE
feat(deploy): 棚卸しと実チェックを check_id で紐づけ、残る負債を解消する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run ruff lint
         run: |
           uv pip install --system ruff==0.11.6
-          ruff check app/
+          ruff check app/ scripts/
 
       # Makefile / 運用スクリプトの契約テスト。make -n の展開結果を検査するだけで
       # docker / op / gcloud は起動しないため、この軽量ジョブで回せる。

--- a/app/website/tests/test_deploy_check_config.py
+++ b/app/website/tests/test_deploy_check_config.py
@@ -250,14 +250,20 @@ class ReadDeployCheckTest(SimpleTestCase):
             self.reader.build_summary(config)
 
     def test_script_outside_repository_is_rejected(self):
-        """リポジトリ外を指す参照は、実在しても検証の対象外なので落とす。"""
-        config = dict(self.config)
-        config['migrations'] = dict(
-            self.config['migrations'], check_command='./scripts/../../../tmp/evil.sh'
-        )
+        """リポジトリ外を指す参照は、実在しても検証の対象外なので落とす。
 
-        with self.assertRaises(ValueError):
-            self.reader.build_summary(config, base_dir=REPO_ROOT)
+        絶対パス指定は、リポジトリ内に同名ファイルがあると実在確認をすり抜けやすい
+        （実行されるのは外部のスクリプトなのに設定が受理される）。
+        """
+        for command in (
+            './scripts/../../../tmp/evil.sh',
+            '/tmp/scripts/check_pending_migrations.sh',
+        ):
+            with self.subTest(command=command):
+                with self.assertRaises(ValueError):
+                    self.reader.build_summary(
+                        self._with_check_command(command), base_dir=REPO_ROOT
+                    )
 
     def test_render_text_shows_migrations(self):
         """テキスト出力にも migrations を出す（AI・人間が目視する経路）。"""

--- a/app/website/tests/test_deploy_check_config.py
+++ b/app/website/tests/test_deploy_check_config.py
@@ -1,5 +1,6 @@
 """docs/deploy-check.toml（deploy-watch が読むデプロイ前チェック定義）のテスト。"""
 
+import copy
 import importlib.util
 import tomllib
 from pathlib import Path
@@ -188,6 +189,53 @@ class ReadDeployCheckTest(SimpleTestCase):
 
         with self.assertRaises(ValueError):
             self.reader.build_summary(config, base_dir=REPO_ROOT)
+
+    def test_critical_paths_resolve_to_actual_checks(self):
+        """棚卸しが実チェックと機械的に紐づく（飾りにしない）。"""
+        summary = self.reader.build_summary(self.config, base_dir=REPO_ROOT)
+
+        paths = summary['critical_paths']
+        self.assertTrue(paths)
+        for path in paths:
+            self.assertTrue(path['check_url'], f"{path['feature']} should resolve to a check URL")
+
+    def test_broken_check_id_reference_is_rejected(self):
+        """チェックを消しても棚卸しだけ残る状態を落とす。"""
+        config = copy.deepcopy(self.config)
+        config['critical_paths'][0]['check_id'] = 'NO_SUCH_ID'
+
+        with self.assertRaises(ValueError):
+            self.reader.build_summary(config)
+
+    def test_duplicate_check_id_is_rejected(self):
+        config = copy.deepcopy(self.config)
+        config['checks']['critical'][1]['id'] = config['checks']['critical'][0]['id']
+
+        with self.assertRaises(ValueError):
+            self.reader.build_summary(config)
+
+    def test_check_without_id_is_rejected(self):
+        config = copy.deepcopy(self.config)
+        del config['checks']['critical'][0]['id']
+
+        with self.assertRaises(ValueError):
+            self.reader.build_summary(config)
+
+    def test_missing_script_is_detected_in_common_notations(self):
+        """`./` 無しや絶対パス指定でも実在確認が働く（fail-open の解消）。
+
+        拾えない記法があると、タイポが黙って検証をすり抜ける。
+        """
+        for command in (
+            './scripts/nonexistent.sh',
+            'bash scripts/nonexistent.sh',
+            '/repo/scripts/nonexistent.sh',
+        ):
+            with self.subTest(command=command):
+                with self.assertRaises(ValueError):
+                    self.reader.build_summary(
+                        self._with_check_command(command), base_dir=REPO_ROOT
+                    )
 
     def test_malformed_check_entry_is_rejected(self):
         """スキーマ違反のチェック定義を黙って捨てない。

--- a/docs/deploy-check.toml
+++ b/docs/deploy-check.toml
@@ -36,6 +36,7 @@ check_command = "./scripts/check_pending_migrations.sh"
 apply_command = "./scripts/create_migrate_job.sh && gcloud run jobs execute vrc-ta-hub-migrate --region=asia-northeast1 --project=vrc-ta-hub --wait"
 
 [[checks.critical]]
+id = "C1"
 name = "トップページ"
 url = "https://vrc-ta-hub.com/"
 method = "GET"
@@ -44,6 +45,7 @@ expect_body = "VRChat技術・学術系イベントHub"
 
 # /health は cache 失敗でも status=ok を返す設計（app/ta_hub/health.py）。
 [[checks.critical]]
+id = "C2"
 name = "ヘルスチェック（DB）"
 url = "https://vrc-ta-hub.com/health"
 method = "GET"
@@ -53,6 +55,7 @@ expect_body = "\"db\": \"ok\""
 # migration 未適用（DatabaseCache のテーブル不在）はここでしか検知できない。
 # cache フィールドは常に LocMem の healthcheck alias を見るため、テーブルが無くても ok を返す。
 [[checks.critical]]
+id = "C3"
 name = "ヘルスチェック（共有キャッシュ）"
 url = "https://vrc-ta-hub.com/health"
 method = "GET"
@@ -60,6 +63,7 @@ expect_status = 200
 expect_body = "\"shared_cache\": \"ok\""
 
 [[checks.critical]]
+id = "C4"
 name = "ヘルスチェック（cache）"
 url = "https://vrc-ta-hub.com/health"
 method = "GET"
@@ -68,6 +72,7 @@ expect_body = "\"cache\": \"ok\""
 
 # DatabaseCache に実際に依存するため、即時モード（critical のみ実行）でも検知したい。
 [[checks.critical]]
+id = "C5"
 name = "ログイン画面"
 url = "https://vrc-ta-hub.com/account/login/"
 method = "GET"
@@ -75,6 +80,7 @@ expect_status = 200
 expect_body = "csrfmiddlewaretoken"
 
 [[checks.critical]]
+id = "C6"
 name = "ヘルスチェック（総合ステータス）"
 url = "https://vrc-ta-hub.com/health"
 method = "GET"
@@ -82,6 +88,7 @@ expect_status = 200
 expect_body = "\"status\": \"ok\""
 
 [[checks.important]]
+id = "I1"
 name = "集会一覧"
 url = "https://vrc-ta-hub.com/community/list/"
 method = "GET"
@@ -89,6 +96,7 @@ expect_status = 200
 expect_body = "技術学術系集会一覧"
 
 [[checks.important]]
+id = "I2"
 name = "発表一覧"
 url = "https://vrc-ta-hub.com/event/detail/history/"
 method = "GET"
@@ -108,25 +116,30 @@ description = "DatabaseCache のテーブル未作成（migration 未適用）�
 
 [[critical_paths]]
 priority = "P0"
+check_id = "C1"
 feature = "トップページ /"
 impact = "サイト全体が閲覧不可"
 
 [[critical_paths]]
 priority = "P0"
+check_id = "C3"
 feature = "ヘルスチェック /health"
 impact = "Cloud Run がインスタンスを異常判定"
 
 [[critical_paths]]
 priority = "P0"
+check_id = "C5"
 feature = "ログイン /account/login/"
 impact = "主催者が集会・発表を管理できない"
 
 [[critical_paths]]
 priority = "P1"
+check_id = "I1"
 feature = "集会一覧 /community/list/"
 impact = "集会情報の集約という主目的が果たせない"
 
 [[critical_paths]]
 priority = "P1"
+check_id = "I2"
 feature = "発表一覧 /event/detail/history/"
 impact = "発表アーカイブへ到達できない"

--- a/scripts/read_deploy_check.py
+++ b/scripts/read_deploy_check.py
@@ -154,12 +154,14 @@ def resolve_migrations(config: dict[str, Any], base_dir: Path | None = None) -> 
 
 
 def _referenced_scripts(command: str) -> list[str]:
-    """コマンド文字列から scripts/*.sh 形式の参照を拾う。
+    """コマンド文字列から scripts/*.sh への参照をパス全体として拾う。
 
     `./scripts/x.sh` だけでなく `bash scripts/x.sh` や絶対パス指定も対象にする。
     拾えないと実在確認が黙ってスキップされ、タイポが検証をすり抜ける。
+    先頭を捨てて `scripts/...` だけを返すと、`/tmp/scripts/x.sh` がリポジトリ内の
+    同名ファイルで実在確認を通ってしまうため、必ずパス全体を返す。
     """
-    return re.findall(r"(?:^|[\s'\"=])\.?/?(?:[\w./-]*/)??(scripts/[\w./-]+\.sh)", command)
+    return re.findall(r"(?:^|[\s'\"=])([\w./-]*scripts/[\w./-]+\.sh)", command)
 
 
 def _index_check_ids(checks: dict[str, list[dict[str, Any]]]) -> dict[str, dict[str, Any]]:

--- a/scripts/read_deploy_check.py
+++ b/scripts/read_deploy_check.py
@@ -154,8 +154,51 @@ def resolve_migrations(config: dict[str, Any], base_dir: Path | None = None) -> 
 
 
 def _referenced_scripts(command: str) -> list[str]:
-    """コマンド文字列から ./scripts/*.sh 形式の参照を拾う。"""
-    return re.findall(r"\./(scripts/[\w./-]+\.sh)", command)
+    """コマンド文字列から scripts/*.sh 形式の参照を拾う。
+
+    `./scripts/x.sh` だけでなく `bash scripts/x.sh` や絶対パス指定も対象にする。
+    拾えないと実在確認が黙ってスキップされ、タイポが検証をすり抜ける。
+    """
+    return re.findall(r"(?:^|[\s'\"=])\.?/?(?:[\w./-]*/)??(scripts/[\w./-]+\.sh)", command)
+
+
+def _index_check_ids(checks: dict[str, list[dict[str, Any]]]) -> dict[str, dict[str, Any]]:
+    """critical / important の id を索引する。重複と欠落は設定ミスとして落とす。"""
+    indexed: dict[str, dict[str, Any]] = {}
+    for section in ("critical", "important"):
+        for item in checks.get(section, []):
+            check_id = item.get("id")
+            if not isinstance(check_id, str) or not check_id.strip():
+                raise ValueError(f"checks.{section} entry requires a non-empty string id")
+            if check_id in indexed:
+                raise ValueError(f"duplicate check id: {check_id}")
+            indexed[check_id] = item
+    return indexed
+
+
+def resolve_critical_paths(
+    config: dict[str, Any], checks: dict[str, list[dict[str, Any]]]
+) -> list[dict[str, Any]]:
+    """critical_paths の check_id を実チェックへ解決する。
+
+    棚卸しと実チェックが機械的に紐づいていないと、チェックを消しても棚卸しだけが
+    残り「守られているつもり」になる。
+    """
+    indexed = _index_check_ids(checks)
+    resolved: list[dict[str, Any]] = []
+    for path in _ensure_list(config.get("critical_paths")):
+        if not isinstance(path, dict):
+            raise ValueError("critical_paths entries must be tables")
+        check_id = path.get("check_id")
+        if not check_id:
+            raise ValueError(f"critical_paths {path.get('feature')!r} requires check_id")
+        source = indexed.get(str(check_id))
+        if source is None:
+            raise ValueError(
+                f"critical_paths {path.get('feature')!r} references unknown check_id: {check_id}"
+            )
+        resolved.append({**path, "check_url": source.get("url")})
+    return resolved
 
 
 def resolve_absence_alerts(config: dict[str, Any]) -> list[dict[str, Any]]:
@@ -226,7 +269,7 @@ def build_summary(
         "selected_checks": selected_checks,
         "log_checks": _ensure_list(config.get("log_checks")),
         "absence_alerts": resolve_absence_alerts(config),
-        "critical_paths": _ensure_list(config.get("critical_paths")),
+        "critical_paths": resolve_critical_paths(config, checks),
         "watch_path": watch_path,
         "service_name": service_name,
     }


### PR DESCRIPTION
## なぜこの変更が必要か

PR #617 までで残していた技術的負債3件を解消する。これで一連のデプロイ運用改善の宿題が片付く。

1. **`critical_paths` が飾りになっていた** — 棚卸しリストが `priority` / `feature` / `impact` だけを持ち、実際のチェックと機械的に紐づいていなかった。チェックを消しても棚卸しだけが残り「守られているつもり」になる
2. **参照抽出が fail-open** — `_referenced_scripts` が `./scripts/x.sh` 形式しか拾わず、`bash scripts/x.sh` や絶対パス指定では実在確認が黙ってスキップされていた
3. **ruff のスコープが `app/` のみ** — 前回追加した reader（327行）が静的解析の対象外だった

## 変更内容

- `docs/deploy-check.toml`: checks に `id`（C1〜C6 / I1・I2）、`critical_paths` に `check_id` を付与
- `scripts/read_deploy_check.py`: `resolve_critical_paths` で参照を解決。id の欠落・重複・未定義参照を落とす。`_referenced_scripts` の対応記法を拡張
- `.github/workflows/ci.yml`: `ruff check app/ scripts/`

## 意思決定

### 参照先を critical と important の両方にした理由

`critical_paths` 5件のうち P1 の2件（集会一覧・発表一覧）は important 側にチェックがある。参照先を critical に限ると、この2件のために important のチェックを critical へ昇格させることになるが、**チェック実行が増えるだけで検知価値は変わらない**（即時モードで見たいのは DatabaseCache に依存するログイン画面で、そちらは PR #616 で既に critical に上げてある）。棚卸しの紐づけが目的なので、参照先を広く取る方が素直。

### ruff スコープ拡大は無リスクと確認

前回のレビューで「既存の `scripts/*.py` が引っかかる可能性がある」と指摘されたが、実際に `ruff check scripts/` を走らせたところ **All checks passed** だった。別 PR に分ける理由がないので同時に入れる。

## テスト

- [x] `ReadDeployCheckTest` に5件追加（参照解決・未定義参照・重複id・id欠落・記法別の実在確認）。合計22件緑
- [x] `website` の151件中、失敗は例の nginx ノイズ1件のみ（ローカル固有、CI では緑）
- [x] `ruff check app/ scripts/` パス
- [x] shell テスト3本 PASS
- [x] **実地検証**: 参照整合性の4ケース（id欠落・重複・未定義参照・check_id欠落）がすべて落ちることを確認。拡張前の正規表現では `bash scripts/x.sh` と絶対パス形式を拾えないことも確認（検出力の担保）

## 残る負債

なし。これで PR #616 / #617 で挙げた技術的負債はすべて解消した。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
