### PR TITLE
chore(ui): bootstrap-icons CSS に SRI を付ける

### DIFF
--- a/app/event/templates/event/speaker_link_confirm.html
+++ b/app/event/templates/event/speaker_link_confirm.html
@@ -56,7 +56,9 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
           crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+"
+          crossorigin="anonymous">
 </head>
 <body>
     <main class="container my-5">

--- a/app/ta_hub/templates/ta_hub/base.html
+++ b/app/ta_hub/templates/ta_hub/base.html
@@ -59,7 +59,9 @@
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+"
+          crossorigin="anonymous">
     <style>
         .navbar {
             height: 55px;


### PR DESCRIPTION
## なぜこの変更が必要か

jsdelivr から読み込む bootstrap-icons の CSS に `integrity` / `crossorigin` が付いておらず、CDN が改竄された場合に任意の CSS・フォントの読み込みを許す状態だった。同じ CDN から読む bootstrap 本体には SRI が付いており、不整合でもあった。

PR #620（発表者アカウント紐づけの CSRF 修正）のセキュリティレビューで、本変更とは無関係な既存の指摘として挙がったもの。

## 変更内容

- `app/event/templates/event/speaker_link_confirm.html` の bootstrap-icons `<link>` に SRI を追加
- `app/ta_hub/templates/ta_hub/base.html` の同じ `<link>` にも追加

## 意思決定

### 採用アプローチ
Issue #621 は紐づけ確認画面だけを対象にしていたが、`base.html` も同一 CDN・同一バージョンで同じ 1 行が欠けていたため同時に修正した。片方だけ直すと「サイト全体は無防備なまま 1 画面だけ保護される」中途半端な状態になり、レビュー時に意図が読めなくなるため。

### 却下した代替案
- 静的ファイルをセルフホストする → 却下: キャッシュ効率とメンテコストの観点で今回の目的（改竄検知）に対して過剰

## テスト

- [x] 実ブラウザ（Playwright）でトップページと紐づけ確認画面を開き、bootstrap-icons の CSS が適用され（`document.styleSheets` にルールあり）、requestfailed も integrity エラーも出ないことを確認
- [x] 逆方向の確認: `integrity` を 1 文字壊すとブラウザが digest 不一致でブロックすることを確認（付与した値が正しいことの裏取り。ブラウザ計算値と一致）
- [x] `python manage.py test ta_hub event` — 726 tests OK

## Screenshot

画面の見た目は変わらない（`<link>` への属性追加のみ）。アイコン表示に影響がないことは上記の実ブラウザ確認で担保。

Closes #621

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)