### PR TITLE
修正: DB操作の1Password依存を環境ファイル直接読込へ置換

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,9 @@ DATE      := $(shell date +%Y%m%d_%H%M%S)
 DUMPS_DIR := dumps
 
 DB_SECRET_SUFFIX := PASSWORD
-LOCAL_DB_NAME     := $(shell docker compose exec -T vrc-ta-hub printenv DB_NAME 2>/dev/null || grep '^DB_NAME=' .env.local | cut -d= -f2-)
-LOCAL_DB_USER     := $(shell docker compose exec -T vrc-ta-hub printenv DB_USER 2>/dev/null || grep '^DB_USER=' .env.local | cut -d= -f2-)
-LOCAL_DB_AUTH     := $(shell docker compose exec -T vrc-ta-hub printenv DB_$(DB_SECRET_SUFFIX) 2>/dev/null || grep '^DB_$(DB_SECRET_SUFFIX)=' .env.local | cut -d= -f2-)
+LOCAL_DB_NAME     = $(shell docker compose exec -T vrc-ta-hub printenv DB_NAME 2>/dev/null || grep '^DB_NAME=' .env.local | cut -d= -f2-)
+LOCAL_DB_USER     = $(shell docker compose exec -T vrc-ta-hub printenv DB_USER 2>/dev/null || grep '^DB_USER=' .env.local | cut -d= -f2-)
+LOCAL_DB_AUTH     = $(shell docker compose exec -T vrc-ta-hub printenv DB_$(DB_SECRET_SUFFIX) 2>/dev/null || grep '^DB_$(DB_SECRET_SUFFIX)=' .env.local | cut -d= -f2-)
 
 COMPOSE_APP_SERVICE      ?= vrc-ta-hub
 COMPOSE_DB_SERVICE       ?= db
@@ -66,26 +66,18 @@ PROD_ENV_FILE ?= .env.production.local
 # --set-gtid-purged=OFF は GTID を持たない Compose DB へ流し込むために必須。
 PROD_DUMP_OPTS := --single-transaction --routines --triggers --no-tablespaces --set-gtid-purged=OFF
 
-# .env.production.local の値は 1Password 参照（op://...）なので生値を読んではいけない。
-# `op run --env-file` で実値へ解決し、コマンド内でシェル変数として参照する。
+# Git 管理外の .env.production.local から DB 変数だけを直接読み込む。
+# 値はシェル評価せず、子プロセスの環境へ渡す。
 # また本番 MySQL 8 の認証プラグインにホストの MariaDB クライアントは非対応なため、
 # 本番への mysqldump / mysql は Compose の db サービス（MySQL 8 正規クライアント）経由で叩く。
-OP_RUN := op run --env-file=$(PROD_ENV_FILE) --
+PROD_DB_RUN = python3 scripts/production_db_env.py "$(PROD_ENV_FILE)" --
 # 値なしの `-e MYSQL_PWD` は呼び出し元プロセスの環境から引き継ぐ。
 # `-e MYSQL_PWD=<値>` にすると docker CLI の argv に本番パスワードが平文で乗り、
-# 実行中は同一ホストの ps から読める（op run のマスクは argv に効かない）。
+# 実行中は同一ホストの ps から読める（CLI のログマスクは argv に効かない）。
 PROD_MYSQL_EXEC := MYSQL_PWD="$$DB_PASSWORD" docker compose exec -T -e MYSQL_PWD
 
-define require_op
-	@command -v op >/dev/null 2>&1 || \
-		(echo "ERROR: 1Password CLI (op) not found. $(PROD_ENV_FILE) stores op:// references and requires 'op run'." >&2; exit 1)
-	@test -f "$(PROD_ENV_FILE)" || (echo "ERROR: $(PROD_ENV_FILE) not found." >&2; exit 1)
-endef
-
-# op run 配下で必須 DB 変数が解決できたかを検証する（値そのものは出力しない）
-define assert_prod_db_env
-	test -n "$$DB_NAME" -a -n "$$DB_USER" -a -n "$$DB_PASSWORD" -a -n "$$DB_HOST" || \
-		{ echo "ERROR: $(PROD_ENV_FILE) must define DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST." >&2; exit 1; }
+define require_prod_env
+	@python3 scripts/production_db_env.py "$(PROD_ENV_FILE)" --check
 endef
 
 # DROP/CREATE DATABASE に埋め込む前に識別子を検証する（scripts/db_pull_restore.sh と同基準）。
@@ -105,9 +97,9 @@ define assert_dump_is_usable
 endef
 
 db-backup: ## 本番DBバックアップ → dumps/
-	$(require_op)
+	$(require_prod_env)
 	@mkdir -p $(DUMPS_DIR)
-	@$(OP_RUN) sh -c '$(assert_prod_db_env); \
+	@$(PROD_DB_RUN) sh -c '\
 		echo "Backing up production DB ($$DB_NAME)..."; \
 		$(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME"' \
 		| gzip > $(DUMPS_DIR)/production_$(DATE).sql.gz
@@ -122,9 +114,9 @@ db-backup-local: ## ローカルDBバックアップ → dumps/
 	@echo "Done: $(DUMPS_DIR)/local_$(DATE).sql.gz"
 
 db-pull: ## 本番DB → ローカルDB
-	$(require_op)
+	$(require_prod_env)
 	@mkdir -p $(DUMPS_DIR)
-	@$(OP_RUN) sh -c '$(assert_prod_db_env); \
+	@$(PROD_DB_RUN) sh -c '\
 		echo "Dumping production DB ($$DB_NAME)..."; \
 		$(PROD_MYSQL_EXEC) $(COMPOSE_DB_SERVICE) mysqldump -h "$$DB_HOST" -u "$$DB_USER" $(PROD_DUMP_OPTS) "$$DB_NAME"' \
 		| gzip > $(DUMPS_DIR)/production.sql.gz
@@ -143,14 +135,14 @@ db-verify-local: ## アプリコンテナ経由でローカルDB復元結果を�
 	@docker compose exec -T vrc-ta-hub python manage.py shell -c "from community.models import Community; from event.models import Event; from vket.models import VketCollaboration; print('local DB verify:', {'communities': Community.objects.count(), 'events': Event.objects.count(), 'vket_collaborations': VketCollaboration.objects.count()}); assert Community.objects.exists(); assert Event.objects.exists();"
 
 db-push: ## ローカルDB → 本番DB（確認プロンプト + 自動backup）
-	$(require_op)
+	$(require_prod_env)
 	@echo "WARNING: This will OVERWRITE the production database with local data."
 	@mkdir -p $(DUMPS_DIR)
 	@echo "Dumping Docker Compose local DB ($(LOCAL_DB_NAME))..."
 	@docker compose exec -T -e MYSQL_PWD="$(LOCAL_DB_AUTH)" db mysqldump -u "$(LOCAL_DB_USER)" --single-transaction --routines --triggers --no-tablespaces "$(LOCAL_DB_NAME)" \
 		| gzip > $(DUMPS_DIR)/local.sql.gz
 	$(call assert_dump_is_usable,$(DUMPS_DIR)/local.sql.gz)
-	@$(OP_RUN) bash -e -o pipefail -c '$(assert_prod_db_env); \
+	@$(PROD_DB_RUN) bash -e -o pipefail -c '\
 		$(assert_prod_db_name_is_identifier); \
 		printf "Type the production DB name (%s) to continue: " "$$DB_NAME"; \
 		read confirm </dev/tty; \

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -21,6 +21,8 @@ Django関係のスクリプトはカスタムコマンドとして、各アプ�
 
 ## DB同期
 
+- `scripts/production_db_env.py`: `.env.production.local` のDB用4変数をシェル評価なしで読み、子プロセスの環境へ渡します。op不要。欠落・重複・未解決参照はDB操作前に拒否します。
+- `scripts/tests/test_production_db_env.py`: ダミー値で引用符・ドル記号・非漏洩・異常時の停止を検証し、Dockerをモックして `make db-backup` を確認します。
 - `scripts/db_pull_restore.sh`: `make db-pull` が取得した本番ダンプを Docker Compose の `db` サービスへ復元し、アプリコンテナ経由で代表テーブル件数を検証します。
 - `scripts/tests/test_db_pull_restore.sh`: Docker Compose 呼び出しをモックして、復元先サービス固定・`DB_HOST` 不一致検知・代表テーブル件数検証を確認します。
 
@@ -29,4 +31,4 @@ Django関係のスクリプトはカスタムコマンドとして、各アプ�
 - `scripts/create_migrate_job.sh`: Cloud Run Job `vrc-ta-hub-migrate` を作成/更新（冪等）。稼働中サービスからイメージ・環境変数・シークレット・SA を引き継ぎます。
 - `scripts/check_pending_migrations.sh`: 本番の未適用 migration を一覧（read-only）。未適用ありで exit 1、ログが取れなければ exit 2 で落とします。
 - `scripts/read_deploy_check.py`: `docs/deploy-check.toml` を検証して要約を出力（deploy-watch が読む層）。`[migrations]` の必須項目と `check_command` の read-only 性を実行前に確認します。
-- `scripts/tests/test_deploy_ops_config.sh`: `make -n` の展開結果で本番DBターゲットの `op run` / Compose 経由を検証し、migrate Job スクリプトの必須オプションを静的検証します。
+- `scripts/tests/test_deploy_ops_config.sh`: `make -n` の展開結果で本番DBターゲットのdotenv直接読込 / Compose 経由を検証し、migrate Job スクリプトの必須オプションを静的検証します。

--- a/scripts/production_db_env.py
+++ b/scripts/production_db_env.py
@@ -32,12 +32,16 @@ def read_db_env(path: Path) -> dict[str, str]:
         if key in values:
             raise ConfigurationError(f"{key} が重複しています")
         if raw.startswith("'"):
-            if len(raw) < 2 or not raw.endswith("'") or "'" in raw[1:-1]:
+            quoted = re.fullmatch(r"'([^']*)'(?:\s+#.*)?", raw)
+            if quoted is None:
                 raise ConfigurationError(f"{key} の単引用符が不正です")
-            value = raw[1:-1]
+            value = quoted[1]
         elif raw.startswith('"'):
+            quoted = re.fullmatch(r'(\"(?:[^\"\\]|\\.)*\")(?:\s+#.*)?', raw)
+            if quoted is None:
+                raise ConfigurationError(f"{key} の二重引用符が不正です")
             try:
-                value = json.loads(raw)
+                value = json.loads(quoted[1])
             except (ValueError, TypeError):
                 raise ConfigurationError(f"{key} の二重引用符が不正です") from None
             value = value.replace("$$", "$")

--- a/scripts/production_db_env.py
+++ b/scripts/production_db_env.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""本番DBのdotenvをデータとして読み、必要な4変数だけを子プロセスへ渡す。"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+DB_KEYS = ("DB_HOST", "DB_NAME", "DB_USER", "DB_PASSWORD")
+ASSIGNMENT = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$")
+
+
+class ConfigurationError(ValueError):
+    """秘密値を含まない設定エラー。"""
+
+
+def read_db_env(path: Path) -> dict[str, str]:
+    """単一行の値を読む。単引用符はliteral、二重引用符はCompose互換。"""
+    try:
+        text = path.read_bytes().decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        raise ConfigurationError("環境ファイルをUTF-8で読み込めません") from None
+    values: dict[str, str] = {}
+    for line in text.split("\n"):
+        match = ASSIGNMENT.fullmatch(line)
+        if not match or match[1] not in DB_KEYS:
+            continue
+        key, raw = match[1], match[2].strip()
+        if key in values:
+            raise ConfigurationError(f"{key} が重複しています")
+        if raw.startswith("'"):
+            if len(raw) < 2 or not raw.endswith("'") or "'" in raw[1:-1]:
+                raise ConfigurationError(f"{key} の単引用符が不正です")
+            value = raw[1:-1]
+        elif raw.startswith('"'):
+            try:
+                value = json.loads(raw)
+            except (ValueError, TypeError):
+                raise ConfigurationError(f"{key} の二重引用符が不正です") from None
+            value = value.replace("$$", "$")
+        else:
+            value = re.split(r"\s+#", raw, maxsplit=1)[0].rstrip()
+            if any(c in value for c in ("'", '"', "\\")):
+                raise ConfigurationError(f"{key} は引用符で囲んでください")
+        if not value or any(c in value for c in ("\0", "\r", "\n")):
+            raise ConfigurationError(f"{key} が空か制御文字を含みます")
+        if "op://" in value:
+            raise ConfigurationError(f"{key} のop参照を環境ファイル内の実値へ復元してください")
+        values[key] = value
+    missing = [key for key in DB_KEYS if key not in values]
+    if missing:
+        raise ConfigurationError("必須変数がありません: " + ", ".join(missing))
+    return values
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3 or (argv[2:] != ["--check"] and (argv[2] != "--" or len(argv) < 4)):
+        print("Usage: production_db_env.py ENV_FILE --check | -- COMMAND [ARGS...]", file=sys.stderr)
+        return 2
+    try:
+        values = read_db_env(Path(argv[1]))
+    except ConfigurationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if argv[2:] == ["--check"]:
+        return 0
+    environment = os.environ.copy()
+    environment.pop("OP_SERVICE_ACCOUNT_TOKEN", None)
+    environment.update(values)
+    try:
+        os.execvpe(argv[3], argv[3:], environment)
+    except OSError:
+        print("ERROR: DB操作コマンドを起動できません", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/tests/test_deploy_ops_config.sh
+++ b/scripts/tests/test_deploy_ops_config.sh
@@ -36,7 +36,7 @@ expand_target() {
   local out="$TMP_DIR/$target.expanded"
 
   if [[ ! -f "$out" ]]; then
-    make -C "$REPO_ROOT" -n "$target" > "$out" 2>/dev/null \
+    make -C "$REPO_ROOT" -n "$target" LOCAL_DB_NAME=test_db LOCAL_DB_USER=test_user LOCAL_DB_AUTH=test_password > "$out" 2>/dev/null \
       || fail "make -n $target failed"
   fi
   printf '%s\n' "$out"
@@ -55,17 +55,18 @@ assert_expansion_not_contains() {
   fi
 }
 
-# --- 課題1: 本番DBターゲットが 1Password 参照を解決し、Compose の db 経由で叩く ---
+# --- 本番DBターゲットはdotenvを直接読み、Compose の db 経由で叩く ---
 
 for target in db-backup db-pull db-push; do
-  # op run 経由でなければ op:// 参照がホスト名として渡り接続に失敗する
-  assert_expansion_contains "$target" "op run --env-file=.env.production.local --"
+  assert_expansion_contains "$target" 'python3 scripts/production_db_env.py ".env.production.local" --'
+  assert_expansion_not_contains "$target" "op run"
   # ホストの MariaDB クライアントは本番 MySQL 8 の認証プラグインに非対応
   assert_expansion_contains "$target" 'docker compose exec -T -e MYSQL_PWD db'
   # 値付き -e は docker CLI の argv に本番パスワードを平文で載せる（ps から読める）
   assert_expansion_not_contains "$target" '-e MYSQL_PWD="$DB_PASSWORD"'
-  # op が無い環境では分かりやすく落とす
-  assert_expansion_contains "$target" "command -v op"
+  # ファイルの欠落・不正はDB操作前に検知する
+  assert_expansion_contains "$target" 'production_db_env.py ".env.production.local" --check'
+  assert_expansion_not_contains "$target" "command -v op"
 done
 
 # 本番DBを DROP する前に識別子検証とバックアップ健全性チェックを通す
@@ -137,3 +138,6 @@ assert_file_contains "$MIGRATE_JOB_SCRIPT" 'REGION="${REGION:-asia-northeast1}"'
 assert_file_contains "$MIGRATE_JOB_SCRIPT" 'PROJECT_ID="${PROJECT_ID:-vrc-ta-hub}"'
 
 printf 'PASS: deploy ops config (Makefile / create_migrate_job.sh)\n'
+
+# CIの既存エントリポイントから、ダミー値だけを使う実行検証も回す。
+python3 -m unittest discover -s "$SCRIPT_DIR" -p test_production_db_env.py

--- a/scripts/tests/test_production_db_env.py
+++ b/scripts/tests/test_production_db_env.py
@@ -61,6 +61,15 @@ class ProductionDbEnvTests(unittest.TestCase):
                 self.assertNotIn("private", result.stderr)
                 self.assertNotIn("Traceback", result.stderr)
 
+    def test_quoted_trailing_comments_preserve_hash_inside_value(self):
+        for raw, expected in [("'fixture #literal $value' # rotated", "fixture #literal $value"),
+                              ('"fixture #literal $$value" # rotated', "fixture #literal $value")]:
+            with self.subTest(raw=raw):
+                self.env_file.write_text("".join(f"{k}={raw if k == 'DB_PASSWORD' else v}\n" for k, v in self.values.items()))
+                result = self.run_command("--", sys.executable, "-c", "import os,json; print(json.dumps(os.environ['DB_PASSWORD']))")
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(json.loads(result.stdout), expected)
+
     def test_missing_or_duplicate_key_and_missing_file(self):
         self.env_file.write_text("DB_HOST=example.invalid\n")
         self.assertNotEqual(self.run_command("--check", extra_env=self.values).returncode, 0)

--- a/scripts/tests/test_production_db_env.py
+++ b/scripts/tests/test_production_db_env.py
@@ -1,0 +1,103 @@
+"""DBやopに接続せず、dotenvの受け渡しとmake db-backupを検証する。"""
+
+import gzip
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER = ROOT / "scripts/production_db_env.py"
+
+
+class ProductionDbEnvTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.env_file = self.root / "production settings.env"
+        self.values = dict(DB_HOST="example.invalid", DB_NAME="fixture_db", DB_USER="fixture_user", DB_PASSWORD="fixture-password")
+        self.base = {"PATH": os.path.dirname(sys.executable) + ":/usr/bin:/bin", "HOME": self.tmp.name}
+        self.write_env()
+
+    def write_env(self, changes=None, extra=""):
+        values = {**self.values, **(changes or {})}
+        self.env_file.write_text("".join(f"{k}='{v}'\n" for k, v in values.items()) + extra)
+
+    def run_command(self, *command, extra_env=None):
+        return subprocess.run([sys.executable, str(RUNNER), str(self.env_file), *command],
+                              env={**self.base, **(extra_env or {})}, capture_output=True, text=True)
+
+    def test_exec_preserves_literal_values_without_shell_evaluation(self):
+        value = f"$dollar $$two #hash space `touch {self.root}/bad` $(touch {self.root}/bad2) \\literal"
+        self.write_env({"DB_PASSWORD": value}, "UNUSED_API_KEY=must-not-be-exported\n")
+        code = "import os,json; print(json.dumps({k:os.environ.get(k) for k in ['DB_HOST','DB_NAME','DB_USER','DB_PASSWORD','UNUSED_API_KEY','OP_SERVICE_ACCOUNT_TOKEN']}))"
+        result = self.run_command("--", sys.executable, "-c", code,
+                                  extra_env={"DB_HOST": "stale.invalid", "OP_SERVICE_ACCOUNT_TOKEN": "fixture-token"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout), {**self.values, "DB_PASSWORD": value, "UNUSED_API_KEY": None, "OP_SERVICE_ACCOUNT_TOKEN": None})
+        self.assertFalse((self.root / "bad").exists())
+        self.assertFalse((self.root / "bad2").exists())
+
+    def test_compose_double_quotes(self):
+        value = 'dollar$ quote" slash\\'
+        encoded = json.dumps(value).replace("$", "$$")
+        self.env_file.write_text("".join(f"{k}={encoded if k == 'DB_PASSWORD' else v}\n" for k, v in self.values.items()))
+        result = self.run_command("--", sys.executable, "-c", "import os,json; print(json.dumps(os.environ['DB_PASSWORD']))")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout), value)
+
+    def test_invalid_input_never_runs_child_or_prints_value(self):
+        for raw in ["'op://fixture/item/private'", "'private\x00value'", '"private\\nvalue"', "'private", "''"]:
+            with self.subTest(raw=raw):
+                self.env_file.write_text("".join(f"{k}={raw if k == 'DB_PASSWORD' else v}\n" for k, v in self.values.items()))
+                result = self.run_command("--", sys.executable, "-c", "print('CHILD_EXECUTED')")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertNotIn("private", result.stderr)
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_missing_or_duplicate_key_and_missing_file(self):
+        self.env_file.write_text("DB_HOST=example.invalid\n")
+        self.assertNotEqual(self.run_command("--check", extra_env=self.values).returncode, 0)
+        self.write_env(extra="DB_HOST=duplicate.invalid\n")
+        self.assertNotEqual(self.run_command("--check").returncode, 0)
+        self.env_file.unlink()
+        self.assertNotEqual(self.run_command("--check").returncode, 0)
+
+    def test_check_is_quiet_and_child_exit_is_preserved(self):
+        result = self.run_command("--check")
+        self.assertEqual((result.returncode, result.stdout, result.stderr), (0, "", ""))
+        self.assertEqual(self.run_command("--", sys.executable, "-c", "raise SystemExit(7)").returncode, 7)
+
+    def test_make_backup_uses_env_not_password_argument(self):
+        shutil.copy(ROOT / "Makefile", self.root / "Makefile")
+        (self.root / "scripts").symlink_to(ROOT / "scripts", target_is_directory=True)
+        binary = self.root / "bin"
+        binary.mkdir()
+        docker = binary / "docker"
+        docker.write_text(f"#!{sys.executable}\n" + "import os,sys,json\nfrom pathlib import Path\nPath('docker-call.json').write_text(json.dumps({'args':sys.argv[1:],'password':os.environ.get('MYSQL_PWD')}))\nprint('CREATE TABLE fixture (id int);')\n")
+        docker.chmod(0o755)
+        op = binary / "op"
+        op.write_text("#!/bin/sh\nexit 99\n")
+        op.chmod(0o755)
+        result = subprocess.run(["make", "db-backup", f"PROD_ENV_FILE={self.env_file}", "DATE=fixture"],
+                                cwd=self.root, env={**self.base, "PATH": str(binary) + ":" + self.base["PATH"]},
+                                capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        call = json.loads((self.root / "docker-call.json").read_text())
+        self.assertEqual(call["password"], self.values["DB_PASSWORD"])
+        self.assertNotIn(self.values["DB_PASSWORD"], " ".join(call["args"]))
+        self.assertIn("mysqldump", call["args"])
+        self.assertNotIn("printenv", call["args"])
+        self.assertNotIn(self.values["DB_PASSWORD"], result.stdout + result.stderr)
+        with gzip.open(self.root / "dumps/production_fixture.sql.gz", "rt") as source:
+            self.assertIn("CREATE TABLE", source.read())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## なぜこの変更が必要か

`.env.production.local` を実値保存へ戻した後も、DB操作用Makefileが `op run` を必須としており、1Password CLIの認証待ち・ハングが残っていました。

## 変更内容

- `db-backup` / `db-pull` / `db-push` は、Python標準ライブラリの小さなrunnerでDB用4変数を直接読み込みます。値はシェル評価せず、子プロセスの環境へ渡します。
- 必須値の欠落、重複、制御文字、未解決のop参照はDB操作前に拒否します。パスワードをDockerの引数へ出さず、本番DB名の確認・バックアップ検証も維持します。
- ローカルDB設定の取得を必要なターゲットまで遅延し、本番バックアップだけの実行時に不要なローカル設定照会が走るのを防ぎます。
- Dockerをモックしたバックアップ実行と、引用符・ドル記号・非漏洩・異常時停止のテストを既存CIエントリポイントへ追加しました。

## テスト

- [x] `bash scripts/tests/test_deploy_ops_config.sh`（引用値の後置コメント対応を含む7件のPythonテスト）
- [x] `bash scripts/tests/test_db_pull_restore.sh`
- [x] Ruff 0.11.6（追加Pythonファイル）と `git diff --check`
- [x] 復元済み実ファイルの `--check`（出力なし・DB接続なし）

本番DBへの接続や書き込み、環境ファイルの変更は行っていません。
