### PR TITLE
トップページの発表一覧ボタン下にスマホ用余白を追加

### DIFF
--- a/app/ta_hub/templates/ta_hub/index.html
+++ b/app/ta_hub/templates/ta_hub/index.html
@@ -944,7 +944,7 @@
                     各集会ごとのテーマはその日の講演や発表の延長でみんなの興味を深堀り！そこから派生したトピックで盛り上がることも！
                 </p>
 
-                <div class="text-center mt-4">
+                <div class="text-center mt-4 mb-4 mb-md-0">
                     <a href="{% url 'event:detail_history' %}" class="btn btn-primary btn-lg">
                         <i class="bi bi-collection-play me-2"></i>過去の発表一覧はここからチェック！
                     </a>


### PR DESCRIPTION
## 概要

トップページの「過去の発表一覧はここからチェック！」ボタンと直下の画像が、スマホ表示で密着していたため余白を追加しました。

## 変更内容

- スマホ表示ではボタン下に `1.5rem` の余白を追加
- 横並びになる `md` 以上では従来どおり下余白なし

## 確認

- [x] PC表示（1440×900）でレイアウト確認
- [x] スマホ表示（390×844）でボタンと画像の間隔を確認
- [x] `python manage.py check`
- [x] ローカルのトップページが HTTP 200 で応答

## スクリーンショット

### PC表示

![PC表示](./desktop-after.png)

### スマホ表示

![スマホ表示](./mobile-after.png)

![PC表示](https://github.com/user-attachments/assets/81048690-b9b5-454f-ae47-7d45572f8f2d)

![スマホ表示](https://github.com/user-attachments/assets/842aa73b-644c-46be-bd5e-e28cccb11b71)