### PR TITLE
feat: 未紐づけ発表に招待リンク作成導線を追加

### DIFF
--- a/app/event/templates/event/my_list.html
+++ b/app/event/templates/event/my_list.html
@@ -251,6 +251,12 @@
                                         {% endif %}
                                         <div class="mb-2">
                                             <a href="{% url 'event:detail' detail.pk %}" class="btn btn-primary btn-sm">記事</a>
+                                            {% if not detail.applicant and detail.detail_type == 'LT' and detail.status == 'approved' %}
+                                            <a href="{% url 'event:detail' detail.pk %}#speaker-account-heading"
+                                               class="btn btn-outline-primary btn-sm">
+                                                <i class="fas fa-link" aria-hidden="true"></i> 紐づけ用リンクを作成
+                                            </a>
+                                            {% endif %}
                                             <a href="{% url 'event:detail_update' detail.pk %}"
                                                class="btn btn-success btn-sm">編集</a>
                                             <form method="post" action="{% url 'event:detail_delete' detail.pk %}"

--- a/app/event/tests/test_event_my_list_speaker_link.py
+++ b/app/event/tests/test_event_my_list_speaker_link.py
@@ -1,0 +1,95 @@
+"""my_list の発表者アカウント紐づけ導線を検証する。"""
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from tests.factories import make_community, make_event, make_event_detail, make_user
+
+
+class EventMyListSpeakerLinkTest(TestCase):
+    """既存の記事ページ内招待リンク発行UIへの導線を検証する。"""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = make_user(
+            user_name="speaker_link_owner",
+            email="speaker-link-owner@example.com",
+        )
+        cls.speaker = make_user(
+            user_name="linked_speaker",
+            email="linked-speaker@example.com",
+        )
+        cls.community = make_community(
+            name="紐づけ導線テスト集会",
+            owner=cls.owner,
+        )
+        cls.event = make_event(cls.community)
+        cls.unlinked_detail = make_event_detail(
+            cls.event,
+            status="approved",
+            theme="未紐づけの発表",
+        )
+        cls.linked_detail = make_event_detail(
+            cls.event,
+            applicant=cls.speaker,
+            status="approved",
+            theme="紐づけ済みの発表",
+        )
+        cls.pending_detail = make_event_detail(
+            cls.event,
+            status="pending",
+            theme="承認待ちの発表",
+        )
+        cls.special_detail = make_event_detail(
+            cls.event,
+            detail_type="SPECIAL",
+            status="approved",
+            theme="特別企画",
+        )
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.owner)
+
+    def test_unlinked_approved_lt_links_to_article_invite_section(self):
+        """未紐づけの承認済み発表は記事内の招待リンク発行UIへ遷移できる。"""
+        response = self.client.get(reverse("event:my_list"))
+
+        target = (
+            reverse("event:detail", kwargs={"pk": self.unlinked_detail.pk})
+            + "#speaker-account-heading"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'href="{target}"')
+
+    def test_linked_lt_does_not_show_invite_section_link(self):
+        """紐づけ済みの発表には招待リンク発行UIへの導線を表示しない。"""
+        response = self.client.get(reverse("event:my_list"))
+
+        target = (
+            reverse("event:detail", kwargs={"pk": self.linked_detail.pk})
+            + "#speaker-account-heading"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, f'href="{target}"')
+
+    def test_pending_lt_does_not_link_to_unavailable_invite_section(self):
+        """承認待ちでは記事側に存在しない招待リンク発行UIへ誘導しない。"""
+        response = self.client.get(reverse("event:my_list"))
+
+        target = (
+            reverse("event:detail", kwargs={"pk": self.pending_detail.pk})
+            + "#speaker-account-heading"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, f'href="{target}"')
+
+    def test_unlinked_special_does_not_link_to_unavailable_invite_section(self):
+        """特別企画では記事側に存在しない招待リンク発行UIへ誘導しない。"""
+        response = self.client.get(reverse("event:my_list"))
+
+        target = (
+            reverse("event:detail", kwargs={"pk": self.special_detail.pk})
+            + "#speaker-account-heading"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, f'href="{target}"')


### PR DESCRIPTION
## なぜこの変更が必要か

集会管理者が申請者アカウント未紐づけの発表を確認した際、招待リンクを作るには一度記事ページを開き、対象セクションを探す必要がありました。一覧から既存のリンク発行UIへ直接移動できる導線を追加します。

## 変更内容

- 未紐づけ・承認済みの発表に「紐づけ用リンクを作成」ボタンを追加
- 既存の記事ページ内「発表者アカウント」セクションへアンカー移動
- 紐づけ済み・承認待ち・非LTでは導線を表示しない回帰テストを追加
- 発表者アカウントの解除処理は変更なし

## 意思決定

- 新画面は作らず、既存の `#speaker-account-heading` を遷移先として再利用
- 記事側にリンク発行UIが存在する「承認済み・未紐づけ・LT」に表示条件を限定

## テスト

- [x] 関連76テスト成功
- [x] PC幅で一覧から記事内セクションへの遷移を確認
- [x] 375px幅で同じ遷移とレイアウトを確認
- [x] コンソールエラーなし
- [x] コード・セキュリティ・デザインレビューでブロッキング指摘なし
- [x] file-size-guard / `git diff --check` 成功
- [x] architecture-gate: 契約なし（advisory）

## Screenshot

| 一覧画面の追加ボタン | クリック後の記事内セクション |
|---|---|
| ![一覧画面の紐づけ用リンク作成ボタン](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/b3179c1dae83-01-my-list-link-button-20260821-231220.avif) | ![記事内の発表者アカウントセクション](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/401bc769405a-02-article-invite-section-20260821-231220.avif) |
