### PR TITLE
fix: 発表申請の直近日を初期選択

### DIFF
--- a/app/community/tests/test_member_identity_display.py
+++ b/app/community/tests/test_member_identity_display.py
@@ -4,6 +4,9 @@ user_name の unique 制約解除（#579）により、メンバー管理画面�
 ユーザーが並び得る。権限操作（削除・昇格）で別人を誤操作しないための副次情報が
 出ていること、その副次情報に email が含まれないことを振る舞いとして検証する。
 """
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
 from django.db import connection
 from django.test import Client, TestCase
 from django.test.utils import CaptureQueriesContext
@@ -61,10 +64,9 @@ class SameNameMemberIdentificationTest(TestCase):
 
     def test_registration_date_is_rendered_for_each_member(self):
         """各メンバーの登録日が描画され、副次情報として使える"""
-        joined = self.duplicate_unlinked.date_joined.replace(
-            year=2020, month=1, day=15
+        self.duplicate_unlinked.date_joined = datetime(
+            2020, 1, 15, 12, tzinfo=ZoneInfo('Asia/Tokyo')
         )
-        self.duplicate_unlinked.date_joined = joined
         self.duplicate_unlinked.save(update_fields=['date_joined'])
         self.client.force_login(self.owner)
 

--- a/app/event/forms/lt_application.py
+++ b/app/event/forms/lt_application.py
@@ -129,13 +129,18 @@ class LTApplicationForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         if self.community:
-            # accepts_lt_application=True かつ未来のイベントのみ
-            today = timezone.now().date()
-            self.fields['event'].queryset = Event.objects.filter(
+            # Cloud Run のシステム時刻は UTC なので、開催日の境界は
+            # settings.TIME_ZONE（Asia/Tokyo）に合わせる。
+            today = timezone.localdate()
+            event_queryset = Event.objects.filter(
                 community=self.community,
                 accepts_lt_application=True,
                 date__gte=today
             ).order_by('date', 'start_time')
+            self.fields['event'].queryset = event_queryset
+            self.fields['event'].initial = event_queryset.values_list(
+                'pk', flat=True
+            ).first()
 
             # テンプレートが設定されている場合は初期値として編集可能にする
             if self.community.lt_application_template:

--- a/app/event/tests/test_lt_application_date_choices.py
+++ b/app/event/tests/test_lt_application_date_choices.py
@@ -1,0 +1,54 @@
+"""発表申請フォームの開催日候補に関するテスト。"""
+
+from datetime import date, datetime
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from tests.factories import make_community, make_event
+from user_account.tests.utils import create_discord_linked_user
+
+
+class LTApplicationDateChoiceTest(TestCase):
+    """発表申請フォームの開催日候補を検証する。"""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = create_discord_linked_user(
+            user_name='date_choice_user',
+            email='date-choice@example.com',
+            password='testpass123',
+        )
+        self.community = make_community(owner=self.user)
+
+    def test_starts_with_nearest_date_and_excludes_jst_yesterday(self):
+        """JSTの当日を初期選択し、前日の開催回は候補から除外する。"""
+        jst_early_morning = datetime(
+            2026, 8, 20, 1, 30, tzinfo=ZoneInfo('Asia/Tokyo')
+        )
+        yesterday_event = make_event(
+            self.community,
+            event_date=date(2026, 8, 19),
+        )
+        today_event = make_event(
+            self.community,
+            event_date=date(2026, 8, 20),
+        )
+        make_event(self.community, event_date=date(2026, 8, 21))
+        self.client.force_login(self.user)
+        url = reverse(
+            'event:lt_application_create',
+            kwargs={'community_pk': self.community.pk},
+        )
+
+        with patch(
+            'django.utils.timezone.now',
+            return_value=jst_early_morning.astimezone(ZoneInfo('UTC')),
+        ):
+            form = self.client.get(url).context['form']
+
+        self.assertNotIn(yesterday_event, form.fields['event'].queryset)
+        self.assertIn(today_event, form.fields['event'].queryset)
+        self.assertEqual(form.fields['event'].initial, today_event.pk)

--- a/app/event/tests/test_notifications.py
+++ b/app/event/tests/test_notifications.py
@@ -3,7 +3,9 @@
 メール/Discord Webhook の通知送信パスをカバーする。
 silent failure を起こしうる recipient リスト構築・例外ハンドリングを重点的に検証する。
 """
+from datetime import datetime
 from unittest.mock import patch, MagicMock
+from zoneinfo import ZoneInfo
 
 import requests
 from django.contrib.auth import get_user_model
@@ -385,8 +387,8 @@ class SpeakerAccountLinkedNotificationTest(TestCase):
         self.event = _make_event(self.community)
         self.event_detail = _make_event_detail(self.event)
         self.speaker = _make_user("かぶり太郎", "linked-speaker@example.com")
-        self.speaker.date_joined = self.speaker.date_joined.replace(
-            year=2024, month=3, day=9
+        self.speaker.date_joined = datetime(
+            2024, 3, 9, 12, tzinfo=ZoneInfo("Asia/Tokyo")
         )
         self.speaker.save(update_fields=["date_joined"])
 


### PR DESCRIPTION
## なぜこの変更が必要か

発表申請画面で開催日が未選択のまま表示され、JSTの深夜帯には終了済みの前日開催回まで候補へ混入する可能性がありました。申請者が迷わず直近の開催回へ申し込めるようにします。

## 変更内容

- 発表申請の開催日判定をJST基準の当日以降へ変更
- 日付・開始時刻順で最も近い開催回を初期選択
- JST早朝の前日除外、当日包含、初期値を公開画面経由で検証する回帰テストを追加
- CIで顕在化した既存の登録日テスト2件をJST正午固定にし、実行時刻による翌日ずれを解消（本番ロジック変更なし）

## 意思決定

- プロジェクトの `TIME_ZONE=Asia/Tokyo` を正本として `timezone.localdate()` を使用
- 表示だけでなく `ModelChoiceField` のqueryset自体を当日以降へ絞り、POST時の候補検証も維持

## テスト

- [x] 発表申請・承認とCI失敗箇所の関連48テスト
- [x] PC／375pxのブラウザ表示
- [x] ローカルで発表申請完了まで操作
- [x] コード・セキュリティ・デザインレビュー（初回headでブロッキングなし）

---
🤖 Generated with Codex
