### PR TITLE
fix(ui): マイ集会の集会名クリックでマイイベント一覧へ遷移できるようにする

### DIFF
--- a/app/community/tests/test_switch_community.py
+++ b/app/community/tests/test_switch_community.py
@@ -1,3 +1,4 @@
+import re
 from datetime import date, timedelta
 
 from django.test import TestCase, Client
@@ -246,6 +247,49 @@ class SwitchCommunityViewTest(TestCase):
 
         # refererにリダイレクトされる
         self.assertRedirects(response, '/account/settings/', fetch_redirect_response=False)
+
+    def test_switch_from_my_list_with_community_param_is_not_reverted(self):
+        """?community= 付きページの切替フォームを使った切り替えが巻き戻されない"""
+        self.client.force_login(self.user)
+
+        my_list_url = reverse('event:my_list')
+        page_url = f'{my_list_url}?community={self.community2.id}'
+        session = self.client.session
+        session['active_community_id'] = self.community2.id
+        session.save()
+
+        # 集会2のマイイベント一覧（?community=2）を開き、そこに描画された切替フォームを送る。
+        # redirect_to が無いと Referer 経由で ?community=2 に戻され切り替えが取り消される。
+        page = self.client.get(page_url, HTTP_SEC_FETCH_SITE='same-origin')
+        self.assertEqual(page.status_code, 200)
+        form_data = self._extract_switch_form_data(page, self.community1.id)
+
+        response = self.client.post(
+            reverse('community:switch'),
+            form_data,
+            HTTP_REFERER=page_url,
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.client.session['active_community_id'], self.community1.id)
+
+    def _extract_switch_form_data(self, response, community_id):
+        """レンダリング済みページから指定集会への切替フォームの入力値を取り出す"""
+        switch_url = re.escape(reverse('community:switch'))
+        forms = re.findall(
+            r'<form[^>]+action="{}"[^>]*>(.*?)</form>'.format(switch_url),
+            response.content.decode(),
+            re.DOTALL,
+        )
+        target = [
+            form for form in forms
+            if f'name="community_id" value="{community_id}"' in form
+        ]
+        self.assertTrue(target, f'集会 {community_id} への切替フォームが見つからない')
+        return dict(
+            re.findall(r'<input[^>]+name="([^"]+)"[^>]+value="([^"]*)"', target[0])
+        )
 
 
 class CommunityUpdateViewPermissionTest(TestCase):

--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -35,6 +35,8 @@
                                 <form method="post" action="{% url 'community:switch' %}">
                                     {% csrf_token %}
                                     <input type="hidden" name="community_id" value="{{ community.id }}">
+                                    {# redirect_to が無いと Referer（?community= 付き URL）へ戻され、切替が即取り消される #}
+                                    <input type="hidden" name="redirect_to" value="{% url 'event:my_list' %}">
                                     <button type="submit" class="dropdown-item {% if active_community and community.id == active_community.id %}active{% endif %}">
                                         {{ community.name }}
                                     </button>

--- a/app/event/tests/test_event_my_list_view.py
+++ b/app/event/tests/test_event_my_list_view.py
@@ -12,6 +12,12 @@ from django.utils import timezone
 from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
 from event.views.my_list import EventMyList
+from tests.factories import (
+    make_community,
+    make_community_member,
+    make_event,
+    make_user,
+)
 from vket.models import VketCollaboration, VketParticipation
 
 User = get_user_model()
@@ -779,57 +785,37 @@ class EventMyListCommunityQueryParamTest(TestCase):
 
     def setUp(self):
         self.client = Client()
-        self.user = User.objects.create_user(
+        self.user = make_user(
             user_name='QP User', email='qp_user@example.com', password='qppass123',
         )
-        self.other_user = User.objects.create_user(
+        self.other_user = make_user(
             user_name='QP Other', email='qp_other@example.com', password='qppass123',
         )
 
-        self.community_a = self._create_community('QP Community A')
-        self.community_b = self._create_community('QP Community B')
-        self.foreign_community = self._create_community('QP Foreign Community')
-
-        CommunityMember.objects.create(
-            community=self.community_a, user=self.user, role=CommunityMember.Role.OWNER,
+        self.community_a = make_community(name='QP Community A', owner=self.user, organizers='QP')
+        self.community_b = make_community(name='QP Community B', organizers='QP')
+        self.foreign_community = make_community(
+            name='QP Foreign Community', owner=self.other_user, organizers='QP',
         )
-        CommunityMember.objects.create(
-            community=self.community_b, user=self.user, role=CommunityMember.Role.STAFF,
-        )
-        CommunityMember.objects.create(
-            community=self.foreign_community, user=self.other_user,
-            role=CommunityMember.Role.OWNER,
+        make_community_member(
+            self.community_b, self.user, role=CommunityMember.Role.STAFF,
         )
 
         past = timezone.now().date() - timedelta(days=7)
-        self.event_a = Event.objects.create(
-            community=self.community_a, date=past, start_time=time(22, 0),
-            duration=60, weekday='Mon',
+        self.event_a = make_event(
+            self.community_a, event_date=past, start_time=time(22, 0), weekday='Mon',
         )
-        self.event_b = Event.objects.create(
-            community=self.community_b, date=past, start_time=time(21, 0),
-            duration=60, weekday='Fri',
+        self.event_b = make_event(
+            self.community_b, event_date=past, start_time=time(21, 0), weekday='Fri',
         )
-        self.foreign_event = Event.objects.create(
-            community=self.foreign_community, date=past, start_time=time(20, 0),
-            duration=60, weekday='Wed',
+        self.foreign_event = make_event(
+            self.foreign_community, event_date=past, start_time=time(20, 0), weekday='Wed',
         )
 
         self.client.force_login(self.user)
         session = self.client.session
         session['active_community_id'] = self.community_a.id
         session.save()
-
-    def _create_community(self, name):
-        return Community.objects.create(
-            name=name,
-            start_time=time(22, 0),
-            duration=60,
-            weekdays=['Mon'],
-            frequency='Every week',
-            organizers='QP',
-            status='approved',
-        )
 
     def test_query_param_switches_to_specified_community(self):
         """所属集会を指定すると、その集会のイベントだけが表示されセッションも更新される"""

--- a/app/event/tests/test_event_my_list_view.py
+++ b/app/event/tests/test_event_my_list_view.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from community.models import Community, CommunityMember
 from event.models import Event, EventDetail
+from event.views.my_list import EventMyList
 from vket.models import VketCollaboration, VketParticipation
 
 User = get_user_model()
@@ -771,3 +772,123 @@ class EventMyListEditButtonTest(TestCase):
         # 有効なリンクとしては表示されない（disabled ラップ）
         self.assertNotContains(response, f'href="{update_url}"')
         self.assertContains(response, 'Vketコラボ期間中は編集できません')
+
+
+class EventMyListCommunityQueryParamTest(TestCase):
+    """?community=<id> でアクティブな集会を固定する挙動のテスト。"""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            user_name='QP User', email='qp_user@example.com', password='qppass123',
+        )
+        self.other_user = User.objects.create_user(
+            user_name='QP Other', email='qp_other@example.com', password='qppass123',
+        )
+
+        self.community_a = self._create_community('QP Community A')
+        self.community_b = self._create_community('QP Community B')
+        self.foreign_community = self._create_community('QP Foreign Community')
+
+        CommunityMember.objects.create(
+            community=self.community_a, user=self.user, role=CommunityMember.Role.OWNER,
+        )
+        CommunityMember.objects.create(
+            community=self.community_b, user=self.user, role=CommunityMember.Role.STAFF,
+        )
+        CommunityMember.objects.create(
+            community=self.foreign_community, user=self.other_user,
+            role=CommunityMember.Role.OWNER,
+        )
+
+        past = timezone.now().date() - timedelta(days=7)
+        self.event_a = Event.objects.create(
+            community=self.community_a, date=past, start_time=time(22, 0),
+            duration=60, weekday='Mon',
+        )
+        self.event_b = Event.objects.create(
+            community=self.community_b, date=past, start_time=time(21, 0),
+            duration=60, weekday='Fri',
+        )
+        self.foreign_event = Event.objects.create(
+            community=self.foreign_community, date=past, start_time=time(20, 0),
+            duration=60, weekday='Wed',
+        )
+
+        self.client.force_login(self.user)
+        session = self.client.session
+        session['active_community_id'] = self.community_a.id
+        session.save()
+
+    def _create_community(self, name):
+        return Community.objects.create(
+            name=name,
+            start_time=time(22, 0),
+            duration=60,
+            weekdays=['Mon'],
+            frequency='Every week',
+            organizers='QP',
+            status='approved',
+        )
+
+    def test_query_param_switches_to_specified_community(self):
+        """所属集会を指定すると、その集会のイベントだけが表示されセッションも更新される"""
+        response = self.client.get(
+            reverse('event:my_list'), {'community': self.community_b.id}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['active_community'].id, self.community_b.id)
+        event_ids = [event.id for event in response.context['events']]
+        self.assertEqual(event_ids, [self.event_b.id])
+        self.assertEqual(self.client.session['active_community_id'], self.community_b.id)
+
+    def test_foreign_community_is_ignored(self):
+        """権限のない集会IDは無視され、セッションも書き換わらない"""
+        response = self.client.get(
+            reverse('event:my_list'), {'community': self.foreign_community.id}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['active_community'].id, self.community_a.id)
+        event_ids = [event.id for event in response.context['events']]
+        self.assertNotIn(self.foreign_event.id, event_ids)
+        self.assertEqual(self.client.session['active_community_id'], self.community_a.id)
+
+    def test_non_numeric_community_falls_back(self):
+        """非数値の集会IDでもエラーにならず既存の表示にフォールバックする"""
+        response = self.client.get(reverse('event:my_list'), {'community': 'abc'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['active_community'].id, self.community_a.id)
+        self.assertEqual(self.client.session['active_community_id'], self.community_a.id)
+
+    def test_pagination_keeps_community_param(self):
+        """ページ送りしても集会指定が維持される"""
+        page_size = EventMyList.paginate_by
+        past_base = timezone.now().date() - timedelta(days=30)
+        extra_events = [
+            Event(
+                community=self.community_b,
+                date=past_base - timedelta(days=offset),
+                start_time=time(21, 0),
+                duration=60,
+                weekday='Fri',
+            )
+            for offset in range(page_size)
+        ]
+        Event.objects.bulk_create(extra_events)
+
+        response = self.client.get(
+            reverse('event:my_list'), {'community': self.community_b.id, 'page': 2}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['active_community'].id, self.community_b.id)
+        self.assertEqual(response.context['page_obj'].number, 2)
+        self.assertEqual(
+            response.context['current_query_params'],
+            f'community={self.community_b.id}',
+        )
+        for event in response.context['events']:
+            self.assertEqual(event.community_id, self.community_b.id)

--- a/app/event/tests/test_event_my_list_view.py
+++ b/app/event/tests/test_event_my_list_view.py
@@ -863,6 +863,43 @@ class EventMyListCommunityQueryParamTest(TestCase):
         self.assertEqual(response.context['active_community'].id, self.community_a.id)
         self.assertEqual(self.client.session['active_community_id'], self.community_a.id)
 
+    def test_ended_community_is_ignored(self):
+        """終了済みの所属集会は指定してもセッションが書き換わらない"""
+        self.community_b.end_at = timezone.now().date() - timedelta(days=1)
+        self.community_b.save(update_fields=['end_at'])
+
+        response = self.client.get(
+            reverse('event:my_list'), {'community': self.community_b.id}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['active_community'].id, self.community_a.id)
+        self.assertEqual(self.client.session['active_community_id'], self.community_a.id)
+
+    def test_cross_site_navigation_does_not_switch_community(self):
+        """クロスサイト起点の遷移では集会が切り替わらない"""
+        response = self.client.get(
+            reverse('event:my_list'),
+            {'community': self.community_b.id},
+            headers={'sec-fetch-site': 'cross-site'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['active_community'].id, self.community_a.id)
+        self.assertEqual(self.client.session['active_community_id'], self.community_a.id)
+
+    def test_same_origin_navigation_switches_community(self):
+        """同一オリジン起点の遷移では従来どおり集会が切り替わる"""
+        response = self.client.get(
+            reverse('event:my_list'),
+            {'community': self.community_b.id},
+            headers={'sec-fetch-site': 'same-origin'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['active_community'].id, self.community_b.id)
+        self.assertEqual(self.client.session['active_community_id'], self.community_b.id)
+
     def test_pagination_keeps_community_param(self):
         """ページ送りしても集会指定が維持される"""
         page_size = EventMyList.paginate_by

--- a/app/event/views/my_list.py
+++ b/app/event/views/my_list.py
@@ -26,6 +26,31 @@ class EventMyList(LoginRequiredMixin, ListView):
             self.request.user.community_memberships.values_list('community_id', flat=True)
         )
 
+    def _apply_community_query_param(self):
+        """?community=<id> が指定されていればアクティブな集会をそこへ固定する。
+
+        不正値・権限外の ID は黙って無視し、既存のセッション/フォールバック挙動に委ねる
+        （community:switch も権限外を画面遷移だけで済ませるため、URL 直叩きの失敗を
+        エラー表示せずに揃える）。
+        """
+        raw_community_id = self.request.GET.get('community')
+        if not raw_community_id:
+            return
+
+        try:
+            community_id = int(raw_community_id)
+        except (TypeError, ValueError):
+            return
+
+        if community_id in self._get_user_communities():
+            self.request.session['active_community_id'] = community_id
+
+    def get(self, request, *args, **kwargs):
+        # get_queryset / get_context_data の双方が更新後のセッションを読むよう、
+        # 一覧の組み立て前にアクティブな集会を確定させる。
+        self._apply_community_query_param()
+        return super().get(request, *args, **kwargs)
+
     def _get_active_community(self):
         """アクティブな集会を取得する"""
         active_community_id = self.request.session.get('active_community_id')

--- a/app/event/views/my_list.py
+++ b/app/event/views/my_list.py
@@ -37,12 +37,28 @@ class EventMyList(LoginRequiredMixin, ListView):
         if not raw_community_id:
             return
 
+        # クロスサイト起点のトップレベルナビゲーションではセッションを書き換えない
+        # （active_community_id は集会更新・イベント作成の対象決定に使われる共有状態のため、
+        #   CSRF 保護のない GET で外部サイトから切り替えられると別タブのフォーム対象がすり替わる）
+        if self.request.headers.get('Sec-Fetch-Site') == 'cross-site':
+            return
+
         try:
             community_id = int(raw_community_id)
         except (TypeError, ValueError):
             return
 
-        if community_id in self._get_user_communities():
+        # community:switch（community/views/member.py）と同じ受理条件に揃える:
+        # メンバーシップがあり、かつ終了済みでない集会のみ。条件を変える時は両方を更新すること
+        membership = self.request.user.community_memberships.select_related('community').filter(
+            community_id=community_id
+        ).first()
+        if membership is None or membership.community.is_ended:
+            return
+
+        # 同値の再代入でも session.modified が立ち毎回 DB 書き込みになるため差分がある時だけ更新
+        # （ページネーションリンクが community= を引き継ぐので my_list の全ページビューに乗る）
+        if self.request.session.get('active_community_id') != community_id:
             self.request.session['active_community_id'] = community_id
 
     def get(self, request, *args, **kwargs):

--- a/app/ta_hub/templates/ta_hub/base.html
+++ b/app/ta_hub/templates/ta_hub/base.html
@@ -375,7 +375,8 @@
                                         {% if not membership.community.is_ended %}
                                             {% if membership.community.id == active_community.id %}
                                                 <li><a class="dropdown-item active" aria-current="true" href="{% url 'event:my_list' %}?community={{ membership.community.id }}">
-                                                    <i class="bi bi-check-lg me-2 text-primary" aria-hidden="true"></i>{{ membership.community.name|truncatechars:12 }}
+                                                    {# .dropdown-item.active は青背景・白文字。text-primary を付けると青地に青で潰れるため継承色を使う #}
+                                                    <i class="bi bi-check-lg me-2" aria-hidden="true"></i>{{ membership.community.name|truncatechars:12 }}
                                                 </a></li>
                                             {% else %}
                                                 <li><a class="dropdown-item" href="{% url 'event:my_list' %}?community={{ membership.community.id }}">

--- a/app/ta_hub/templates/ta_hub/base.html
+++ b/app/ta_hub/templates/ta_hub/base.html
@@ -374,9 +374,9 @@
                                     {% for membership in user_communities %}
                                         {% if not membership.community.is_ended %}
                                             {% if membership.community.id == active_community.id %}
-                                                <li><span class="dropdown-item-text">
+                                                <li><a class="dropdown-item" href="{% url 'event:my_list' %}">
                                                     <i class="bi bi-check-lg me-2 text-primary"></i>{{ membership.community.name|truncatechars:12 }}
-                                                </span></li>
+                                                </a></li>
                                             {% else %}
                                                 <li>
                                                     <form action="{% url 'community:switch' %}" method="post" class="d-inline w-100">

--- a/app/ta_hub/templates/ta_hub/base.html
+++ b/app/ta_hub/templates/ta_hub/base.html
@@ -374,20 +374,13 @@
                                     {% for membership in user_communities %}
                                         {% if not membership.community.is_ended %}
                                             {% if membership.community.id == active_community.id %}
-                                                <li><a class="dropdown-item" href="{% url 'event:my_list' %}">
-                                                    <i class="bi bi-check-lg me-2 text-primary"></i>{{ membership.community.name|truncatechars:12 }}
+                                                <li><a class="dropdown-item active" aria-current="true" href="{% url 'event:my_list' %}?community={{ membership.community.id }}">
+                                                    <i class="bi bi-check-lg me-2 text-primary" aria-hidden="true"></i>{{ membership.community.name|truncatechars:12 }}
                                                 </a></li>
                                             {% else %}
-                                                <li>
-                                                    <form action="{% url 'community:switch' %}" method="post" class="d-inline w-100">
-                                                        {% csrf_token %}
-                                                        <input type="hidden" name="community_id" value="{{ membership.community.id }}">
-                                                        <input type="hidden" name="redirect_to" value="{% url 'event:my_list' %}">
-                                                        <button type="submit" class="dropdown-item">
-                                                            <i class="bi bi-circle me-2 text-muted"></i>{{ membership.community.name|truncatechars:12 }}
-                                                        </button>
-                                                    </form>
-                                                </li>
+                                                <li><a class="dropdown-item" href="{% url 'event:my_list' %}?community={{ membership.community.id }}">
+                                                    <i class="bi bi-circle me-2 text-muted" aria-hidden="true"></i>{{ membership.community.name|truncatechars:12 }}
+                                                </a></li>
                                             {% endif %}
                                         {% endif %}
                                     {% endfor %}

--- a/app/ta_hub/tests/test_header_community_dropdown.py
+++ b/app/ta_hub/tests/test_header_community_dropdown.py
@@ -106,8 +106,16 @@ class HeaderCommunityDropdownTest(TestCase):
         # チェックマークアイコンが存在することを確認
         self.assertContains(response, 'bi-check-lg')
 
-    def test_active_community_links_to_my_list(self):
-        """アクティブな集会名はマイイベント一覧へのリンクになっている"""
+    def _find_my_list_links(self, response):
+        """マイイベント一覧への集会指定リンクを (href, 内側HTML) で列挙する"""
+        my_list_url = reverse('event:my_list')
+        pattern = r'<a([^>]+href="{}\?community=\d+"[^>]*)>(.*?)</a>'.format(
+            re.escape(my_list_url)
+        )
+        return re.findall(pattern, response.content.decode(), re.DOTALL)
+
+    def test_active_community_links_to_my_list_with_community_param(self):
+        """アクティブな集会名は集会IDを固定したマイイベント一覧リンクになっている"""
         self.client.force_login(self.user)
 
         session = self.client.session
@@ -118,13 +126,40 @@ class HeaderCommunityDropdownTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         my_list_url = reverse('event:my_list')
-        links = re.findall(
-            r'<a[^>]+href="{}"[^>]*>(.*?)</a>'.format(re.escape(my_list_url)),
-            response.content.decode(),
-            re.DOTALL,
+        expected_href = f'{my_list_url}?community={self.community1.id}'
+        # テスト用集会名は truncatechars:12 に切られない12文字以内を前提にしている
+        self.assertTrue(
+            any(
+                expected_href in attrs and self.community1.name in inner
+                for attrs, inner in self._find_my_list_links(response)
+            ),
+            'アクティブ集会名を含む my_list リンクが見つからない',
         )
-        self.assertEqual(len(links), 1)
-        self.assertIn(self.community1.name, links[0])
+
+    def test_active_community_link_marked_as_current(self):
+        """アクティブな集会リンクは Bootstrap の選択状態で示される"""
+        self.client.force_login(self.user)
+
+        session = self.client.session
+        session['active_community_id'] = self.community1.id
+        session.save()
+
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        expected_href = '{}?community={}'.format(
+            reverse('event:my_list'), self.community1.id
+        )
+        # テスト用集会名は truncatechars:12 に切られない12文字以内を前提にしている
+        active_links = [
+            attrs
+            for attrs, inner in self._find_my_list_links(response)
+            if self.community1.name in inner
+        ]
+        self.assertTrue(active_links, 'アクティブ集会のリンクが見つからない')
+        self.assertIn(expected_href, active_links[0])
+        self.assertIn('aria-current="true"', active_links[0])
+        self.assertIn('active', active_links[0])
 
     def test_inactive_community_has_circle_icon(self):
         """非アクティブな集会には丸アイコンが表示される"""
@@ -141,8 +176,8 @@ class HeaderCommunityDropdownTest(TestCase):
         # 丸アイコンが存在することを確認（非アクティブ集会用）
         self.assertContains(response, 'bi-circle')
 
-    def test_switch_form_exists_for_inactive_community(self):
-        """非アクティブな集会には切り替えフォームがある"""
+    def test_inactive_community_links_to_my_list_with_community_param(self):
+        """非アクティブな集会は集会IDを固定したGETリンクで切り替えられる"""
         self.client.force_login(self.user)
 
         # セッションにactive_community_idを設定
@@ -153,8 +188,32 @@ class HeaderCommunityDropdownTest(TestCase):
         response = self.client.get(reverse('ta_hub:index'))
 
         self.assertEqual(response.status_code, 200)
-        # 切り替えフォームにcommunity_idが含まれることを確認
-        self.assertContains(response, f'name="community_id" value="{self.community2.id}"')
+        expected_href = '{}?community={}'.format(
+            reverse('event:my_list'), self.community2.id
+        )
+        # テスト用集会名は truncatechars:12 に切られない12文字以内を前提にしている
+        self.assertTrue(
+            any(
+                expected_href in attrs and self.community2.name in inner
+                for attrs, inner in self._find_my_list_links(response)
+            ),
+            '非アクティブ集会名を含む my_list リンクが見つからない',
+        )
+
+    def test_inactive_community_link_switches_active_community(self):
+        """非アクティブ集会のリンクを辿るとアクティブな集会が切り替わる"""
+        self.client.force_login(self.user)
+
+        session = self.client.session
+        session['active_community_id'] = self.community1.id
+        session.save()
+
+        response = self.client.get(
+            reverse('event:my_list'), {'community': self.community2.id}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.client.session['active_community_id'], self.community2.id)
 
     def test_add_community_link_exists(self):
         """集会を追加リンクが存在する"""

--- a/app/ta_hub/tests/test_header_community_dropdown.py
+++ b/app/ta_hub/tests/test_header_community_dropdown.py
@@ -1,5 +1,7 @@
 """ヘッダーの集会ドロップダウン表示のテスト"""
 
+import re
+
 from django.test import TestCase, Client
 from django.urls import reverse
 from django.contrib.auth import get_user_model
@@ -103,6 +105,26 @@ class HeaderCommunityDropdownTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # チェックマークアイコンが存在することを確認
         self.assertContains(response, 'bi-check-lg')
+
+    def test_active_community_links_to_my_list(self):
+        """アクティブな集会名はマイイベント一覧へのリンクになっている"""
+        self.client.force_login(self.user)
+
+        session = self.client.session
+        session['active_community_id'] = self.community1.id
+        session.save()
+
+        response = self.client.get(reverse('ta_hub:index'))
+
+        self.assertEqual(response.status_code, 200)
+        my_list_url = reverse('event:my_list')
+        links = re.findall(
+            r'<a[^>]+href="{}"[^>]*>(.*?)</a>'.format(re.escape(my_list_url)),
+            response.content.decode(),
+            re.DOTALL,
+        )
+        self.assertEqual(len(links), 1)
+        self.assertIn(self.community1.name, links[0])
 
     def test_inactive_community_has_circle_icon(self):
         """非アクティブな集会には丸アイコンが表示される"""

--- a/app/ta_hub/tests/test_header_community_dropdown.py
+++ b/app/ta_hub/tests/test_header_community_dropdown.py
@@ -159,7 +159,8 @@ class HeaderCommunityDropdownTest(TestCase):
         self.assertTrue(active_links, 'アクティブ集会のリンクが見つからない')
         self.assertIn(expected_href, active_links[0])
         self.assertIn('aria-current="true"', active_links[0])
-        self.assertIn('active', active_links[0])
+        # 部分一致だと "dropdown-item" 等の別語に含まれる 'active' でも通るため class 属性値で照合する
+        self.assertIn('class="dropdown-item active"', active_links[0])
 
     def test_inactive_community_has_circle_icon(self):
         """非アクティブな集会には丸アイコンが表示される"""
@@ -201,16 +202,23 @@ class HeaderCommunityDropdownTest(TestCase):
         )
 
     def test_inactive_community_link_switches_active_community(self):
-        """非アクティブ集会のリンクを辿るとアクティブな集会が切り替わる"""
+        """ドロップダウンに描画されたリンクをそのまま辿るとアクティブな集会が切り替わる"""
         self.client.force_login(self.user)
 
         session = self.client.session
         session['active_community_id'] = self.community1.id
         session.save()
 
-        response = self.client.get(
-            reverse('event:my_list'), {'community': self.community2.id}
-        )
+        header_response = self.client.get(reverse('ta_hub:index'))
+        # 描画済み href をそのまま辿ることで、テンプレートとビューの結線ずれを検知する
+        hrefs = [
+            re.search(r'href="([^"]+)"', attrs).group(1)
+            for attrs, inner in self._find_my_list_links(header_response)
+            if self.community2.name in inner
+        ]
+        self.assertTrue(hrefs, '非アクティブ集会のリンクが見つからない')
+
+        response = self.client.get(hrefs[0], HTTP_SEC_FETCH_SITE='same-origin')
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.client.session['active_community_id'], self.community2.id)

--- a/app/website/settings/security.py
+++ b/app/website/settings/security.py
@@ -1,7 +1,7 @@
 """セキュリティ関連の Django 設定.
 
 ALLOWED_HOSTS / SECURE_PROXY_SSL_HEADER / SESSION_COOKIE_SECURE /
-CSRF_COOKIE_SECURE / SECURE_HSTS_* / CSRF_TRUSTED_ORIGINS /
+SESSION_COOKIE_SAMESITE / CSRF_COOKIE_SECURE / SECURE_HSTS_* / CSRF_TRUSTED_ORIGINS /
 CORS_ALLOWED_ORIGINS / CORS_URLS_REGEX / DISCORD_AUTH_REQUIRED を扱う。
 """
 import os
@@ -43,6 +43,11 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # Cloud Run が XFF 末尾へ追加する client / Google frontend の2要素を信頼する。
 # nginx はこのチェーンを追加せず透過し、左側の偽装値をIP制限キーに使わせない。
 ALLAUTH_TRUSTED_PROXY_COUNT = 2
+
+# Django 既定と同値だが明示固定する。event:my_list の ?community= が GET でセッションを
+# 更新するため、サブリソース（img/iframe/fetch）経由でセッション Cookie が送られない Lax が
+# 外部サイトからのアクティブ集会すり替えを防ぐ防御線になっている。
+SESSION_COOKIE_SAMESITE = 'Lax'
 
 # 本番環境のセキュリティ強化
 if not DEBUG:


### PR DESCRIPTION
## なぜこの変更が必要か

ナビバーのアカウントドロップダウン「マイ集会」で、アクティブな集会（チェックマーク付き）が非リンクの `<span class="dropdown-item-text">` のため、集会名を押しても何も起きなかった（ユーザー報告のバグ）。さらに複数集会の主催者は、任意の集会のマイイベント一覧へ URL で直接飛ぶ手段がなく、切替はセッション依存の POST（`community:switch`）のみだった。

## 変更内容

- `EventMyList` に `?community=<id>` GET パラメータを追加。メンバーシップ照合・終了済み（`is_ended`）拒否のうえで `active_community_id` セッションを更新し、URL で表示集会を固定できるようにした
- ナビドロップダウンの集会項目を全件（アクティブ含む）`/event/my_list/?community=<id>` への GET リンクに統一。アクティブ項目は `.dropdown-item.active` + `aria-current="true"` で明示
- my_list ページ内の POST 切替フォームに `redirect_to` を追加（`?community=` 付き Referer に戻され切替が即取り消されるバグをレビューで検出・修正）
- `SESSION_COOKIE_SAMESITE = 'Lax'` を明示固定（Django 既定と同値だが、GET セッション更新の防御線になったため）

## 意思決定

### 採用アプローチ
- `?community=` はリクエストスコープ表示ではなく**セッション固定**を採用。理由: 表示だけ切り替えると、イベント作成・集会更新などセッションのアクティブ集会を参照する後続操作と表示が食い違う
- クロスサイト起点の GET ではセッションを書き換えない（`Sec-Fetch-Site: cross-site` を拒否）。`active_community_id` は書き込み系ビューの対象決定に使われる共有状態のため、CSRF 保護のない GET で外部サイトから切り替えられると別タブのフォーム対象がすり替わる（セキュリティレビュー MEDIUM 指摘への対処）
- 受理条件（int 変換・メンバーシップ・is_ended）は `community:switch` と同一に揃えた

### 却下した代替案
- 「セッションに書かずリクエストスコープに留める」（セキュリティレビュー第1案）→ 却下: 表示と操作対象の食い違いという別の confused deputy を生む
- ドロップダウンを POST フォームのまま維持 → 却下: URL 指定・ブックマークでの直接遷移という要件を満たせない

### トレードオフ
- GET リンク化による導線の単純さ > 切替時トースト（「集会を切り替えました。」）の喪失: 遷移先ページの集会名とドロップダウンのチェック位置でフィードバックは成立する
- `Sec-Fetch-Site` 未送信の古いブラウザではガードが効かないが、`SameSite=Lax` Cookie が二重の防御線になる

### 技術的負債
- 受理条件が `EventMyList` と `SwitchCommunityView` に二重化 → #624（共通ヘルパーへの集約）
- QA で発見した既存問題（本 PR の回帰ではない）: モバイル幅でドロップダウンが画面外にはみ出す → #625

## テスト

- [x] 再発防止: アクティブ集会名が my_list へのリンクとして描画される（修正前に red を確認）
- [x] `?community=` で集会切替 / 他人の集会 ID は無視 / 非数値は無視 / 終了済み集会は無視 / cross-site ヘッダでは更新されない / ページネーションとの併用
- [x] ページ内 POST 切替が `?community=` 付き Referer に巻き戻されない（回帰テスト、修正前 red を確認）
- [x] `docker compose exec vrc-ta-hub python manage.py test`: 対象スイート 172 件 OK、community + event.tests 全 963 件 OK (skipped=20)
- [x] ブラウザ QA（Playwright・テストユーザー2集会）: リンク遷移・切替・チェック移動・権限外/不正値の無視・JS コンソールエラー 0 件を確認

## Screenshot

Before は非リンクのため見た目の差分なし（クリック不能だった項目がリンク化・アクティブ項目が青背景に変更）。

| 場面 | After |
|------|-------|
| ドロップダウン（アクティブ集会が青背景 + 白チェック） | ![ドロップダウン初期状態](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/6071ddb22fbe-01-dropdown-open-initial-20260813-104049.avif) |
| アクティブ集会クリックで my_list へ遷移 | ![アクティブ集会のマイイベント一覧](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/3f495b8a4baa-02-my-list-active-community-20260813-104049.avif) |
| 非アクティブ集会クリックで表示集会が切替 | ![切替後のマイイベント一覧](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/cc34b1000b1b-04-my-list-switched-community-20260813-104049.avif) |
| 切替後はチェック位置も移動 | ![切替後のドロップダウン](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/692f57a8c225-05-dropdown-after-switch-20260813-104049.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
