### PR TITLE
fix: 空の発表を登録できないよう必須入力を追加

### DIFF
--- a/app/api_v1/serializers.py
+++ b/app/api_v1/serializers.py
@@ -189,6 +189,19 @@ class EventDetailWriteSerializer(serializers.ModelSerializer):
     """EventDetail作成・更新用シリアライザー"""
     generate_from_pdf = serializers.BooleanField(write_only=True, required=False, default=False)
 
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        instance = self.instance or EventDetail()
+        if attrs.get('detail_type', instance.detail_type) == 'LT':
+            errors = {}
+            for field_name, label in (('theme', 'テーマ'), ('speaker', '発表者')):
+                value = attrs.get(field_name, getattr(instance, field_name))
+                if not value or not value.strip():
+                    errors[field_name] = f'{label}を入力してください。'
+            if errors:
+                raise serializers.ValidationError(errors)
+        return attrs
+
     class Meta:
         model = EventDetail
         fields = [

--- a/app/api_v1/tests/test_event_detail_api.py
+++ b/app/api_v1/tests/test_event_detail_api.py
@@ -141,6 +141,50 @@ class EventDetailAPITest(TestCase):
         if 'results' in response.data:
             return response.data['results']
         return response.data
+
+    def test_empty_presentation_create_is_rejected(self):
+        from twitter.models import TweetQueue
+
+        self.client.force_authenticate(user=self.user1)
+        count = EventDetail.objects.count()
+        queued = TweetQueue.objects.count()
+        for field in ('theme', 'speaker'):
+            for value in (None, '', ' \t\u3000'):
+                with self.subTest(field=field, value=value):
+                    data = {'event': self.event1.pk, 'start_time': '20:00',
+                            'duration': 30, 'theme': 'テーマ', 'speaker': '発表者'}
+                    if value is None:
+                        data.pop(field)
+                    else:
+                        data[field] = value
+                    response = self.client.post(self.url, data, format='json')
+                    self.assertEqual(response.status_code, 400)
+        self.assertEqual(EventDetail.objects.count(), count)
+        self.assertEqual(TweetQueue.objects.count(), queued)
+
+    def test_empty_presentation_patch_is_rejected(self):
+        self.client.force_authenticate(user=self.user1)
+        url = reverse('event-detail-api-detail', kwargs={'pk': self.event_detail1.pk})
+        for field in ('theme', 'speaker'):
+            for value in ('', ' \t\u3000'):
+                with self.subTest(field=field, value=value):
+                    response = self.client.patch(url, {field: value}, format='json')
+                    self.assertEqual(response.status_code, 400)
+        self.event_detail1.refresh_from_db()
+        self.assertEqual(self.event_detail1.theme, 'Test Theme 1')
+        self.assertEqual(self.event_detail1.speaker, 'Speaker 1')
+        response = self.client.patch(url, {'additional_info': '追記'}, format='json')
+        self.assertEqual(response.status_code, 200)
+
+    def test_switching_empty_blog_to_presentation_is_rejected(self):
+        self.client.force_authenticate(user=self.user1)
+        EventDetail.objects.filter(pk=self.event_detail1.pk).update(
+            detail_type='BLOG', theme='', speaker='')
+        url = reverse('event-detail-api-detail', kwargs={'pk': self.event_detail1.pk})
+        response = self.client.patch(url, {'detail_type': 'LT'}, format='json')
+        self.assertEqual(response.status_code, 400)
+        response = self.client.patch(url, {'contents': 'ブログ本文'}, format='json')
+        self.assertEqual(response.status_code, 200)
     
     def test_api_key_authentication(self):
         """APIキー認証のテスト"""

--- a/app/event/forms/event_detail.py
+++ b/app/event/forms/event_detail.py
@@ -133,6 +133,10 @@ class EventDetailForm(EventDetailMediaFormMixin, forms.ModelForm):
     def clean(self):
         cleaned_data = super().clean()
         detail_type = cleaned_data.get('detail_type')
+        if detail_type == 'LT':
+            for field_name, label in (('theme', 'テーマ'), ('speaker', '発表者')):
+                if field_name not in self.errors and not cleaned_data.get(field_name):
+                    self.add_error(field_name, f'{label}を入力してください。')
         is_datetime_locked = (
             self.instance.pk
             and self.request

--- a/app/event/forms/lt_application.py
+++ b/app/event/forms/lt_application.py
@@ -60,6 +60,9 @@ class LTApplicationEditForm(EventDetailMediaFormMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        for field_name, label in (('theme', 'テーマ'), ('speaker', '発表者')):
+            self.fields[field_name].required = True
+            self.fields[field_name].error_messages['required'] = f'{label}を入力してください。'
         # 記事未生成ならON、生成済みならOFF。
         # meta_description だけで判定すると手書きの contents / h1 を上書き再生成してしまう。
         has_article = bool(

--- a/app/event/templates/event/detail_form.html
+++ b/app/event/templates/event/detail_form.html
@@ -231,6 +231,10 @@
             function updateFieldVisibility(detailType) {
                 const config = fieldVisibility[detailType];
                 if (!config) return;
+                ['theme', 'speaker'].forEach(name => {
+                    const input = document.getElementById('id_' + name);
+                    if (input) input.required = detailType === 'LT';
+                });
                 
                 // 詳細設定ボタンの表示/非表示
                 if (detailType === 'LT' && isBeforeEvent) {

--- a/app/event/tests/test_event_detail_form.py
+++ b/app/event/tests/test_event_detail_form.py
@@ -110,6 +110,43 @@ class EventDetailFormCleanTest(TestCase):
         self.assertIn('自動トリミング', form.fields['thumbnail_image'].help_text)
         self.assertIn('はみ出した部分', form.fields['thumbnail_image'].help_text)
 
+    def test_presentation_requires_theme_and_speaker(self):
+        """新規・編集とも欠落、空文字、空白だけの発表情報を拒否する。"""
+        for form_class in (EventDetailForm, LTApplicationEditForm):
+            for editing in (False, True):
+                for field in ('theme', 'speaker'):
+                    for value in (None, '', ' \t\n\u3000'):
+                        with self.subTest(form=form_class, editing=editing, field=field, value=value):
+                            data = {
+                                'detail_type': 'LT', 'theme': 'テーマ', 'speaker': '発表者',
+                                'start_time': '22:00', 'duration': 30,
+                            }
+                            if value is None:
+                                data.pop(field)
+                            else:
+                                data[field] = value
+                            instance = self.existing_detail if editing else EventDetail(event=self.event)
+                            form = form_class(data=data, instance=instance)
+                            self.assertFalse(form.is_valid())
+                            self.assertIn(field, form.errors)
+
+    def test_empty_presentation_post_does_not_save_or_queue_tweet(self):
+        """ブラウザの必須チェックを迂回しても保存・投稿予約しない。"""
+        from django.urls import reverse
+
+        self.client.force_login(self.user)
+        detail_count = EventDetail.objects.count()
+        queue_count = TweetQueue.objects.count()
+        response = self.client.post(
+            reverse('event:detail_create', kwargs={'event_pk': self.event.pk}),
+            {'detail_type': 'LT', 'start_time': '22:00', 'duration': 30},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('theme', response.context['form'].errors)
+        self.assertIn('speaker', response.context['form'].errors)
+        self.assertEqual(EventDetail.objects.count(), detail_count)
+        self.assertEqual(TweetQueue.objects.count(), queue_count)
+
     def test_lt_application_edit_form_accepts_thumbnail_image(self):
         """LT申請者編集フォームでもサムネイル画像をアップロードできる."""
         form = LTApplicationEditForm(instance=self.existing_detail)


### PR DESCRIPTION
## 修正内容
発表のテーマ・発表者が未入力でも登録でき、空の発表がX投稿予約に入る問題を修正します。Webフォームと書き込みAPIの登録・編集で両項目を検証し、欠落・空文字・空白のみの入力を拒否します。ブラウザ側でも発表選択時に必須チェックを有効にします。

APIの部分更新では省略された項目は既存値で検証し、正常な発表の部分更新は維持します。特別企画・ブログの入力ルールは維持します。DBマイグレーションはありません。

## 検証
- 関連テスト130件成功（フォーム・権限・発表申請・API）
- 不正POSTで発表とX投稿予約が増えないことを確認
- 空値PATCH、ブログから空の発表への種別変更を拒否
- git diff --check 成功
