### PR TITLE
fix(event): 発表者アカウント紐づけが実ブラウザで CSRF 403 になる不具合を直す

### DIFF
--- a/app/event/templates/event/speaker_link_confirm.html
+++ b/app/event/templates/event/speaker_link_confirm.html
@@ -4,7 +4,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex,nofollow">
-    <meta name="referrer" content="no-referrer">
+    {# no-referrer はフォーム送信の Origin を null にし、確定 POST が CSRF 検証で必ず落ちる。 #}
+    {# strict-origin ならパスも fragment（招待トークン）も送らずオリジンだけを送る。 #}
+    <meta name="referrer" content="strict-origin">
     <meta name="description" content="発表と本人アカウントの紐づけを確認します。">
     <link rel="canonical" href="https://vrc-ta-hub.com{% url 'event:speaker_link_confirm' %}">
     <title>発表者アカウントの紐づけ - VRChat 技術・学術系イベントHub</title>

--- a/app/event/templates/event/speaker_link_confirm.html
+++ b/app/event/templates/event/speaker_link_confirm.html
@@ -4,9 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex,nofollow">
-    {# no-referrer はフォーム送信の Origin を null にし、確定 POST が CSRF 検証で必ず落ちる。 #}
-    {# strict-origin ならパスも fragment（招待トークン）も送らずオリジンだけを送る。 #}
-    <meta name="referrer" content="strict-origin">
+    {# Referrer-Policy は SpeakerLink 系ビューの _protect_sensitive_response が正本。 #}
+    {# meta で二重に持つと片方だけ変わった時に静かに食い違うため置かない。 #}
     <meta name="description" content="発表と本人アカウントの紐づけを確認します。">
     <link rel="canonical" href="https://vrc-ta-hub.com{% url 'event:speaker_link_confirm' %}">
     <title>発表者アカウントの紐づけ - VRChat 技術・学術系イベントHub</title>

--- a/app/event/tests/test_speaker_invite.py
+++ b/app/event/tests/test_speaker_invite.py
@@ -117,7 +117,7 @@ class SpeakerInviteTests(TestCase):
 
         self._assert_detail_redirect_with_message(response, "既にアカウント")
 
-    def test_sensitive_responses_disable_cache_and_referrer(self):
+    def test_sensitive_responses_restrict_cache_and_referrer(self):
         self.client.force_login(self.owner)
         issue_response = self._issue()
         token = urlparse(issue_response.json()["invite_url"]).fragment
@@ -129,9 +129,9 @@ class SpeakerInviteTests(TestCase):
         for response in (issue_response, exchange_response, confirm_response):
             with self.subTest(path=response.request["PATH_INFO"]):
                 self.assertEqual(response.headers["Cache-Control"], "private, no-store")
-                # no-referrer にするとブラウザのフォーム送信で Origin: null になり、
-                # 確定 POST が CSRF 検証で必ず落ちる。strict-origin ならオリジンのみ送る。
-                self.assertEqual(response.headers["Referrer-Policy"], "strict-origin")
+                # no-referrer は Origin: null を招き CSRF 検証を壊す
+                # （理由は _protect_sensitive_response のコメント参照）。
+                self.assertEqual(response.headers["Referrer-Policy"], "same-origin")
 
     def test_bootstrap_page_clears_fragment_without_loading_analytics(self):
         token = create_invite_token(self.event_detail)

--- a/app/event/tests/test_speaker_invite.py
+++ b/app/event/tests/test_speaker_invite.py
@@ -129,7 +129,9 @@ class SpeakerInviteTests(TestCase):
         for response in (issue_response, exchange_response, confirm_response):
             with self.subTest(path=response.request["PATH_INFO"]):
                 self.assertEqual(response.headers["Cache-Control"], "private, no-store")
-                self.assertEqual(response.headers["Referrer-Policy"], "no-referrer")
+                # no-referrer にするとブラウザのフォーム送信で Origin: null になり、
+                # 確定 POST が CSRF 検証で必ず落ちる。strict-origin ならオリジンのみ送る。
+                self.assertEqual(response.headers["Referrer-Policy"], "strict-origin")
 
     def test_bootstrap_page_clears_fragment_without_loading_analytics(self):
         token = create_invite_token(self.event_detail)

--- a/app/event/views/speaker_link.py
+++ b/app/event/views/speaker_link.py
@@ -46,7 +46,11 @@ def _is_invitable(event_detail: EventDetail) -> bool:
 
 def _protect_sensitive_response(response: HttpResponse) -> HttpResponse:
     response["Cache-Control"] = "private, no-store"
-    response["Referrer-Policy"] = "no-referrer"
+    # no-referrer にすると Chrome はこのページからのフォーム送信で Origin: null を送り、
+    # Django の CSRF Origin 検証が必ず失敗する（紐づけ確定が 403 になる）。
+    # strict-origin ならパスも fragment も送らずオリジンのみ送るため、招待トークンの
+    # 漏洩リスクは変わらない。
+    response["Referrer-Policy"] = "strict-origin"
     return response
 
 

--- a/app/event/views/speaker_link.py
+++ b/app/event/views/speaker_link.py
@@ -46,11 +46,11 @@ def _is_invitable(event_detail: EventDetail) -> bool:
 
 def _protect_sensitive_response(response: HttpResponse) -> HttpResponse:
     response["Cache-Control"] = "private, no-store"
-    # no-referrer にすると Chrome はこのページからのフォーム送信で Origin: null を送り、
-    # Django の CSRF Origin 検証が必ず失敗する（紐づけ確定が 403 になる）。
-    # strict-origin ならパスも fragment も送らずオリジンのみ送るため、招待トークンの
-    # 漏洩リスクは変わらない。
-    response["Referrer-Policy"] = "strict-origin"
+    # no-referrer にするとブラウザはこのページからのフォーム送信で Origin: null を送り、
+    # CSRF の Origin 検証が必ず失敗する（紐づけ確定が 403 になる）。same-origin なら
+    # 同一オリジンには Origin が付き、外部には何も送らない。招待トークンは fragment に
+    # あり、fragment は referrer policy によらず Referer から除去されるため漏洩しない。
+    response["Referrer-Policy"] = "same-origin"
     return response
 
 

--- a/app/website/tests/e2e/test_user_journeys.py
+++ b/app/website/tests/e2e/test_user_journeys.py
@@ -367,3 +367,47 @@ class UserJourneysE2ETests(PlaywrightLiveServerTestCase):
             f'{self.live_server_url}{reverse("event:detail", kwargs={"pk": application.pk})}'
         )
         expect(self.page.get_by_role('heading', name=application_theme, exact=True)).to_be_visible()
+
+    def test_speaker_invite_link_binds_applicant_account(self) -> None:
+        """主催者が発行した招待リンクで発表者本人がアカウントを紐づけられる."""
+        invite_detail = make_event_detail(
+            self.event,
+            applicant=None,
+            status='approved',
+            speaker='招待対象の発表者',
+            theme='招待リンクで紐づけるE2E発表',
+        )
+
+        self.login(self.owner.email, self.password)
+        self.page.goto(
+            f'{self.live_server_url}'
+            f'{reverse("event:detail", kwargs={"pk": invite_detail.pk})}'
+        )
+        self.page.get_by_role('button', name=re.compile(r'招待リンクを発行$')).click()
+        invite_url_field = self.page.locator('#speaker-invite-url')
+        expect(invite_url_field).to_be_visible()
+        invite_url = invite_url_field.input_value()
+        self.assertIn('#', invite_url)
+        self.logout()
+
+        # 招待リンクを開くとトークンがサーバーへ預けられ、URLからfragmentが消える。
+        self.page.goto(invite_url)
+        expect(self.page).to_have_url(
+            re.compile(r'/account/login/\?next=/event/speaker-link/$')
+        )
+        self.page.get_by_label('メールアドレス').fill(self.applicant.email)
+        self.page.get_by_label('パスワード').fill(self.password)
+        self.page.get_by_role('button', name=re.compile(r'ログイン$')).click()
+        self.page.wait_for_load_state('domcontentloaded')
+
+        # 確認画面が Referrer-Policy: no-referrer を返すとブラウザは Origin: null で
+        # POST し CSRF 検証が必ず落ちる。Django test client では再現しない回帰。
+        self.page.get_by_role(
+            'button', name=re.compile(r'このアカウントに紐づける$')
+        ).click()
+        expect(self.page).to_have_url(
+            re.compile(rf'{re.escape(reverse("event:my_presentations"))}$')
+        )
+
+        invite_detail.refresh_from_db()
+        self.assertEqual(invite_detail.applicant, self.applicant)

--- a/app/website/tests/e2e/test_user_journeys.py
+++ b/app/website/tests/e2e/test_user_journeys.py
@@ -384,10 +384,15 @@ class UserJourneysE2ETests(PlaywrightLiveServerTestCase):
             f'{reverse("event:detail", kwargs={"pk": invite_detail.pk})}'
         )
         self.page.get_by_role('button', name=re.compile(r'招待リンクを発行$')).click()
-        invite_url_field = self.page.locator('#speaker-invite-url')
+        invite_url_field = self.page.get_by_label('招待リンク')
         expect(invite_url_field).to_be_visible()
         invite_url = invite_url_field.input_value()
-        self.assertIn('#', invite_url)
+        self.assertTrue(
+            invite_url.startswith(
+                f'{self.live_server_url}{reverse("event:speaker_link_confirm")}#'
+            ),
+            invite_url,
+        )
         self.logout()
 
         # 招待リンクを開くとトークンがサーバーへ預けられ、URLからfragmentが消える。
@@ -400,8 +405,8 @@ class UserJourneysE2ETests(PlaywrightLiveServerTestCase):
         self.page.get_by_role('button', name=re.compile(r'ログイン$')).click()
         self.page.wait_for_load_state('domcontentloaded')
 
-        # 確認画面が Referrer-Policy: no-referrer を返すとブラウザは Origin: null で
-        # POST し CSRF 検証が必ず落ちる。Django test client では再現しない回帰。
+        # Referrer-Policy が no-referrer だとブラウザは Origin: null で POST し
+        # CSRF 検証が落ちる（Django test client では再現しない回帰）。
         self.page.get_by_role(
             'button', name=re.compile(r'このアカウントに紐づける$')
         ).click()


### PR DESCRIPTION
## なぜこの変更が必要か

PR #585 で入った「発表者アカウント招待リンク」の**紐づけ確定が、実ブラウザでは必ず失敗していた**。

主催者が発表を代理登録して招待リンクを渡しても、発表者が確認画面で「このアカウントに紐づける」を押した時点で `403 CSRF verification failed (Origin checking failed – null does not match any trusted origins)` になり、機能全体が使えない状態だった。

原因は確認画面が指定していた `Referrer-Policy: no-referrer`（ビューの HTTP ヘッダと `speaker_link_confirm.html` の meta タグの両方）。このポリシー下ではブラウザがフォーム送信の `Origin` を `null` として送るため、Django の CSRF Origin 検証が必ず失敗する。トークン交換は `fetch()` なので Origin が付いており通っていて、**最後の確定 POST だけが落ちる**ため気づきにくかった。

既存テストが検知できなかったのは、`test_speaker_invite.py` が Django test client（`Origin` ヘッダを送らない）で書かれているため。

## 変更内容

- `_protect_sensitive_response` の `Referrer-Policy` を `no-referrer` → `same-origin`（`app/event/views/speaker_link.py`）
- 確認画面テンプレートの `<meta name="referrer">` を削除し、ビュー側を唯一の正本にする
- 単体テストの期待値を更新（テスト名も実態に合わせて `..._restrict_cache_and_referrer` へ）
- 実ブラウザの回帰テストを追加（`test_speaker_invite_link_binds_applicant_account`）。招待発行 → リンク経由のログイン → 確定 → `applicant` 反映まで通す

## 意思決定

### 採用アプローチ
`same-origin` を採用。同一オリジンの POST には `Origin` が正しく付いて CSRF を通り、外部（CDN 等）には `Referer` を一切送らない。`SECURE_REFERRER_POLICY` 未設定のためサイト既定も `same-origin` で、この画面だけ特別扱いする理由がなくなる。

招待トークンは URL の fragment (`#<token>`) に載るが、**fragment は referrer policy の値に関わらず Referer から必ず除去される**（Fetch 仕様の "strip the URL for use as a referrer" が policy 評価より前に fragment を落とす）。よってトークン漏洩リスクは `no-referrer` と同等。

### 却下した代替案
- `strict-origin` → 却下: CSRF は直るが、この画面だけ cross-origin（jsdelivr CDN）にオリジンを送ることになり、サイト既定より緩い方向のオーバーライドになる
- 確認フォームを `fetch()` + `X-CSRFToken` 送信に変更 → 却下: `no-referrer` を維持できるが JS 依存が増える。fragment が Referer に載らない以上、得られる追加の秘匿性がない
- meta タグだけ修正 → 却下: ヘッダと meta で値が二重管理になり、片方だけ変わった時に静かに食い違う

### トレードオフ
同一オリジンの Referer にパス `/event/speaker-link/` が載る > 機能が動く: パス自体は公開情報で、秘匿すべきトークンは fragment 側にあるため許容。

## テスト

- [x] `python manage.py test event` — 619 tests OK
- [x] ローカル実ブラウザ（Playwright）で通し実演: 主催者ログイン → 発表登録 → 招待リンク発行 → 発表者がリンクを開く → ログイン → 確定 → `EventDetail.applicant` に反映、を 11 画面で確認
- [x] 修正前の再現確認: 同じ経路で確定 POST が `origin='null'` → 403 になることを実測
- [x] 修正後の実測: 確定 POST が `origin='http://localhost:8015'` / `referer` はパスまで（fragment のトークンは非送出）→ 302 で `/event/my_presentations/`
- [ ] 追加した E2E テストは CI の e2e ジョブで実行（ローカルの Docker イメージに playwright 未導入のため未実行）

## Screenshot

画面の見た目は変わらない（meta タグ削除のみ）。以下は修正後に紐づけが完走することの確認。

| 確認画面 | 紐づけ完了 |
|--------|-------|
| ![08-speaker-link-confirm](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/edab615890a8-08-speaker-link-confirm.avif) | ![09-speaker-my-presentations](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/3b4f922a75e9-09-speaker-my-presentations.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)